### PR TITLE
fix(plugin): add actionable suggestions to total failure errors

### DIFF
--- a/cmd/pentora/commands/plugin/clean.go
+++ b/cmd/pentora/commands/plugin/clean.go
@@ -94,7 +94,7 @@ func executeCleanCommand(cmd *cobra.Command, cacheDir string) error {
 			Err(err).
 			Str("error_code", plugin.ErrorCode(err)).
 			Msg("clean failed")
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("clean", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with metrics

--- a/cmd/pentora/commands/plugin/embedded.go
+++ b/cmd/pentora/commands/plugin/embedded.go
@@ -48,7 +48,7 @@ for common security issues across SSH, HTTP, TLS, Database, and Network protocol
 			// Load embedded plugins
 			plugins, err := plugin.LoadEmbeddedPlugins()
 			if err != nil {
-				return formatter.PrintError(fmt.Errorf("load embedded plugins: %w", err))
+				return formatter.PrintTotalFailureSummary("load embedded plugins", err, "LOAD_ERROR")
 			}
 
 			// Filter plugins by category
@@ -101,7 +101,7 @@ func filterPluginsByCategory(plugins map[plugin.Category][]*plugin.YAMLPlugin, c
 		case "misc":
 			categoryFilter = plugin.CategoryMisc
 		default:
-			return nil, formatter.PrintError(fmt.Errorf("unknown category: %s (valid: ssh, http, tls, database, network, misc)", category))
+			return nil, formatter.PrintTotalFailureSummary("embedded", fmt.Errorf("unknown category: %s", category), "INVALID_CATEGORY")
 		}
 
 		// Get plugins for the specified category

--- a/cmd/pentora/commands/plugin/info.go
+++ b/cmd/pentora/commands/plugin/info.go
@@ -86,9 +86,9 @@ func executeInfoCommand(cmd *cobra.Command, pluginName, cacheDir string) error {
 			Str("plugin_name", pluginName).
 			Msg("info failed")
 		if err == plugin.ErrPluginNotFound {
-			return formatter.PrintError(fmt.Errorf("plugin '%s' not found\n\nUse 'pentora plugin list' to see installed plugins", pluginName))
+			return formatter.PrintTotalFailureSummary("info", fmt.Errorf("plugin '%s' not found", pluginName), plugin.ErrorCode(err))
 		}
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("info", err, plugin.ErrorCode(err))
 	}
 
 	// Log success

--- a/cmd/pentora/commands/plugin/install.go
+++ b/cmd/pentora/commands/plugin/install.go
@@ -115,7 +115,7 @@ func executeInstallCommand(cmd *cobra.Command, target, cacheDir string) error {
 		}
 
 		// Handle total failure
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("install", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with result metrics

--- a/cmd/pentora/commands/plugin/list.go
+++ b/cmd/pentora/commands/plugin/list.go
@@ -90,7 +90,7 @@ func executeListCommand(cmd *cobra.Command, cacheDir string, verbose bool) error
 			Err(err).
 			Str("error_code", plugin.ErrorCode(err)).
 			Msg("list failed")
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("list", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with metrics

--- a/cmd/pentora/commands/plugin/uninstall.go
+++ b/cmd/pentora/commands/plugin/uninstall.go
@@ -112,7 +112,7 @@ func executeUninstallCommand(cmd *cobra.Command, target, cacheDir string) error 
 			Str("error_code", plugin.ErrorCode(err)).
 			Str("target", target).
 			Msg("uninstall failed")
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("uninstall", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with metrics

--- a/cmd/pentora/commands/plugin/update.go
+++ b/cmd/pentora/commands/plugin/update.go
@@ -118,7 +118,7 @@ func executeUpdateCommand(cmd *cobra.Command, cacheDir string) error {
 			Err(err).
 			Str("error_code", plugin.ErrorCode(err)).
 			Msg("update failed")
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("update", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with metrics

--- a/cmd/pentora/commands/plugin/verify.go
+++ b/cmd/pentora/commands/plugin/verify.go
@@ -90,7 +90,7 @@ func executeVerifyCommand(cmd *cobra.Command, cacheDir string) error {
 			Err(err).
 			Str("error_code", plugin.ErrorCode(err)).
 			Msg("verify failed")
-		return formatter.PrintError(err)
+		return formatter.PrintTotalFailureSummary("verify", err, plugin.ErrorCode(err))
 	}
 
 	// Log success with metrics


### PR DESCRIPTION
## Background

When plugin commands completely fail, users were getting bare error messages with no guidance on what to try next. This was confusing because the suggestions system was built in Issue #47, but it only worked for partial failures (when some plugins succeed and others fail).

For total failures (everything fails), commands fell back to the old PrintError() method which shows no actionable hints.

## What Changed

Updated all 8 plugin commands to use PrintTotalFailureSummary() instead of PrintError() for total failure error handling:

- install.go
- update.go
- uninstall.go
- clean.go
- verify.go
- list.go
- info.go (2 locations)
- embedded.go (2 locations)

The error code mapping already exists in format/summary.go GetSuggestions(), so errors automatically show helpful next steps.

## Example Output

**Before (unhelpful):**
```bash
$ go run ./cmd plugin install nonexistent
Error: plugin not found: plugin 'nonexistent' not found
```

**After (helpful):**
```bash
$ go run ./cmd plugin install nonexistent
✗ Failed to install: plugin not found: plugin 'nonexistent' not found

💡 Suggestions:
  → List available plugins:  pentora plugin list
  → Try GitHub source:       pentora plugin install <plugin> --source github
```

## Testing

Tested each command with error scenarios:

```bash
# Plugin not found
go run ./cmd plugin install nonexistent-plugin
✓ Shows suggestions (list plugins, try GitHub)

# Invalid category
go run ./cmd plugin embedded --category invalid
✓ Shows valid categories list

# Plugin not found (info)
go run ./cmd plugin info unknown-plugin
✓ Shows suggestions
```

All tests pass:
```bash
make test      # ✓ All unit tests pass
make validate  # ✓ Linting passes (0 issues)
```

## Impact

Users now get actionable next steps for all plugin command errors:
- Plugin not found → List available plugins, try GitHub source
- Service unavailable → Retry with different source
- Permission denied → Check cache directory permissions
- Invalid category → Show valid categories

This completes the UX work started in Issue #47, giving consistent helpful error messaging across all plugin commands.

## Files Changed

- 8 files
- 10 lines changed (simple one-line replacements)
- Zero risk (infrastructure already exists)

Resolves #96