### PR TITLE
fix(scanner): enable loopback scanning by default for development

### DIFF
--- a/pkg/modules/discovery/icmp_ping.go
+++ b/pkg/modules/discovery/icmp_ping.go
@@ -76,7 +76,7 @@ func newICMPPingDiscoveryModule() *ICMPPingDiscoveryModule {
 		PacketTimeout: 1 * time.Second, // This will be used for pinger.Timeout
 		Privileged:    false,
 		Concurrency:   50,
-		AllowLoopback: false,
+		AllowLoopback: true,
 	}
 
 	return &ICMPPingDiscoveryModule{


### PR DESCRIPTION
## Summary

Enabled loopback scanning by default to allow local development and testing without external network access.

**Problem**: Developers couldn't test scan command locally because 127.0.0.1 addresses were blocked by default with error: "no hosts to ping: all specified targets were loopback addresses"

**Solution**: Changed `AllowLoopback` default from `false` to `true` in ICMP ping discovery module.

## Changes

- `pkg/modules/discovery/icmp_ping.go`: Changed `AllowLoopback: false` → `AllowLoopback: true` in defaultConfig (line 79)

## Rationale

**Why this is safe**:
- Development/testing on localhost is common and expected
- Most security tools allow localhost scanning by default (nmap, masscan, etc.)
- Production deployments can override via config if needed
- No security risk (only affects discovery phase, not vulnerability scanning)
- Matches user expectations for a security tool

## Testing

✅ `make test` - All unit tests pass  
✅ `make validate` - Linting and validation pass  
✅ Loopback scan verified working

**Before**:
```bash
$ go run ./cmd scan 127.0.0.1 --ports 22
ERROR: no hosts to ping: all specified targets were loopback addresses
```

**After**:
```bash
$ go run ./cmd scan 127.0.0.1 --ports 22
Target: 127.0.0.1
  Port: 22/tcp (open)
  Service: SSH OpenSSH 9.0
```

## Related

- Resolves #106
- Part of scan-fix-sprint-nov-01 milestone
- Unblocks local development workflow
- Enables integration testing with localhost services

## Definition of Done

- [x] AllowLoopback default changed to true
- [x] make test passes
- [x] make validate passes
- [x] 127.0.0.1 scans work without errors
- [x] "Skipping loopback" error message eliminated