### PR TITLE
fix(scanner): correct banner type mismatch in module metadata

### DIFF
--- a/pkg/modules/parse/fingerprint_parser.go
+++ b/pkg/modules/parse/fingerprint_parser.go
@@ -54,7 +54,7 @@ func newFingerprintParserModule() *FingerprintParserModule {
 			Consumes: []engine.DataContractEntry{
 				{
 					Key:          "service.banner.tcp",
-					DataTypeName: "scan.BannerScanResult",
+					DataTypeName: "scan.BannerGrabResult",
 					Cardinality:  engine.CardinalityList,
 					IsOptional:   true,
 					Description:  "List of raw TCP banners captured from the service-banner module.",

--- a/pkg/modules/parse/http_parser.go
+++ b/pkg/modules/parse/http_parser.go
@@ -72,13 +72,13 @@ func newHTTPParserModule() *HTTPParserModule {
 					Key: "service.banner.tcp", // Expects output from service-banner-scanner
 					// DataTypeName is the type of *each item* within the []interface{} list
 					// that DataContext stores for "instance_id_of_banner_scanner.service.banner.tcp".
-					DataTypeName: "scan.BannerScanResult",
+					DataTypeName: "scan.BannerGrabResult",
 					// CardinalityList means this module expects the value for "service.banner.tcp"
 					// in its 'inputs' map to be an []interface{} list, where each element
-					// can be cast to scan.BannerScanResult.
+					// can be cast to scan.BannerGrabResult.
 					Cardinality: engine.CardinalityList,
 					IsOptional:  false, // Requires banner input to do any work
-					Description: "List of raw TCP banners, where each item is a scan.BannerScanResult.",
+					Description: "List of raw TCP banners, where each item is a scan.BannerGrabResult.",
 				},
 			},
 			Produces: []engine.DataContractEntry{

--- a/pkg/modules/parse/ssh_parser.go
+++ b/pkg/modules/parse/ssh_parser.go
@@ -68,13 +68,13 @@ func newSSHParserModule() *SSHParserModule {
 					Key: "service.banner.tcp", // Expects output from service-banner-scanner
 					// DataTypeName is the type of *each item* within the []interface{} list
 					// that DataContext stores for "instance_id_of_banner_scanner.service.banner.tcp".
-					DataTypeName: "scan.BannerScanResult", // Defined in pkg/modules/scan
+					DataTypeName: "scan.BannerGrabResult", // Defined in pkg/modules/scan
 					// CardinalityList means this module expects the value for "service.banner.tcp"
 					// in its 'inputs' map to be an []interface{} list, where each element
-					// can be cast to scan.BannerScanResult.
+					// can be cast to scan.BannerGrabResult.
 					Cardinality: engine.CardinalityList,
 					IsOptional:  false, // Requires banner input to do any work
-					Description: "List of raw TCP banners, where each item is a scan.BannerScanResult.",
+					Description: "List of raw TCP banners, where each item is a scan.BannerGrabResult.",
 				},
 			},
 			Produces: []engine.DataContractEntry{

--- a/pkg/modules/scan/banner_grab.go
+++ b/pkg/modules/scan/banner_grab.go
@@ -125,7 +125,7 @@ func newBannerGrabModule() *BannerGrabModule {
 			Produces: []engine.DataContractEntry{
 				{
 					Key:          "service.banner.tcp",
-					DataTypeName: "scan.BannerScanResult",
+					DataTypeName: "scan.BannerGrabResult",
 					Cardinality:  engine.CardinalityList,
 					Description:  "List of banners (or errors) captured from TCP services, one result per target/port.",
 				},


### PR DESCRIPTION
## Summary

Fixed critical type mismatch between banner_grab module and parser modules that prevented the scan pipeline from working correctly.

**Problem**: The banner_grab module declared it produces `"scan.BannerScanResult"` but the actual Go type is `BannerGrabResult`. This caused parser modules (HTTP, SSH, fingerprint) to fail when trying to consume banner data.

**Solution**: Updated DataTypeName in all 4 affected files to use the correct type name `"scan.BannerGrabResult"`.

## Changes

- `pkg/modules/scan/banner_grab.go`: Fixed DataTypeName in Produces contract (line 128)
- `pkg/modules/parse/http_parser.go`: Fixed DataTypeName in Consumes contract (line 75)
- `pkg/modules/parse/fingerprint_parser.go`: Fixed DataTypeName in Consumes contract (line 57)
- `pkg/modules/parse/ssh_parser.go`: Fixed DataTypeName in Consumes contract (line 71)

## Testing

✅ `make test` - All unit tests pass  
✅ `make validate` - Linting and validation pass  
✅ Scan test - Type mismatch warning no longer appears

**Before**:
```
WARN Item in 'service.banner.tcp' list is not of expected type scan.BannerScanResult
```

**After**:
```
No type warnings - parser modules can now consume banner data correctly
```

## Related

- Resolves #105
- Part of scan-fix-sprint-nov-01 milestone
- Unblocks parser modules (HTTP, SSH, fingerprint)
- Enables asset profile generation (needed for #107)

## Definition of Done

- [x] All 4 files updated with correct DataTypeName
- [x] make test passes
- [x] make validate passes
- [x] Type mismatch warnings eliminated
- [x] Parser modules can consume banner data