### PR TITLE
fix(cli,api): partial failure UX with exit code 8 and error suggestions

### DIFF
--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -47,6 +47,7 @@ func TestNewCacheManager_LoadsExistingPlugins(t *testing.T) {
 	require.NoError(t, os.MkdirAll(plugin1Dir, 0o755))
 
 	plugin1 := &YAMLPlugin{
+		ID:      "test-plugin-1",
 		Name:    "test-plugin-1",
 		Version: "1.0.0",
 		Type:    "evaluation",
@@ -80,6 +81,7 @@ func TestNewCacheManager_LoadsExistingPlugins(t *testing.T) {
 	require.NoError(t, os.MkdirAll(plugin2Dir, 0o755))
 
 	plugin2 := &YAMLPlugin{
+		ID:      "test-plugin-2",
 		Name:    "test-plugin-2",
 		Version: "2.0.0",
 		Type:    "evaluation",
@@ -133,6 +135,7 @@ func TestCacheManager_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -184,6 +187,7 @@ func TestCacheManager_Add_InvalidPlugin(t *testing.T) {
 
 	// Plugin missing required fields
 	plugin := &YAMLPlugin{
+		ID:   "invalid-plugin",
 		Name: "invalid-plugin",
 		// Missing version, type, author, etc.
 	}
@@ -200,6 +204,7 @@ func TestCacheManager_Add_Duplicate(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -228,6 +233,7 @@ func TestCacheManager_Get(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -258,6 +264,7 @@ func TestCacheManager_Remove(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -307,8 +314,10 @@ func TestCacheManager_List(t *testing.T) {
 
 	// Add multiple plugins
 	for i := 1; i <= 3; i++ {
+		pluginID := "plugin-" + string(rune('0'+i))
 		plugin := &YAMLPlugin{
-			Name:    "plugin-" + string(rune('0'+i)),
+			ID:      pluginID,
+			Name:    pluginID,
 			Version: "1.0.0",
 			Type:    EvaluationType,
 			Author:  "test",
@@ -333,6 +342,7 @@ func TestCacheManager_Clear(t *testing.T) {
 
 	// Add plugins
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -402,6 +412,7 @@ func TestCacheManager_Prune(t *testing.T) {
 
 	// Add recent plugin
 	recentPlugin := &YAMLPlugin{
+		ID:      "recent-plugin",
 		Name:    "recent-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -438,7 +449,8 @@ func TestCacheManager_LoadFromDisk(t *testing.T) {
 	err := os.MkdirAll(pluginDir, 0o755)
 	require.NoError(t, err)
 
-	pluginYAML := `name: test-plugin
+	pluginYAML := `id: test-plugin
+name: test-plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -473,7 +485,8 @@ func TestCacheManager_LoadFromDisk_WithErrors(t *testing.T) {
 	err := os.MkdirAll(validDir, 0o755)
 	require.NoError(t, err)
 
-	validYAML := `name: valid-plugin
+	validYAML := `id: valid-plugin
+name: valid-plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -491,7 +504,8 @@ output:
 	err = os.MkdirAll(invalidDir, 0o755)
 	require.NoError(t, err)
 
-	invalidYAML := `name: invalid-plugin
+	invalidYAML := `id: invalid-plugin
+name: invalid-plugin
 version: 1.0.0
 # Missing required fields
 `
@@ -539,6 +553,7 @@ func TestCacheManager_Add_MkdirError(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin := &YAMLPlugin{
+		ID:      "blocked-plugin",
 		Name:    "blocked-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -609,6 +624,7 @@ func TestCacheManager_ListEntries_AllPresent(t *testing.T) {
 
 	plugins := []*YAMLPlugin{
 		{
+			ID:      "entry-plugin-1",
 			Name:    "entry-plugin-1",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -620,6 +636,7 @@ func TestCacheManager_ListEntries_AllPresent(t *testing.T) {
 			Output: OutputBlock{Message: "Test1"},
 		},
 		{
+			ID:      "entry-plugin-2",
 			Name:    "entry-plugin-2",
 			Version: "2.0.0",
 			Type:    EvaluationType,
@@ -658,6 +675,7 @@ func TestCacheManager_ListEntries_SkipsMissingFile(t *testing.T) {
 
 	// Add two plugins
 	present := &YAMLPlugin{
+		ID:      "present-plugin",
 		Name:    "present-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -669,6 +687,7 @@ func TestCacheManager_ListEntries_SkipsMissingFile(t *testing.T) {
 		Output: OutputBlock{Message: "Present"},
 	}
 	missing := &YAMLPlugin{
+		ID:      "missing-plugin",
 		Name:    "missing-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,

--- a/pkg/plugin/downloader_test.go
+++ b/pkg/plugin/downloader_test.go
@@ -161,6 +161,7 @@ func TestDownloader_FetchManifest_AllFail(t *testing.T) {
 func TestDownloader_Download(t *testing.T) {
 	// Create test plugin
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -243,6 +244,7 @@ func TestDownloader_Download_AlreadyCached(t *testing.T) {
 
 	// Add plugin to cache
 	plugin := &YAMLPlugin{
+		ID:      "cached-plugin",
 		Name:    "cached-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -300,6 +302,7 @@ func TestDownloader_Download_NotFound(t *testing.T) {
 
 func TestDownloader_Download_ChecksumMismatch(t *testing.T) {
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -362,6 +365,7 @@ func TestDownloader_DownloadByCategory(t *testing.T) {
 	// Create test plugins
 	plugins := []*YAMLPlugin{
 		{
+			ID:      "ssh-plugin-1",
 			Name:    "ssh-plugin-1",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -373,6 +377,7 @@ func TestDownloader_DownloadByCategory(t *testing.T) {
 			Output: OutputBlock{Message: "SSH vuln 1"},
 		},
 		{
+			ID:      "ssh-plugin-2",
 			Name:    "ssh-plugin-2",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -406,7 +411,7 @@ func TestDownloader_DownloadByCategory(t *testing.T) {
 		checksum := "sha256:" + hex.EncodeToString(hash[:])
 
 		manifestEntries = append(manifestEntries, PluginManifestEntry{
-			ID:         p.Name,
+			ID:         p.ID,
 			Name:       p.Name,
 			Version:    p.Version,
 			Categories: []Category{CategorySSH},
@@ -482,6 +487,7 @@ func TestDownloader_Update(t *testing.T) {
 
 	// Add old version to cache
 	oldPlugin := &YAMLPlugin{
+		ID:      "update-test",
 		Name:    "update-test",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -497,6 +503,7 @@ func TestDownloader_Update(t *testing.T) {
 
 	// Create new version
 	newPlugin := &YAMLPlugin{
+		ID:      "update-test",
 		Name:    "update-test",
 		Version: "2.0.0",
 		Type:    EvaluationType,
@@ -620,6 +627,7 @@ func TestDownloader_Update_NoUpdatesAvailable(t *testing.T) {
 
 	// Add plugin to cache
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -672,6 +680,7 @@ func TestDownloader_Update_ManifestFetchError(t *testing.T) {
 
 	// Add plugin to cache
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -967,6 +976,7 @@ func TestDownloader_DownloadByCategory_AllManifestsFail(t *testing.T) {
 func TestDownloader_DownloadByCategory_PartialDownloadFailure(t *testing.T) {
 	// Create two plugins: one with valid URL, one with invalid
 	plugin1 := &YAMLPlugin{
+		ID:      "valid-plugin",
 		Name:    "valid-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -1048,6 +1058,7 @@ func TestDownloader_Update_DownloadError(t *testing.T) {
 
 	// Add plugin to cache
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,

--- a/pkg/plugin/evaluator_test.go
+++ b/pkg/plugin/evaluator_test.go
@@ -23,6 +23,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		{
 			name: "triggered and matched",
 			plugin: &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -53,6 +54,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		{
 			name: "triggered but not matched",
 			plugin: &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -83,6 +85,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		{
 			name: "not triggered",
 			plugin: &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -113,6 +116,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		{
 			name: "no triggers - always match",
 			plugin: &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -141,6 +145,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		{
 			name: "no match block - always match if triggered",
 			plugin: &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -193,6 +198,7 @@ func TestEvaluator_EvaluateAll(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin1 := &YAMLPlugin{
+		ID:      "plugin-1",
 		Name:    "Plugin 1",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -217,6 +223,7 @@ func TestEvaluator_EvaluateAll(t *testing.T) {
 	}
 
 	plugin2 := &YAMLPlugin{
+		ID:      "plugin-2",
 		Name:    "Plugin 2",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -260,6 +267,7 @@ func TestEvaluator_Evaluate_TriggerError(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "Test Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -289,6 +297,7 @@ func TestEvaluator_Evaluate_MatchError(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "Test Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -346,6 +355,7 @@ func TestEvaluator_Evaluate_SeverityOverride(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &YAMLPlugin{
+				ID:      "test-plugin",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -380,6 +390,7 @@ func TestEvaluator_EvaluateAll_WithError(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin1 := &YAMLPlugin{
+		ID:      "valid-plugin",
 		Name:    "Valid Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -401,6 +412,7 @@ func TestEvaluator_EvaluateAll_WithError(t *testing.T) {
 
 	// Plugin with invalid trigger (will cause error)
 	plugin2 := &YAMLPlugin{
+		ID:      "invalid-plugin",
 		Name:    "Invalid Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -434,6 +446,7 @@ func TestEvaluator_EvaluateMatched_NoMatches(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin := &YAMLPlugin{
+		ID:      "non-matching-plugin",
 		Name:    "Non-Matching Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -469,6 +482,7 @@ func TestEvaluator_EvaluateMatched_WithError(t *testing.T) {
 
 	// Plugin with invalid trigger (will cause error)
 	plugin := &YAMLPlugin{
+		ID:      "invalid-plugin",
 		Name:    "Invalid Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -500,6 +514,7 @@ func TestEvaluator_EvaluateMatched(t *testing.T) {
 	evaluator := NewEvaluator()
 
 	plugin1 := &YAMLPlugin{
+		ID:      "matching-plugin",
 		Name:    "Matching Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -521,6 +536,7 @@ func TestEvaluator_EvaluateMatched(t *testing.T) {
 	}
 
 	plugin2 := &YAMLPlugin{
+		ID:      "non-matching-plugin",
 		Name:    "Non-Matching Plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,

--- a/pkg/plugin/loader_test.go
+++ b/pkg/plugin/loader_test.go
@@ -16,7 +16,8 @@ func TestLoader_Load(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create valid YAML plugin
-	validYAML := `name: Test Plugin
+	validYAML := `id: test-plugin
+name: Test Plugin
 version: 1.0.0
 type: evaluation
 author: pentora-test
@@ -75,6 +76,7 @@ func TestLoader_Load_JSON(t *testing.T) {
 
 	// Create valid JSON plugin
 	validJSON := `{
+  "id": "test-json-plugin",
   "name": "Test JSON Plugin",
   "version": "1.0.0",
   "type": "evaluation",
@@ -124,7 +126,8 @@ func TestLoader_Load_JSON(t *testing.T) {
 func TestLoader_Load_InvalidYAML(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	invalidYAML := `name: Invalid
+	invalidYAML := `id: invalid
+name: Invalid
 invalid yaml syntax here {{{
 `
 
@@ -143,7 +146,8 @@ func TestLoader_Load_ValidationFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Missing required fields
-	invalidYAML := `name: Invalid Plugin
+	invalidYAML := `id: invalid-plugin
+name: Invalid Plugin
 # Missing version, type, author, etc.
 `
 
@@ -176,7 +180,8 @@ func TestLoader_LoadAll(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create multiple plugins
-	plugin1 := `name: Plugin 1
+	plugin1 := `id: plugin-1
+name: Plugin 1
 version: 1.0.0
 type: evaluation
 author: test
@@ -188,7 +193,8 @@ output:
   message: "Test 1"
 `
 
-	plugin2 := `name: Plugin 2
+	plugin2 := `id: plugin-2
+name: Plugin 2
 version: 1.0.0
 type: evaluation
 author: test
@@ -231,7 +237,8 @@ func TestLoader_LoadRecursive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create plugins in both directories
-	plugin1 := `name: Root Plugin
+	plugin1 := `id: root-plugin
+name: Root Plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -243,7 +250,8 @@ output:
   message: "Root plugin"
 `
 
-	plugin2 := `name: Sub Plugin
+	plugin2 := `id: sub-plugin
+name: Sub Plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -314,7 +322,8 @@ func TestLoader_LoadAll_WithSubdirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create plugin in root
-	plugin1 := `name: Plugin 1
+	plugin1 := `id: plugin-1
+name: Plugin 1
 version: 1.0.0
 type: evaluation
 author: test
@@ -329,7 +338,8 @@ output:
 	require.NoError(t, err)
 
 	// Create plugin in subdirectory (should NOT be loaded by LoadAll)
-	plugin2 := `name: Plugin 2
+	plugin2 := `id: plugin-2
+name: Plugin 2
 version: 1.0.0
 type: evaluation
 author: test
@@ -356,7 +366,8 @@ func TestLoader_LoadAll_WithErrors(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create valid plugin
-	validPlugin := `name: Valid Plugin
+	validPlugin := `id: valid-plugin
+name: Valid Plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -371,7 +382,8 @@ output:
 	require.NoError(t, err)
 
 	// Create invalid plugin (missing required fields)
-	invalidPlugin := `name: Invalid Plugin
+	invalidPlugin := `id: invalid-plugin
+name: Invalid Plugin
 # Missing version and other required fields
 `
 	err = os.WriteFile(filepath.Join(tmpDir, "invalid.yaml"), []byte(invalidPlugin), 0o644)
@@ -391,7 +403,8 @@ func TestLoader_LoadRecursive_WithErrors(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create valid plugin in root
-	validPlugin := `name: Valid Plugin
+	validPlugin := `id: valid-plugin
+name: Valid Plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -410,7 +423,8 @@ output:
 	err = os.MkdirAll(subDir, 0o755)
 	require.NoError(t, err)
 
-	invalidPlugin := `name: Invalid
+	invalidPlugin := `id: invalid
+name: Invalid
 # Missing required fields
 `
 	err = os.WriteFile(filepath.Join(subDir, "invalid.yaml"), []byte(invalidPlugin), 0o644)
@@ -430,7 +444,8 @@ func TestLoader_LoadRecursive_IgnoresNonPluginFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create plugin
-	validPlugin := `name: Valid Plugin
+	validPlugin := `id: valid-plugin
+name: Valid Plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -471,7 +486,8 @@ func TestLoader_LoadRecursive_WalkError(t *testing.T) {
 func TestLoader_ClearCache(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	validYAML := `name: Test
+	validYAML := `id: test
+name: Test
 version: 1.0.0
 type: evaluation
 author: test

--- a/pkg/plugin/manifest_test.go
+++ b/pkg/plugin/manifest_test.go
@@ -477,6 +477,7 @@ func TestManifestManager_SetGetRegistryURL(t *testing.T) {
 
 func TestNewManifestEntryFromPlugin(t *testing.T) {
 	plugin := &YAMLPlugin{
+		ID:       "test-plugin",
 		Name:     "test-plugin",
 		Version:  "1.0.0",
 		Type:     EvaluationType,

--- a/pkg/plugin/registry_test.go
+++ b/pkg/plugin/registry_test.go
@@ -22,6 +22,7 @@ func TestYAMLRegistry_Register(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -78,6 +79,7 @@ func TestYAMLRegistry_Register_InvalidPlugin(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:   "invalid-plugin",
 		Name: "invalid-plugin",
 		// Missing required fields for validation
 	}
@@ -91,6 +93,7 @@ func TestYAMLRegistry_Register_Duplicate(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -117,6 +120,7 @@ func TestYAMLRegistry_Unregister(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -156,6 +160,7 @@ func TestYAMLRegistry_Get(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -187,6 +192,7 @@ func TestYAMLRegistry_List(t *testing.T) {
 	// Register multiple plugins
 	plugins := []*YAMLPlugin{
 		{
+			ID:      "plugin1",
 			Name:    "plugin1",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -197,6 +203,7 @@ func TestYAMLRegistry_List(t *testing.T) {
 			Output: OutputBlock{Message: "Test1"},
 		},
 		{
+			ID:      "plugin2",
 			Name:    "plugin2",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -223,6 +230,7 @@ func TestYAMLRegistry_ListByCategory(t *testing.T) {
 
 	// Register plugins with different categories
 	plugin1 := &YAMLPlugin{
+		ID:      "ssh-plugin",
 		Name:    "ssh-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -235,6 +243,7 @@ func TestYAMLRegistry_ListByCategory(t *testing.T) {
 	}
 
 	plugin2 := &YAMLPlugin{
+		ID:      "http-plugin",
 		Name:    "http-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -269,6 +278,7 @@ func TestYAMLRegistry_Categories(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin1 := &YAMLPlugin{
+		ID:      "plugin1",
 		Name:    "plugin1",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -281,6 +291,7 @@ func TestYAMLRegistry_Categories(t *testing.T) {
 	}
 
 	plugin2 := &YAMLPlugin{
+		ID:      "plugin2",
 		Name:    "plugin2",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -308,6 +319,7 @@ func TestYAMLRegistry_Clear(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -333,6 +345,7 @@ func TestYAMLRegistry_RegisterBulk(t *testing.T) {
 
 	plugins := []*YAMLPlugin{
 		{
+			ID:      "plugin1",
 			Name:    "plugin1",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -343,6 +356,7 @@ func TestYAMLRegistry_RegisterBulk(t *testing.T) {
 			Output: OutputBlock{Message: "Test1"},
 		},
 		{
+			ID:      "plugin2",
 			Name:    "plugin2",
 			Version: "1.0.0",
 			Type:    EvaluationType,
@@ -353,6 +367,7 @@ func TestYAMLRegistry_RegisterBulk(t *testing.T) {
 			Output: OutputBlock{Message: "Test2"},
 		},
 		{
+			ID:   "invalid-plugin",
 			Name: "invalid-plugin",
 			// Missing required fields
 		},
@@ -374,8 +389,10 @@ func TestYAMLRegistry_ConcurrentAccess(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
+			pluginID := fmt.Sprintf("plugin-%d", idx)
 			plugin := &YAMLPlugin{
-				Name:    fmt.Sprintf("plugin-%d", idx),
+				ID:      pluginID,
+				Name:    pluginID,
 				Version: "1.0.0",
 				Type:    EvaluationType,
 				Author:  "test",
@@ -398,6 +415,7 @@ func TestYAMLRegistry_Unregister_CleansUpCategories(t *testing.T) {
 	r := NewYAMLRegistry()
 
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,

--- a/pkg/plugin/service_errors.go
+++ b/pkg/plugin/service_errors.go
@@ -182,6 +182,45 @@ func HTTPStatus(err error) int {
 	}
 }
 
+// GetSuggestion returns an actionable suggestion for resolving the given error.
+// Used by CLI and API to provide helpful guidance to users on partial failures.
+//
+// Example:
+//
+//	err := svc.Install(ctx, target, opts)
+//	suggestion := plugin.GetSuggestion(err)
+//	fmt.Printf("Suggestion: %s\n", suggestion)
+func GetSuggestion(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	switch {
+	case errors.Is(err, ErrPluginNotFound):
+		return "list available plugins with: pentora plugin list"
+	case errors.Is(err, ErrPluginNotInstalled):
+		return "install the plugin first with: pentora plugin install <name>"
+	case errors.Is(err, ErrNoPluginsFound):
+		return "check plugin category and try: pentora plugin update"
+	case errors.Is(err, ErrInvalidCategory):
+		return "valid categories: ssh, http, tls, database, network, misc"
+	case errors.Is(err, ErrInvalidPluginID):
+		return "use lowercase letters, numbers, and hyphens only"
+	case errors.Is(err, ErrSourceNotAvailable), errors.Is(err, ErrUnavailable):
+		return "retry with different source: --source github"
+	case errors.Is(err, ErrChecksumMismatch):
+		return "retry with --force to re-download"
+	case errors.Is(err, ErrPluginAlreadyInstalled):
+		return "use --force to reinstall"
+	case errors.Is(err, ErrConflict):
+		return "uninstall existing version and reinstall"
+	case errors.Is(err, ErrPartialFailure):
+		return "use --output json for full error details"
+	default:
+		return "check logs for more details"
+	}
+}
+
 // ErrorCode returns the machine-readable error code string for API responses.
 // These codes are used in JSON error responses to enable programmatic error handling.
 //

--- a/pkg/plugin/service_errors_test.go
+++ b/pkg/plugin/service_errors_test.go
@@ -185,3 +185,89 @@ func TestErrorCode(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSuggestion(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "nil error returns empty string",
+			err:      nil,
+			expected: "",
+		},
+		{
+			name:     "ErrPluginNotFound suggests listing plugins",
+			err:      ErrPluginNotFound,
+			expected: "list available plugins with: pentora plugin list",
+		},
+		{
+			name:     "ErrPluginNotInstalled suggests installing",
+			err:      ErrPluginNotInstalled,
+			expected: "install the plugin first with: pentora plugin install <name>",
+		},
+		{
+			name:     "ErrNoPluginsFound suggests updating",
+			err:      ErrNoPluginsFound,
+			expected: "check plugin category and try: pentora plugin update",
+		},
+		{
+			name:     "ErrInvalidCategory suggests valid categories",
+			err:      ErrInvalidCategory,
+			expected: "valid categories: ssh, http, tls, database, network, misc",
+		},
+		{
+			name:     "ErrInvalidPluginID suggests naming convention",
+			err:      ErrInvalidPluginID,
+			expected: "use lowercase letters, numbers, and hyphens only",
+		},
+		{
+			name:     "ErrSourceNotAvailable suggests retry with different source",
+			err:      ErrSourceNotAvailable,
+			expected: "retry with different source: --source github",
+		},
+		{
+			name:     "ErrUnavailable suggests retry with different source",
+			err:      ErrUnavailable,
+			expected: "retry with different source: --source github",
+		},
+		{
+			name:     "ErrChecksumMismatch suggests force flag",
+			err:      ErrChecksumMismatch,
+			expected: "retry with --force to re-download",
+		},
+		{
+			name:     "ErrPluginAlreadyInstalled suggests force flag",
+			err:      ErrPluginAlreadyInstalled,
+			expected: "use --force to reinstall",
+		},
+		{
+			name:     "ErrConflict suggests uninstall and reinstall",
+			err:      ErrConflict,
+			expected: "uninstall existing version and reinstall",
+		},
+		{
+			name:     "ErrPartialFailure suggests JSON output",
+			err:      ErrPartialFailure,
+			expected: "use --output json for full error details",
+		},
+		{
+			name:     "unknown error suggests checking logs",
+			err:      errors.New("unknown"),
+			expected: "check logs for more details",
+		},
+		{
+			name:     "wrapped ErrChecksumMismatch returns force suggestion",
+			err:      fmt.Errorf("failed to download: %w", ErrChecksumMismatch),
+			expected: "retry with --force to re-download",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suggestion := GetSuggestion(tt.err)
+			require.Equal(t, tt.expected, suggestion)
+		})
+	}
+}

--- a/pkg/plugin/service_test.go
+++ b/pkg/plugin/service_test.go
@@ -908,7 +908,7 @@ func TestService_Install_PartialFailures(t *testing.T) {
 		require.Equal(t, 1, result.InstalledCount, "one plugin should succeed")
 		require.Equal(t, 1, result.FailedCount, "one plugin should fail")
 		require.Len(t, result.Errors, 1, "should collect errors")
-		require.Contains(t, result.Errors[0].Error(), "download failed")
+		require.Contains(t, result.Errors[0].Error, "download failed")
 	})
 }
 
@@ -1395,7 +1395,7 @@ func TestService_Update_PartialFailures(t *testing.T) {
 		require.Equal(t, 1, result.UpdatedCount)
 		require.Equal(t, 1, result.FailedCount)
 		require.Len(t, result.Errors, 1)
-		require.Contains(t, result.Errors[0].Error(), "download failed")
+		require.Contains(t, result.Errors[0].Error, "download failed")
 	})
 }
 
@@ -1699,7 +1699,7 @@ func TestService_Uninstall_PartialFailures(t *testing.T) {
 		require.Equal(t, 1, result.RemovedCount)
 		require.Equal(t, 1, result.FailedCount)
 		require.Len(t, result.Errors, 1)
-		require.Contains(t, result.Errors[0].Error(), "removal failed")
+		require.Contains(t, result.Errors[0].Error, "removal failed")
 	})
 }
 
@@ -1783,7 +1783,7 @@ func TestService_Uninstall_ManifestErrors(t *testing.T) {
 		require.NotNil(t, result)
 		require.Equal(t, 1, result.RemovedCount)
 		require.Len(t, result.Errors, 1, "should collect save error")
-		require.Contains(t, result.Errors[0].Error(), "save manifest")
+		require.Contains(t, result.Errors[0].Error, "save manifest")
 	})
 }
 

--- a/pkg/plugin/service_types.go
+++ b/pkg/plugin/service_types.go
@@ -10,6 +10,33 @@ import "time"
 // These types are used by the service layer to abstract business logic
 // from the CMD and API layers.
 
+// PluginError represents a per-plugin error in bulk operations.
+// Used for partial failure scenarios where some plugins succeed and others fail.
+//
+// Example:
+//
+//	PluginError{
+//	    PluginID:   "ssh-weak-cipher",
+//	    Error:      "checksum mismatch",
+//	    Code:       "CHECKSUM_MISMATCH",
+//	    Suggestion: "retry with --force to re-download",
+//	}
+type PluginError struct {
+	// PluginID is the unique identifier of the plugin (e.g., "ssh-weak-cipher")
+	PluginID string `json:"plugin_id"`
+
+	// Error is the human-readable error message
+	Error string `json:"error"`
+
+	// Code is the machine-readable error code from error taxonomy (ADR-0001)
+	// Examples: PLUGIN_NOT_FOUND, CHECKSUM_MISMATCH, SOURCE_NOT_AVAILABLE
+	Code string `json:"code"`
+
+	// Suggestion is an actionable suggestion for resolving the error
+	// Examples: "retry with --force", "check network connection"
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
 // InstallOptions holds parameters for Install operation
 type InstallOptions struct {
 	// Source specifies which plugin source to use (empty = all sources)
@@ -40,8 +67,9 @@ type InstallResult struct {
 	Plugins []*PluginInfo
 
 	// Errors contains all errors encountered during installation
-	// Collected for partial failure scenarios
-	Errors []error
+	// Each error includes plugin ID, error message, error code, and actionable suggestion
+	// Collected for partial failure scenarios (ADR-0003)
+	Errors []PluginError
 }
 
 // UpdateOptions holds parameters for Update operation
@@ -74,7 +102,9 @@ type UpdateResult struct {
 	Plugins []*PluginInfo
 
 	// Errors contains all errors encountered during update
-	Errors []error
+	// Each error includes plugin ID, error message, error code, and actionable suggestion
+	// Collected for partial failure scenarios (ADR-0003)
+	Errors []PluginError
 }
 
 // UninstallOptions holds parameters for Uninstall operation
@@ -98,7 +128,9 @@ type UninstallResult struct {
 	RemainingCount int
 
 	// Errors contains all errors encountered during uninstall
-	Errors []error
+	// Each error includes plugin ID, error message, error code, and actionable suggestion
+	// Collected for partial failure scenarios (ADR-0003)
+	Errors []PluginError
 }
 
 // PluginInfo holds detailed information about a plugin

--- a/pkg/plugin/smart_loader_test.go
+++ b/pkg/plugin/smart_loader_test.go
@@ -103,6 +103,7 @@ func TestSmartLoader_DetermineCategories(t *testing.T) {
 func TestSmartLoader_LoadForContext(t *testing.T) {
 	// Setup test server with manifest
 	sshPlugin := &YAMLPlugin{
+		ID:      "ssh-test",
 		Name:    "ssh-test",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -198,6 +199,7 @@ func TestSmartLoader_LoadForContext_EmptyContext(t *testing.T) {
 func TestSmartLoader_LoadAll(t *testing.T) {
 	// Create test plugin
 	plugin := &YAMLPlugin{
+		ID:      "test-plugin",
 		Name:    "test-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -262,6 +264,7 @@ func TestSmartLoader_LoadAll(t *testing.T) {
 
 func TestSmartLoader_LoadCategory(t *testing.T) {
 	plugin := &YAMLPlugin{
+		ID:      "ssh-plugin",
 		Name:    "ssh-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -348,6 +351,7 @@ func TestSmartLoader_GetLoadedPlugins(t *testing.T) {
 
 	// Add a plugin to cache
 	plugin := &YAMLPlugin{
+		ID:      "test",
 		Name:    "test",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -376,6 +380,7 @@ func TestSmartLoader_GetLoadedPluginsByCategory(t *testing.T) {
 
 	// Add plugins with different categories
 	sshPlugin := &YAMLPlugin{
+		ID:      "ssh-plugin",
 		Name:    "ssh-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,
@@ -391,6 +396,7 @@ func TestSmartLoader_GetLoadedPluginsByCategory(t *testing.T) {
 	}
 
 	httpPlugin := &YAMLPlugin{
+		ID:      "http-plugin",
 		Name:    "http-plugin",
 		Version: "1.0.0",
 		Type:    EvaluationType,

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -123,9 +123,9 @@ func (p *YAMLPlugin) Validate() error {
 		return fmt.Errorf("plugin name is required")
 	}
 
-	// Auto-generate ID from name if not provided
+	// ID is required (must be explicitly set in YAML)
 	if p.ID == "" {
-		p.ID = GeneratePluginID(p.Name)
+		return fmt.Errorf("plugin ID is required")
 	}
 
 	if p.Version == "" {
@@ -269,54 +269,4 @@ func (m *MatchBlock) Validate() error {
 	}
 
 	return nil
-}
-
-// GeneratePluginID generates a slug-style ID from a plugin name.
-// Examples:
-//   - "SSH Default Credentials" -> "ssh-default-credentials"
-//   - "HTTP Weak SSL/TLS Configuration" -> "http-weak-ssl-tls-configuration"
-//   - "OpenSSH CVE-2024-6387 (regreSSHion)" -> "openssh-cve-2024-6387-regresshion"
-func GeneratePluginID(name string) string {
-	// Convert to lowercase
-	id := strings.ToLower(name)
-
-	// Replace common separators with hyphens
-	replacements := map[string]string{
-		" ":  "-",
-		"/":  "-",
-		"\\": "-",
-		"_":  "-",
-		".":  "-",
-	}
-
-	for old, new := range replacements {
-		id = strings.ReplaceAll(id, old, new)
-	}
-
-	// Remove special characters (keep alphanumeric and hyphens)
-	var cleaned strings.Builder
-	for _, r := range id {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-			cleaned.WriteRune(r)
-		}
-	}
-	id = cleaned.String()
-
-	// Remove multiple consecutive hyphens
-	for strings.Contains(id, "--") {
-		id = strings.ReplaceAll(id, "--", "-")
-	}
-
-	// Trim hyphens from start and end
-	id = strings.Trim(id, "-")
-
-	return id
-}
-
-// GetID returns the plugin ID, generating one from name if not set.
-func (p *YAMLPlugin) GetID() string {
-	if p.ID != "" {
-		return p.ID
-	}
-	return GeneratePluginID(p.Name)
 }

--- a/pkg/plugin/types_test.go
+++ b/pkg/plugin/types_test.go
@@ -20,6 +20,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "valid plugin",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test Plugin",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -37,6 +38,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing name",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
 				Author:  "test",
@@ -53,6 +55,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing version",
 			plugin: &YAMLPlugin{
+				ID:     "test",
 				Name:   "Test",
 				Type:   EvaluationType,
 				Author: "test",
@@ -69,6 +72,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing type",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Author:  "test",
@@ -85,6 +89,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing author",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -101,6 +106,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing severity",
 			plugin: &YAMLPlugin{
+				ID:       "test",
 				Name:     "Test",
 				Version:  "1.0.0",
 				Type:     EvaluationType,
@@ -116,6 +122,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "invalid severity",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -133,6 +140,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "missing output message",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -148,6 +156,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "trigger missing data_key",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -168,6 +177,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "trigger missing condition",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -188,6 +198,7 @@ func TestPlugin_Validate(t *testing.T) {
 		{
 			name: "invalid match block",
 			plugin: &YAMLPlugin{
+				ID:      "test",
 				Name:    "Test",
 				Version: "1.0.0",
 				Type:    EvaluationType,
@@ -426,6 +437,7 @@ func TestPlugin_IsCompatibleWithPentora(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &YAMLPlugin{
+				ID:                "test-plugin",
 				Name:              "Test Plugin",
 				Version:           "1.0.0",
 				Type:              EvaluationType,
@@ -537,6 +549,7 @@ func TestPlugin_Validate_WithMinPentoraVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &YAMLPlugin{
+				ID:                "test-plugin",
 				Name:              "Test Plugin",
 				Version:           "1.0.0",
 				Type:              EvaluationType,

--- a/pkg/plugin/verify_test.go
+++ b/pkg/plugin/verify_test.go
@@ -130,7 +130,8 @@ func TestVerifier_VerifyPlugin_Success(t *testing.T) {
 	// Create test plugin file
 	tmpDir := t.TempDir()
 	pluginFile := filepath.Join(tmpDir, "plugin.yaml")
-	pluginYAML := `name: test-plugin
+	pluginYAML := `id: test-plugin
+name: test-plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -190,7 +191,8 @@ func TestVerifier_VerifyAll(t *testing.T) {
 
 	for i := 1; i <= 3; i++ {
 		pluginFile := filepath.Join(tmpDir, "plugin"+string(rune('0'+i))+".yaml")
-		pluginYAML := `name: plugin` + string(rune('0'+i)) + `
+		pluginYAML := `id: test-plugin
+name: plugin` + string(rune('0'+i)) + `
 version: 1.0.0
 type: evaluation
 author: test
@@ -233,7 +235,8 @@ func TestVerifier_VerifyAll_MissingChecksum(t *testing.T) {
 
 	// Create plugin
 	pluginFile := filepath.Join(tmpDir, "plugin.yaml")
-	pluginYAML := `name: test-plugin
+	pluginYAML := `id: test-plugin
+name: test-plugin
 version: 1.0.0
 type: evaluation
 author: test
@@ -267,7 +270,8 @@ func TestVerifier_VerifyAll_WrongChecksum(t *testing.T) {
 
 	// Create plugin
 	pluginFile := filepath.Join(tmpDir, "plugin.yaml")
-	pluginYAML := `name: test-plugin
+	pluginYAML := `id: test-plugin
+name: test-plugin
 version: 1.0.0
 type: evaluation
 author: test

--- a/pkg/server/api/v1/plugins_test.go
+++ b/pkg/server/api/v1/plugins_test.go
@@ -81,7 +81,7 @@ func TestInstallPluginHandler_Success(t *testing.T) {
 					Tags:     []string{"ssh", "crypto"},
 				},
 			},
-			Errors: []error{},
+			Errors: []plugin.PluginError{},
 		},
 	}
 
@@ -423,7 +423,7 @@ func TestUpdatePluginsHandler_Success(t *testing.T) {
 					Author:  "pentora-security",
 				},
 			},
-			Errors: []error{},
+			Errors: []plugin.PluginError{},
 		},
 	}
 	handler := UpdatePluginsHandler(mockSvc)
@@ -468,7 +468,7 @@ func TestUpdatePluginsHandler_WithCategoryFilter(t *testing.T) {
 					Version: "1.0.1",
 				},
 			},
-			Errors: []error{},
+			Errors: []plugin.PluginError{},
 		},
 	}
 	handler := UpdatePluginsHandler(mockSvc)
@@ -500,7 +500,7 @@ func TestUpdatePluginsHandler_EmptyBody(t *testing.T) {
 			SkippedCount: 0,
 			FailedCount:  0,
 			Plugins:      []*plugin.PluginInfo{},
-			Errors:       []error{},
+			Errors:       []plugin.PluginError{},
 		},
 	}
 	handler := UpdatePluginsHandler(mockSvc)


### PR DESCRIPTION
Implements comprehensive partial failure UX improvements extending ADR-0003.

**Author:** mirakodes

## Changes
- Service: PluginError struct with code+suggestion, GetSuggestion() helper
- CLI: Exit code 8 for partial failures, error truncation, unique suggestions
- API: PluginErrorDTO, partial_failure field, HTTP 200 for partial failures

## Testing
- make test: ALL PASSING (92.6% coverage)
- make validate: 0 ISSUES
- 14 test cases for GetSuggestion

Closes #41