### PR TITLE
chore(lint): Phase 5 - Dependency Guard (depguard)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,12 @@
 # golangci-lint Configuration
-# Phase 4: Forbidden Patterns (forbidigo)
+# Phase 5: Dependency Guard (depguard)
 #
-# Changes from Phase 3:
+# Changes from Phase 4:
+# 1. Added depguard linter to ban deprecated/problematic packages
+# 2. Banned: io/ioutil, github.com/pkg/errors, golang.org/x/net/context
+# 3. Enforces modern stdlib usage
+#
+# Previous changes (Phase 4):
 # 1. Added forbidigo linter to ban dangerous patterns
 # 2. Forbid: print/println, fmt.Print*, panic
 # 3. Enforces structured logging (zerolog)
@@ -48,6 +53,9 @@ linters:
     # Phase 4: Forbidden patterns
     - forbidigo     # Ban dangerous patterns (print, panic)
 
+    # Phase 5: Dependency guard
+    - depguard      # Ban deprecated/problematic packages
+
   settings:
     errcheck:
       # Don't check these functions for error returns
@@ -92,6 +100,20 @@ linters:
 
         - pattern: ^panic$
           msg: Use log.Fatal() or return error instead of panic()
+
+    # Phase 5: Dependency guard
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: "Deprecated since Go 1.16, use io and os packages instead"
+
+            - pkg: github.com/pkg/errors
+              desc: "Use standard library errors package (errors.Join, errors.As, errors.Is) instead"
+
+            - pkg: golang.org/x/net/context
+              desc: "Use standard library context package instead"
 
   # Exclusion rules for test files
   exclusions:


### PR DESCRIPTION
## Summary

Adds depguard linter to ban deprecated and problematic packages:
- **io/ioutil** - Deprecated since Go 1.16
- **github.com/pkg/errors** - External error handling library
- **golang.org/x/net/context** - Old context package

**Result**: 
- ✅ 11 → 12 linters (+9%)
- ✅ 0 violations found (Pentora is modern Go 1.24)
- ✅ Prevents future deprecated imports
- ✅ All tests pass, CI validation green

## Changes

### Added Linter

**depguard** - Dependency Guard
- Bans: Deprecated and problematic packages
- Enforces: Modern stdlib usage
- Prevents: Technical debt from deprecated imports

### Banned Packages

1. **io/ioutil** (Deprecated)
   - Status: Deprecated since Go 1.16
   - Replacement: `io` and `os` packages
   - Functions:
     - `io/ioutil.ReadFile` → `os.ReadFile`
     - `io/ioutil.WriteFile` → `os.WriteFile`
     - `io/ioutil.ReadAll` → `io.ReadAll`
     - `io/ioutil.TempFile` → `os.CreateTemp`

2. **github.com/pkg/errors** (Problematic)
   - Issue: External dependency for error handling
   - Replacement: stdlib `errors` package
   - Modern Go has:
     - `errors.Join` (Go 1.20) - Combine multiple errors
     - `errors.As` - Type assertion for errors
     - `errors.Is` - Error comparison
     - `fmt.Errorf` with `%w` - Error wrapping

3. **golang.org/x/net/context** (Deprecated)
   - Status: Deprecated since Go 1.7
   - Replacement: stdlib `context` package
   - Very old, unlikely to be found

## Impact

**Before Phase 5**:
- Linters: 11 (no dependency checks)
- Deprecated packages could be imported
- No safeguard against old patterns

**After Phase 5**:
- Linters: 12 (+9%)
- Deprecated packages banned (io/ioutil, pkg/errors, x/net/context)
- Modern stdlib enforced
- 0 violations (Pentora already clean)

**Zero violations**: Pentora uses modern Go 1.24 practices, no deprecated imports found.

## Test Plan

```bash
# Config validation
golangci-lint config verify  # ✅ Passed

# depguard only
golangci-lint run --enable-only=depguard  # ✅ 0 issues

# Full lint suite
make lint  # ✅ 0 issues

# All tests
make test  # ✅ All tests passed

# Full validation
make validate  # ✅ Passed (lint + spell + shell)
```

## Related

- Issue: #71
- Phase: 5/7 (golangci-lint Enhancement)
- Previous: 
  - Phase 1 (PR #64): Foundation - v2 syntax, critical linters ✅
  - Phase 2 (PR #66): Import Organization (gci) ✅
  - Phase 3 (PR #68): Complexity Limits (gocyclo, funlen, goconst) ✅
  - Phase 4 (PR #70): Forbidden Patterns (forbidigo) ✅
- Next: Phase 6 - Full Linter Set (enable all with strategic disables)

## Reviewers

- bfelixer (DevOps/CI/CD)