### PR TITLE
feat(plugin): integrate input validation into service methods (Issue #30 - Part 2/2)

### DIFF
--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -218,6 +218,17 @@ func defaultSources() []PluginSource {
 //	}
 //	fmt.Printf("Installed %d plugins\n", result.InstalledCount)
 func (s *Service) Install(ctx context.Context, target string, opts InstallOptions) (*InstallResult, error) {
+	// Validate inputs (defense-in-depth)
+	if err := validateTarget(target); err != nil {
+		return nil, err
+	}
+	if err := validateCategory(opts.Category); err != nil {
+		return nil, err
+	}
+	if err := validateSource(opts.Source); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info().
 		Str("component", "plugin-service").
 		Str("operation", "install").
@@ -495,6 +506,14 @@ func pluginInfoFromManifestEntry(entry *PluginManifestEntry) *PluginInfo {
 //	result, err := svc.Update(ctx, UpdateOptions{Category: CategorySSH})
 //	fmt.Printf("Updated %d plugins\n", result.UpdatedCount)
 func (s *Service) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
+	// Validate inputs (defense-in-depth)
+	if err := validateCategory(opts.Category); err != nil {
+		return nil, err
+	}
+	if err := validateSource(opts.Source); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info().
 		Str("component", "plugin-service").
 		Str("operation", "update").
@@ -669,6 +688,17 @@ func (s *Service) Update(ctx context.Context, opts UpdateOptions) (*UpdateResult
 //	// Uninstall all plugins
 //	result, err := svc.Uninstall(ctx, "", UninstallOptions{All: true})
 func (s *Service) Uninstall(ctx context.Context, target string, opts UninstallOptions) (*UninstallResult, error) {
+	// Validate inputs (defense-in-depth)
+	// Target is optional when using category or all flags
+	if target != "" {
+		if err := validateTarget(target); err != nil {
+			return nil, err
+		}
+	}
+	if err := validateCategory(opts.Category); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info().
 		Str("component", "plugin-service").
 		Str("operation", "uninstall").
@@ -927,6 +957,11 @@ func (s *Service) List(ctx context.Context) ([]*PluginInfo, error) {
 //	}
 //	fmt.Printf("Plugin: %s v%s (Size: %d bytes)\n", info.Name, info.Version, info.CacheSize)
 func (s *Service) GetInfo(ctx context.Context, pluginID string) (*PluginInfo, error) {
+	// Validate inputs (defense-in-depth)
+	if err := validatePluginID(pluginID); err != nil {
+		return nil, err
+	}
+
 	s.logger.Debug().
 		Str("component", "plugin-service").
 		Str("operation", "get-info").


### PR DESCRIPTION
## Summary

Part 2 of Issue #30: Service-Level Input Validation. Integrates validation helpers (from Part 1/PR #56) into plugin service methods to implement defense-in-depth validation.

**Related PRs:**
- Part 1: PR #56 (validation helpers) - MERGED
- Part 2: This PR (service integration)

**Related Issues:**
- Completes: #30 (Service-Level Input Validation)
- Builds on: #37 (Error Handling Strategy)

---

## Changes

### Service Methods Updated

Added input validation to 4 public service methods in `pkg/plugin/service.go`:

1. **`Install(ctx, target, opts)`** - Lines 221-230
   - Validates `target` (plugin ID or category format)
   - Validates `opts.Category` (valid category enum)
   - Validates `opts.Source` (source name format)

2. **`Update(ctx, opts)`** - Lines 509-515
   - Validates `opts.Category` (valid category enum)
   - Validates `opts.Source` (source name format)

3. **`Uninstall(ctx, target, opts)`** - Lines 691-700
   - Validates `target` if provided (optional when using category/all flags)
   - Validates `opts.Category` (valid category enum)

4. **`GetInfo(ctx, pluginID)`** - Lines 960-963
   - Validates `pluginID` (plugin ID format)

### Validation Pattern

```go
// Example from Install()
func (s *Service) Install(ctx context.Context, target string, opts InstallOptions) (*InstallResult, error) {
    // Validate inputs (defense-in-depth)
    if err := validateTarget(target); err != nil {
        return nil, err
    }
    if err := validateCategory(opts.Category); err != nil {
        return nil, err
    }
    if err := validateSource(opts.Source); err != nil {
        return nil, err
    }

    // ... rest of implementation
}
```

**Characteristics:**
- **Fail-fast**: Validation errors return immediately with `ErrInvalidOption`
- **Consistent**: All validators return same sentinel error for uniform handling
- **Actionable**: Error messages include format requirements
- **Optional fields**: Empty string allowed where appropriate (e.g., category filter in Update)

---

## Test Coverage

Added comprehensive test function `TestServiceInputValidation` with 8 sub-tests:

**Install Method (2 tests):**
- Empty target validation
- Invalid plugin ID format validation
- Invalid category option validation

**Update Method (2 tests):**
- Invalid category filter validation
- Invalid source option validation

**Uninstall Method (2 tests):**
- Invalid target validation (when provided)
- Invalid category filter validation

**GetInfo Method (2 tests):**
- Empty plugin ID validation
- Invalid plugin ID format validation

**All tests verify:**
- `ErrInvalidOption` sentinel error returned
- Error messages contain descriptive format requirements
- Optional fields (empty string) handled correctly

---

## Example Error Messages

```go
// Invalid plugin ID (uppercase)
_, err := svc.Install(ctx, "Invalid-Plugin", InstallOptions{})
// Error: invalid option: invalid plugin ID format 'Invalid-Plugin'
//        (must be lowercase alphanumeric with hyphens/underscores,
//         3-63 chars, starting with letter)

// Invalid category
_, err := svc.Update(ctx, UpdateOptions{Category: "invalid"})
// Error: invalid option: invalid category 'invalid'
//        (valid: ssh, http, web, tls, database, iot, network, misc)

// Whitespace-only target
_, err := svc.Install(ctx, "   ", InstallOptions{})
// Error: invalid option: target cannot be whitespace-only

// Invalid source name
_, err := svc.Install(ctx, "ssh", InstallOptions{Source: "my source"})
// Error: invalid option: invalid source name 'my source'
//        (must be alphanumeric with hyphens/underscores, no spaces)
```

---

## Defense-in-Depth Strategy

This PR implements **service-layer validation** as the second layer of defense:

1. **CLI/API Layer**: User input validation (flag parsing, HTTP request validation)
2. **Service Layer**: This PR - validates inputs regardless of caller ✅
3. **Domain Logic**: Business rules and constraints

**Why service-layer validation matters:**
- Protects against bugs in CLI/API validation
- Future-proofs for new callers (gRPC, internal packages, etc.)
- Provides consistent validation across all entry points
- Prevents invalid data from reaching core business logic

---

## Testing

**Unit Tests:**
```bash
go test ./pkg/plugin/... -run TestServiceInputValidation -v
# PASS: TestServiceInputValidation (0.00s)
# PASS: TestServiceInputValidation/Install_validates_target (0.00s)
# PASS: TestServiceInputValidation/Install_validates_category_option (0.00s)
# ... 8/8 sub-tests passing
```

**Full Test Suite:**
```bash
make test     # All tests pass
make validate # 0 linter issues
```

**Test Cleanup Pattern:**
- Uses `t.Cleanup()` for temporary directory cleanup
- Properly handles error returns: `_ = os.RemoveAll(tmpDir)`
- Passes `golangci-lint` errcheck validation

---

## Code Quality

**Linting:**
- ✅ `golangci-lint` - 0 issues
- ✅ `errcheck` - All error returns properly handled
- ✅ Pre-commit hook passed (auto-linted on commit)

**Test Coverage:**
- 8 new test cases covering all 4 service methods
- All validation error paths tested
- Sentinel error (`ErrInvalidOption`) verified in all tests

**Code Statistics:**
- Files modified: 2 (`service.go`, `service_test.go`)
- Lines added: +151
- Lines removed: 0
- Net change: +151 lines

---

## Related Work

**Dependencies:**
- ✅ PR #56: Validation helpers (`pkg/plugin/validation.go`) - MERGED
- ✅ PR #52: Error handling strategy (`ErrInvalidOption` sentinel) - MERGED

**Follow-up Work:**
- Issue #31: Context Cancellation (next in Phase 1)

---

## Verification Steps

1. **Run tests:**
   ```bash
   make test
   ```

2. **Verify validation errors:**
   ```bash
   go run ./cmd/pentora plugin install "INVALID-ID"
   # Expected: error with actionable message
   ```

3. **Verify linting:**
   ```bash
   make validate
   ```

---

## Closes

Part 2/2 of Issue #30 (combines with PR #56 to complete the issue)