### PR TITLE
chore(lint): Phase 4 - Forbidden Patterns (forbidigo)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,12 @@
 # golangci-lint Configuration
-# Phase 3: Complexity Limits (gocyclo, funlen, goconst)
+# Phase 4: Forbidden Patterns (forbidigo)
 #
-# Changes from Phase 2:
+# Changes from Phase 3:
+# 1. Added forbidigo linter to ban dangerous patterns
+# 2. Forbid: print/println, fmt.Print*, panic
+# 3. Enforces structured logging (zerolog)
+#
+# Previous changes (Phase 3):
 # 1. Added complexity linters: gocyclo, funlen, goconst
 # 2. Configured thresholds: cyclomatic=15, statements=100, goconst=4
 # 3. Prevents unmaintainable functions and technical debt
@@ -40,6 +45,9 @@ linters:
     - funlen        # Function length (statement count)
     - goconst       # Repeated constants
 
+    # Phase 4: Forbidden patterns
+    - forbidigo     # Ban dangerous patterns (print, panic)
+
   settings:
     errcheck:
       # Don't check these functions for error returns
@@ -73,17 +81,60 @@ linters:
       min-len: 3           # Minimum string length to check
       min-occurrences: 4   # Must repeat 4+ times to suggest constant
 
+    # Phase 4: Forbidden patterns
+    forbidigo:
+      forbid:
+        - pattern: ^print(ln)?$
+          msg: Use structured logging (pkg/logging) instead of print()
+
+        - pattern: ^fmt\.Print(f|ln)?$
+          msg: Use log.Info() instead of fmt.Print()
+
+        - pattern: ^panic$
+          msg: Use log.Fatal() or return error instead of panic()
+
   # Exclusion rules for test files
   exclusions:
     rules:
       # Test files - less strict linting
       - path: (.+)_test\.go
         linters:
-          - errcheck  # Test errors can be ignored sometimes
-          - revive    # Revive rules too noisy for tests (Phase 1)
-          - funlen    # Test functions can be long (Phase 3)
-          - goconst   # Test strings can repeat (Phase 3)
-          - gocyclo   # Test setup can be complex (Phase 3)
+          - errcheck   # Test errors can be ignored sometimes
+          - revive     # Revive rules too noisy for tests (Phase 1)
+          - funlen     # Test functions can be long (Phase 3)
+          - goconst    # Test strings can repeat (Phase 3)
+          - gocyclo    # Test setup can be complex (Phase 3)
+          - forbidigo  # panic() OK in tests for deliberate failures (Phase 4)
+
+      # Phase 4: CLI commands - fmt.Print* OK for user output
+      - path: cmd/pentora/commands/
+        linters:
+          - forbidigo  # CLI needs fmt.Print for user-facing output
+
+      # Phase 4: CLI helper functions - fmt.Print* OK for user output
+      - path: pkg/cli/
+        linters:
+          - forbidigo  # CLI helpers need fmt.Print for user-facing output
+
+      # Phase 4: Server shutdown - panic OK for timeout kill
+      - path: pkg/server/server\.go
+        linters:
+          - forbidigo  # Panic acceptable for forced shutdown after timeout
+
+      # Phase 4: Module implementations - TODO: migrate to structured logging
+      - path: pkg/modules/
+        linters:
+          - forbidigo  # Modules currently use fmt.Printf for debug (refactor later)
+
+      # Phase 4: Core engine - TODO: migrate to structured logging
+      - path: pkg/engine/
+        linters:
+          - forbidigo  # Engine uses fmt.Printf for INFO messages (refactor later)
+
+      # Phase 4: Fingerprint loader - TODO: migrate to structured logging
+      - path: pkg/fingerprint/loader\.go
+        linters:
+          - forbidigo  # Loader uses fmt.Printf for errors (refactor later)
 
       # Phase 3: Legitimate high complexity - Core engine (DAG orchestration)
       - path: pkg/engine/orchestrator\.go


### PR DESCRIPTION
## Summary

Adds forbidigo linter to ban dangerous patterns and enforce structured logging:
- **print/println** - Unstructured output
- **fmt.Print family** - Direct console output without log levels
- **panic** - Abrupt termination instead of error handling

**Result**: 
- ✅ 10 → 11 linters (+10%)
- ✅ 0 lint issues (all violations excluded with justification)
- ✅ Prevents future unstructured logging
- ✅ All tests pass, CI validation green

## Changes

### Added Linter

**forbidigo** - Forbidden Patterns
- Bans: `print()`, `println()`, `fmt.Print*()`, `panic()`
- Enforces: Structured logging with zerolog (`log.Info()`, `log.Fatal()`)
- Prevents: Unstructured output, no log levels, no context

### Forbidden Patterns

1. **print/println**
   - Pattern: `^print(ln)?$`
   - Message: "Use structured logging (pkg/logging) instead of print()"
   - Reason: No log levels, no structured fields

2. **fmt.Print family**
   - Pattern: `^fmt\.Print(f|ln)?$`
   - Message: "Use log.Info() instead of fmt.Print()"
   - Reason: No log levels, no context, no structured fields

3. **panic**
   - Pattern: `^panic$`
   - Message: "Use log.Fatal() or return error instead of panic()"
   - Reason: Unrecoverable crashes, no graceful shutdown

### Exclusions Strategy

**Legitimate fmt.Print usage** - User-facing output:
- `cmd/pentora/commands/` - CLI commands need fmt.Print for user output
- `pkg/cli/` - CLI helper functions for formatted output
- Reason: CLI output should NOT go through logging system

**Legitimate panic usage** - Test failures:
- `*_test.go` - panic() OK in tests for deliberate failures
- Reason: Tests use panic to fail fast

**TODO: Future Refactoring** - Migrate to structured logging:
- `pkg/modules/` - Module implementations use fmt.Printf for debug
- `pkg/engine/` - Engine uses fmt.Printf for INFO messages
- `pkg/fingerprint/loader.go` - Loader uses fmt.Printf for errors
- `pkg/server/server.go` - Panic acceptable for forced shutdown after timeout
- Reason: Current code works, migration requires careful testing

## Impact

**Before Phase 4**:
- Linters: 10 (no forbidden pattern checks)
- fmt.Print/panic could be added to new code
- Inconsistent logging practices

**After Phase 4**:
- Linters: 11 (+10%)
- New code must use structured logging (zerolog)
- panic() banned in new code (use error handling)
- Existing code excluded with justification
- Future code enforces consistency

**Zero breaking changes**: All existing code excluded with justification.

## Test Plan

```bash
# Config validation
golangci-lint config verify  # ✅ Passed

# forbidigo only
golangci-lint run --enable-only=forbidigo  # ✅ 0 issues

# Full lint suite
make lint  # ✅ 0 issues

# All tests
make test  # ✅ All tests passed

# Full validation
make validate  # ✅ Passed (lint + spell + shell)
```

## Related

- Issue: #69
- Phase: 4/7 (golangci-lint Enhancement)
- Previous: 
  - Phase 1 (PR #64): Foundation - v2 syntax, critical linters ✅
  - Phase 2 (PR #66): Import Organization (gci) ✅
  - Phase 3 (PR #68): Complexity Limits (gocyclo, funlen, goconst) ✅
- Next: Phase 5 (depguard) - Dependency guard

## Reviewers

- bfelixer (DevOps/CI/CD)