### PR TITLE
refactor(cli): improve plugin command testability and reduce code duplication

### DIFF
--- a/cmd/pentora/commands/plugin/helpers.go
+++ b/cmd/pentora/commands/plugin/helpers.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pentora-ai/pentora/cmd/pentora/internal/format"
+	"github.com/pentora-ai/pentora/pkg/plugin"
+	"github.com/pentora-ai/pentora/pkg/storage"
+)
+
+// getFormatter creates a formatter from command flags
+func getFormatter(cmd *cobra.Command) format.Formatter {
+	outputMode := format.ParseMode(cmd.Flag("output").Value.String())
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	return format.New(os.Stdout, os.Stderr, outputMode, quiet, !noColor)
+}
+
+// getPluginService creates a plugin service with the given cache directory
+// If cacheDir is empty, uses the default platform-specific cache directory
+func getPluginService(cacheDir string) (*plugin.Service, error) {
+	if cacheDir == "" {
+		storageConfig, err := storage.DefaultConfig()
+		if err != nil {
+			return nil, fmt.Errorf("get storage config: %w", err)
+		}
+		cacheDir = filepath.Join(storageConfig.WorkspaceRoot, "plugins", "cache")
+	}
+
+	svc, err := plugin.NewService(cacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("create plugin service: %w", err)
+	}
+	return svc, nil
+}
+
+// handlePartialFailure handles partial failure errors by printing results and exiting with code 8
+func handlePartialFailure(err error, formatter format.Formatter, printFunc func() error) error {
+	if err != nil && errors.Is(err, plugin.ErrPartialFailure) {
+		// Print result even on partial failure
+		if printErr := printFunc(); printErr != nil {
+			return printErr
+		}
+		// Exit with code 8 for partial failure
+		os.Exit(plugin.ExitCode(err))
+	}
+	return nil
+}
+
+// printErrorList prints a list of plugin errors with suggestions
+// Used by install, update, and uninstall commands
+func printErrorList(f format.Formatter, errors []plugin.PluginError) error {
+	if len(errors) == 0 {
+		return nil
+	}
+
+	if err := f.PrintSummary("\nFailed plugins:"); err != nil {
+		return err
+	}
+
+	// Show first 5, truncate rest
+	maxErrors := 5
+	for i, e := range errors {
+		if i >= maxErrors {
+			remaining := len(errors) - maxErrors
+			if err := f.PrintSummary(fmt.Sprintf("  ... and %d more (use --output json for full list)", remaining)); err != nil {
+				return err
+			}
+			break
+		}
+		if err := f.PrintSummary(fmt.Sprintf("  - %s: %s", e.PluginID, e.Error)); err != nil {
+			return err
+		}
+	}
+
+	// Print suggestions
+	if err := f.PrintSummary("\n💡 Suggestions:"); err != nil {
+		return err
+	}
+
+	// Collect unique suggestions
+	suggestions := make(map[string]bool)
+	for _, e := range errors {
+		if e.Suggestion != "" {
+			suggestions[e.Suggestion] = true
+		}
+	}
+
+	for suggestion := range suggestions {
+		if err := f.PrintSummary(fmt.Sprintf("  → %s", suggestion)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildPluginTable builds table rows for plugin list
+// Used by install and update commands
+func buildPluginTable(plugins []*plugin.PluginInfo) [][]string {
+	var rows [][]string
+	for _, p := range plugins {
+		categoryStr := ""
+		if len(p.Tags) > 0 {
+			categoryStr = p.Tags[0]
+		}
+		rows = append(rows, []string{p.Name, p.Version, categoryStr})
+	}
+	return rows
+}
+
+// formatBytes formats bytes as human-readable string (e.g., "1.5 MiB")
+func formatBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/pentora/commands/plugin/info.go
+++ b/cmd/pentora/commands/plugin/info.go
@@ -3,14 +3,11 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/pentora-ai/pentora/cmd/pentora/internal/format"
 	"github.com/pentora-ai/pentora/pkg/plugin"
-	"github.com/pentora-ai/pentora/pkg/storage"
 )
 
 func newInfoCommand() *cobra.Command {
@@ -33,41 +30,7 @@ installation path, and cache size.`,
   pentora plugin info ssh-cve-2024-6387 --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pluginName := args[0]
-			ctx := context.Background()
-
-			// Create formatter
-			outputMode := format.ParseMode(cmd.Flag("output").Value.String())
-			quiet, _ := cmd.Flags().GetBool("quiet")
-			noColor, _ := cmd.Flags().GetBool("no-color")
-			formatter := format.New(os.Stdout, os.Stderr, outputMode, quiet, !noColor)
-
-			// Use default cache dir if not specified
-			if cacheDir == "" {
-				storageConfig, err := storage.DefaultConfig()
-				if err != nil {
-					return fmt.Errorf("get storage config: %w", err)
-				}
-				cacheDir = filepath.Join(storageConfig.WorkspaceRoot, "plugins", "cache")
-			}
-
-			// Create service
-			svc, err := plugin.NewService(cacheDir)
-			if err != nil {
-				return fmt.Errorf("create plugin service: %w", err)
-			}
-
-			// Call service layer
-			info, err := svc.GetInfo(ctx, pluginName)
-			if err != nil {
-				if err == plugin.ErrPluginNotFound {
-					return formatter.PrintError(fmt.Errorf("plugin '%s' not found\n\nUse 'pentora plugin list' to see installed plugins", pluginName))
-				}
-				return formatter.PrintError(err)
-			}
-
-			// Print results
-			return printPluginInfo(formatter, info)
+			return executeInfoCommand(cmd, args[0], cacheDir)
 		},
 	}
 
@@ -79,7 +42,31 @@ installation path, and cache size.`,
 	return cmd
 }
 
-// printPluginInfo formats and prints the plugin information using the formatter
+// executeInfoCommand orchestrates the info command execution
+func executeInfoCommand(cmd *cobra.Command, pluginName, cacheDir string) error {
+	ctx := context.Background()
+
+	// Setup dependencies
+	formatter := getFormatter(cmd)
+	svc, err := getPluginService(cacheDir)
+	if err != nil {
+		return err
+	}
+
+	// Call service layer
+	info, err := svc.GetInfo(ctx, pluginName)
+	if err != nil {
+		if err == plugin.ErrPluginNotFound {
+			return formatter.PrintError(fmt.Errorf("plugin '%s' not found\n\nUse 'pentora plugin list' to see installed plugins", pluginName))
+		}
+		return formatter.PrintError(err)
+	}
+
+	// Print results
+	return printPluginInfo(formatter, info)
+}
+
+// printPluginInfo formats and prints the plugin information
 func printPluginInfo(f format.Formatter, info *plugin.PluginInfo) error {
 	// Build key-value table
 	rows := [][]string{
@@ -98,18 +85,4 @@ func printPluginInfo(f format.Formatter, info *plugin.PluginInfo) error {
 	}
 
 	return f.PrintTable([]string{"Property", "Value"}, rows)
-}
-
-// formatBytes formats bytes as human-readable string
-func formatBytes(bytes int64) string {
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }

--- a/cmd/pentora/commands/plugin/install.go
+++ b/cmd/pentora/commands/plugin/install.go
@@ -2,10 +2,7 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,7 +10,6 @@ import (
 	"github.com/pentora-ai/pentora/cmd/pentora/internal/bind"
 	"github.com/pentora-ai/pentora/cmd/pentora/internal/format"
 	"github.com/pentora-ai/pentora/pkg/plugin"
-	"github.com/pentora-ai/pentora/pkg/storage"
 )
 
 func newInstallCommand() *cobra.Command {
@@ -45,57 +41,7 @@ You can install entire categories (ssh, http, tls, database, network) or specifi
   pentora plugin install ssh --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target := args[0]
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-
-			// Create formatter
-			outputMode := format.ParseMode(cmd.Flag("output").Value.String())
-			quiet, _ := cmd.Flags().GetBool("quiet")
-			noColor, _ := cmd.Flags().GetBool("no-color")
-			formatter := format.New(os.Stdout, os.Stderr, outputMode, quiet, !noColor)
-
-			// Use default cache dir if not specified
-			if cacheDir == "" {
-				storageConfig, err := storage.DefaultConfig()
-				if err != nil {
-					return fmt.Errorf("get storage config: %w", err)
-				}
-				cacheDir = filepath.Join(storageConfig.WorkspaceRoot, "plugins", "cache")
-			}
-
-			// Create service
-			svc, err := plugin.NewService(cacheDir)
-			if err != nil {
-				return fmt.Errorf("create plugin service: %w", err)
-			}
-
-			// Bind flags to options (centralized binding)
-			opts, err := bind.BindInstallOptions(cmd)
-			if err != nil {
-				return err
-			}
-
-			// Call service layer
-			result, err := svc.Install(ctx, target, opts)
-
-			// Handle partial failure (exit code 8)
-			if err != nil && errors.Is(err, plugin.ErrPartialFailure) {
-				// Print result even on partial failure
-				if printErr := printInstallResult(formatter, result); printErr != nil {
-					return printErr
-				}
-				// Exit with code 8 for partial failure
-				os.Exit(plugin.ExitCode(err))
-			}
-
-			// Handle total failure (exit code 1, 2, 4, 7, etc.)
-			if err != nil {
-				return formatter.PrintError(err)
-			}
-
-			// Print results using formatter
-			return printInstallResult(formatter, result)
+			return executeInstallCommand(cmd, args[0], cacheDir)
 		},
 	}
 
@@ -109,98 +55,65 @@ You can install entire categories (ssh, http, tls, database, network) or specifi
 	return cmd
 }
 
-// printInstallResult formats and prints the install result using the formatter
-// nolint:gocyclo // Complexity justified by comprehensive error handling and formatting
+// executeInstallCommand orchestrates the install command execution
+func executeInstallCommand(cmd *cobra.Command, target, cacheDir string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Setup dependencies
+	formatter := getFormatter(cmd)
+	svc, err := getPluginService(cacheDir)
+	if err != nil {
+		return err
+	}
+
+	// Bind flags to options
+	opts, err := bind.BindInstallOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Call service layer
+	result, err := svc.Install(ctx, target, opts)
+
+	// Handle partial failure (exit code 8)
+	if handleErr := handlePartialFailure(err, formatter, func() error {
+		return printInstallResult(formatter, result)
+	}); handleErr != nil {
+		return handleErr
+	}
+
+	// Handle total failure
+	if err != nil {
+		return formatter.PrintError(err)
+	}
+
+	// Print results
+	return printInstallResult(formatter, result)
+}
+
+// printInstallResult formats and prints the install result
 func printInstallResult(f format.Formatter, result *plugin.InstallResult) error {
-	// JSON mode: output complete result as JSON
 	if f.IsJSON() {
-		jsonResult := map[string]any{
-			"plugins":         result.Plugins,
-			"installed_count": result.InstalledCount,
-			"skipped_count":   result.SkippedCount,
-			"failed_count":    result.FailedCount,
-			"success":         result.FailedCount == 0,
-			"partial_failure": result.FailedCount > 0 && result.InstalledCount > 0,
-			"errors":          result.Errors,
-		}
-		return f.PrintJSON(jsonResult)
+		return printInstallJSON(f, result)
 	}
 
-	// Table mode: use existing table + summary pattern
-	if f == nil {
-		return fmt.Errorf("formatter is nil")
-	}
-
-	// Build table rows
-	var rows [][]string
-	for _, p := range result.Plugins {
-		categoryStr := ""
-		if len(p.Tags) > 0 {
-			categoryStr = p.Tags[0]
-		}
-		rows = append(rows, []string{p.Name, p.Version, categoryStr})
-	}
-
-	// Print table if there are plugins
+	// Print table
+	rows := buildPluginTable(result.Plugins)
 	if len(rows) > 0 {
 		if err := f.PrintTable([]string{"Name", "Version", "Category"}, rows); err != nil {
 			return err
 		}
 	}
 
-	// Build summary message
-	summary := fmt.Sprintf("Installation Summary: Installed: %d", result.InstalledCount)
-	if result.SkippedCount > 0 {
-		summary += fmt.Sprintf(", Already installed: %d", result.SkippedCount)
-	}
-	if result.FailedCount > 0 {
-		summary += fmt.Sprintf(", Failed: %d", result.FailedCount)
-	}
-
 	// Print summary
-	if err := f.PrintSummary(summary); err != nil {
+	if err := f.PrintSummary(buildInstallSummary(result)); err != nil {
 		return err
 	}
 
-	// Print errors if any (show first 5, truncate rest)
-	// nolint:dupl // Intentional code reuse across install/update/uninstall commands
-	if len(result.Errors) > 0 {
-		if err := f.PrintSummary("\nFailed plugins:"); err != nil {
-			return err
-		}
-
-		maxErrors := 5
-		for i, e := range result.Errors {
-			if i >= maxErrors {
-				remaining := len(result.Errors) - maxErrors
-				if err := f.PrintSummary(fmt.Sprintf("  ... and %d more (use --output json for full list)", remaining)); err != nil {
-					return err
-				}
-				break
-			}
-			if err := f.PrintSummary(fmt.Sprintf("  - %s: %s", e.PluginID, e.Error)); err != nil {
-				return err
-			}
-		}
-
-		// Print suggestions
-		if err := f.PrintSummary("\n💡 Suggestions:"); err != nil {
-			return err
-		}
-
-		// Collect unique suggestions
-		suggestions := make(map[string]bool)
-		for _, e := range result.Errors {
-			if e.Suggestion != "" {
-				suggestions[e.Suggestion] = true
-			}
-		}
-
-		for suggestion := range suggestions {
-			if err := f.PrintSummary(fmt.Sprintf("  → %s", suggestion)); err != nil {
-				return err
-			}
-		}
+	// Print errors if any
+	if err := printErrorList(f, result.Errors); err != nil {
+		return err
 	}
 
 	// Success message
@@ -209,4 +122,30 @@ func printInstallResult(f format.Formatter, result *plugin.InstallResult) error 
 	}
 
 	return nil
+}
+
+// printInstallJSON outputs install result as JSON
+func printInstallJSON(f format.Formatter, result *plugin.InstallResult) error {
+	jsonResult := map[string]any{
+		"plugins":         result.Plugins,
+		"installed_count": result.InstalledCount,
+		"skipped_count":   result.SkippedCount,
+		"failed_count":    result.FailedCount,
+		"success":         result.FailedCount == 0,
+		"partial_failure": result.FailedCount > 0 && result.InstalledCount > 0,
+		"errors":          result.Errors,
+	}
+	return f.PrintJSON(jsonResult)
+}
+
+// buildInstallSummary builds the summary message for install results
+func buildInstallSummary(result *plugin.InstallResult) string {
+	summary := fmt.Sprintf("Installation Summary: Installed: %d", result.InstalledCount)
+	if result.SkippedCount > 0 {
+		summary += fmt.Sprintf(", Already installed: %d", result.SkippedCount)
+	}
+	if result.FailedCount > 0 {
+		summary += fmt.Sprintf(", Failed: %d", result.FailedCount)
+	}
+	return summary
 }

--- a/cmd/pentora/commands/plugin/verify.go
+++ b/cmd/pentora/commands/plugin/verify.go
@@ -2,15 +2,12 @@ package plugin
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/pentora-ai/pentora/cmd/pentora/internal/bind"
 	"github.com/pentora-ai/pentora/cmd/pentora/internal/format"
 	"github.com/pentora-ai/pentora/pkg/plugin"
-	"github.com/pentora-ai/pentora/pkg/storage"
 )
 
 func newVerifyCommand() *cobra.Command {
@@ -38,50 +35,7 @@ Exit codes:
   # JSON output
   pentora plugin verify --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Create formatter
-			outputMode := format.ParseMode(cmd.Flag("output").Value.String())
-			quiet, _ := cmd.Flags().GetBool("quiet")
-			noColor, _ := cmd.Flags().GetBool("no-color")
-			formatter := format.New(os.Stdout, os.Stderr, outputMode, quiet, !noColor)
-
-			// Use default cache dir if not specified
-			if cacheDir == "" {
-				storageConfig, err := storage.DefaultConfig()
-				if err != nil {
-					return fmt.Errorf("get storage config: %w", err)
-				}
-				cacheDir = filepath.Join(storageConfig.WorkspaceRoot, "plugins", "cache")
-			}
-
-			// Create service
-			svc, err := plugin.NewService(cacheDir)
-			if err != nil {
-				return fmt.Errorf("create plugin service: %w", err)
-			}
-
-			// Bind flags to options (centralized binding)
-			opts, err := bind.BindVerifyOptions(cmd)
-			if err != nil {
-				return err
-			}
-
-			// Call service layer
-			result, err := svc.Verify(cmd.Context(), opts)
-			if err != nil {
-				return formatter.PrintError(err)
-			}
-
-			// Print results
-			if err := printVerifyResult(formatter, result); err != nil {
-				return err
-			}
-
-			// Return error if any plugins failed
-			if result.FailedCount > 0 {
-				return fmt.Errorf("verification failed for %d plugin(s)", result.FailedCount)
-			}
-
-			return nil
+			return executeVerifyCommand(cmd, cacheDir)
 		},
 	}
 
@@ -94,20 +48,47 @@ Exit codes:
 	return cmd
 }
 
-// printVerifyResult formats and prints the verify result using the formatter
-func printVerifyResult(f format.Formatter, result *plugin.VerifyResult) error {
-	// JSON mode: output complete result as JSON
-	if f.IsJSON() {
-		jsonResult := map[string]any{
-			"results":      result.Results,
-			"total_count":  result.TotalCount,
-			"failed_count": result.FailedCount,
-			"success":      result.FailedCount == 0,
-		}
-		return f.PrintJSON(jsonResult)
+// executeVerifyCommand orchestrates the verify command execution
+func executeVerifyCommand(cmd *cobra.Command, cacheDir string) error {
+	// Setup dependencies
+	formatter := getFormatter(cmd)
+	svc, err := getPluginService(cacheDir)
+	if err != nil {
+		return err
 	}
 
-	// Table mode: use existing table + summary pattern
+	// Bind flags to options
+	opts, err := bind.BindVerifyOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Call service layer
+	result, err := svc.Verify(cmd.Context(), opts)
+	if err != nil {
+		return formatter.PrintError(err)
+	}
+
+	// Print results
+	if err := printVerifyResult(formatter, result); err != nil {
+		return err
+	}
+
+	// Return error if any plugins failed
+	if result.FailedCount > 0 {
+		return fmt.Errorf("verification failed for %d plugin(s)", result.FailedCount)
+	}
+
+	return nil
+}
+
+// printVerifyResult formats and prints the verify result
+func printVerifyResult(f format.Formatter, result *plugin.VerifyResult) error {
+	if f.IsJSON() {
+		return printVerifyJSON(f, result)
+	}
+
+	// No plugins to verify
 	if result.TotalCount == 0 {
 		return f.PrintSummary("No plugins installed to verify.")
 	}
@@ -117,7 +98,33 @@ func printVerifyResult(f format.Formatter, result *plugin.VerifyResult) error {
 		return err
 	}
 
-	// Build table rows
+	// Build and print table
+	rows := buildVerifyTable(result)
+	if err := f.PrintTable([]string{"Plugin", "Version", "Status"}, rows); err != nil {
+		return err
+	}
+
+	// Print summary
+	if result.FailedCount == 0 {
+		return f.PrintSummary(fmt.Sprintf("✓ All %d plugin(s) verified successfully", result.TotalCount))
+	}
+
+	return f.PrintSummary(fmt.Sprintf("✗ %d plugin(s) failed verification", result.FailedCount))
+}
+
+// printVerifyJSON outputs verify result as JSON
+func printVerifyJSON(f format.Formatter, result *plugin.VerifyResult) error {
+	jsonResult := map[string]any{
+		"results":      result.Results,
+		"total_count":  result.TotalCount,
+		"failed_count": result.FailedCount,
+		"success":      result.FailedCount == 0,
+	}
+	return f.PrintJSON(jsonResult)
+}
+
+// buildVerifyTable builds table rows for verify results
+func buildVerifyTable(result *plugin.VerifyResult) [][]string {
 	var rows [][]string
 	for _, r := range result.Results {
 		status := "✓ OK"
@@ -135,16 +142,5 @@ func printVerifyResult(f format.Formatter, result *plugin.VerifyResult) error {
 		}
 		rows = append(rows, []string{r.ID, r.Version, status})
 	}
-
-	// Print table
-	if err := f.PrintTable([]string{"Plugin", "Version", "Status"}, rows); err != nil {
-		return err
-	}
-
-	// Print summary
-	if result.FailedCount == 0 {
-		return f.PrintSummary(fmt.Sprintf("✓ All %d plugin(s) verified successfully", result.TotalCount))
-	}
-
-	return f.PrintSummary(fmt.Sprintf("✗ %d plugin(s) failed verification", result.FailedCount))
+	return rows
 }


### PR DESCRIPTION
## Summary

Refactors plugin CLI commands to improve testability and reduce code duplication by extracting shared helpers and breaking down large command functions into focused, composable units.

**Addresses:** #46 - Command Size and Testability (60-80 Line Target)  
**Milestone:** service-layer-hardening  
**Type:** Refactoring (no behavior changes)

## Changes

### 1. New File: `helpers.go` (131 lines)

Centralized shared functionality:
- `getFormatter()` - Formatter creation from command flags
- `getPluginService()` - Service initialization with default cache dir
- `handlePartialFailure()` - Partial failure error handling
- `printErrorList()` - Error display logic (used by install/update/uninstall)
- `buildPluginTable()` - Plugin table building (used by install/update)
- `formatBytes()` - Human-readable byte formatting

### 2. Refactored Commands

| Command | Before | After | Change | Reduction |
|---------|--------|-------|--------|-----------|
| install.go | 213 | 152 | -61 | -29% |
| update.go | 219 | 171 | -48 | -22% |
| uninstall.go | 192 | 146 | -46 | -24% |
| list.go | 154 | 156 | +2 | -1% |
| info.go | 116 | 89 | -27 | -23% |
| clean.go | 135 | 134 | -1 | -1% |
| verify.go | 151 | 147 | -4 | -3% |
| **Total** | **1180** | **995** | **-185** | **-16%** |

Each command now follows a consistent pattern:
1. `executeXCommand()` - Orchestrates execution (setup → call service → handle errors → print)
2. `printXResult()` - Formats and prints results
3. `printXJSON()` - JSON output helper
4. `buildXSummary()` - Summary message builder

## Benefits

### ✅ Reduced Code Duplication
- 150+ lines of duplicate code eliminated
- Error handling logic centralized (no longer duplicated across 3 files)
- Formatter/service creation logic shared across all commands

### ✅ Improved Testability
- Each helper function can be unit tested independently
- Reduced Cobra dependency in business logic
- Mock-friendly structure

### ✅ Better Readability
- Self-documenting function names (`getFormatter`, `buildPluginTable`)
- Each function has a single, clear responsibility
- High-level flow easy to understand at a glance

### ✅ Easier Maintenance
- Single source of truth for common patterns
- Changes to shared logic automatically apply to all commands
- DRY principle enforced

### ✅ Lower Cognitive Complexity
- Smaller, focused functions
- Clear separation of concerns
- Reduced mental load when reading code

## Testing

- ✅ All existing unit tests pass (100% backward compatible)
- ✅ `make test`: PASS
- ✅ `make validate`: PASS
- ✅ No behavior changes, only structural improvements

## Checklist

- [x] Code builds without errors
- [x] All unit tests pass
- [x] `make validate` passes (linting, formatting)
- [x] No behavior changes (backward compatible)
- [x] Documentation updated (self-documenting code)
- [x] Commit message follows Conventional Commits

## Related

- Resolves #46
- Phase 2: CLI Refactoring
- Milestone: service-layer-hardening