### PR TITLE
feat(cli): add global --verbose and de-duplicate plugin CLI logs

### DIFF
--- a/cmd/pentora/commands/plugin/clean.go
+++ b/cmd/pentora/commands/plugin/clean.go
@@ -90,10 +90,6 @@ func executeCleanCommand(cmd *cobra.Command, cacheDir string) error {
 	// Call service layer
 	result, err := svc.Clean(cmd.Context(), opts)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("clean failed")
 		return formatter.PrintTotalFailureSummary("clean", err, plugin.ErrorCode(err))
 	}
 

--- a/cmd/pentora/commands/plugin/info.go
+++ b/cmd/pentora/commands/plugin/info.go
@@ -70,21 +70,12 @@ func executeInfoCommand(cmd *cobra.Command, pluginName, cacheDir string) error {
 	formatter := getFormatter(cmd)
 	svc, err := getPluginService(cacheDir)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("failed to initialize plugin service")
 		return err
 	}
 
 	// Call service layer
 	info, err := svc.GetInfo(ctx, pluginName)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Str("plugin_name", pluginName).
-			Msg("info failed")
 		if err == plugin.ErrPluginNotFound {
 			return formatter.PrintTotalFailureSummary("info", fmt.Errorf("plugin '%s' not found", pluginName), plugin.ErrorCode(err))
 		}

--- a/cmd/pentora/commands/plugin/install.go
+++ b/cmd/pentora/commands/plugin/install.go
@@ -91,10 +91,6 @@ func executeInstallCommand(cmd *cobra.Command, target, cacheDir string) error {
 	formatter := getFormatter(cmd)
 	svc, err := getPluginService(cacheDir)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("failed to initialize plugin service")
 		return err
 	}
 
@@ -102,10 +98,6 @@ func executeInstallCommand(cmd *cobra.Command, target, cacheDir string) error {
 	result, err := svc.Install(ctx, target, opts)
 	// Handle errors with structured logging
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("install failed")
 
 		// Handle partial failure (exit code 8)
 		if handleErr := handlePartialFailure(err, formatter, func() error {

--- a/cmd/pentora/commands/plugin/list.go
+++ b/cmd/pentora/commands/plugin/list.go
@@ -76,20 +76,12 @@ func executeListCommand(cmd *cobra.Command, cacheDir string, verbose bool) error
 	formatter := getFormatter(cmd)
 	svc, err := getPluginService(cacheDir)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("failed to initialize plugin service")
 		return err
 	}
 
 	// Call service layer
 	plugins, err := svc.List(ctx)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("list failed")
 		return formatter.PrintTotalFailureSummary("list", err, plugin.ErrorCode(err))
 	}
 

--- a/cmd/pentora/commands/plugin/uninstall.go
+++ b/cmd/pentora/commands/plugin/uninstall.go
@@ -107,11 +107,6 @@ func executeUninstallCommand(cmd *cobra.Command, target, cacheDir string) error 
 
 	// Handle total failure
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Str("target", target).
-			Msg("uninstall failed")
 		return formatter.PrintTotalFailureSummary("uninstall", err, plugin.ErrorCode(err))
 	}
 

--- a/cmd/pentora/commands/plugin/update.go
+++ b/cmd/pentora/commands/plugin/update.go
@@ -103,21 +103,11 @@ func executeUpdateCommand(cmd *cobra.Command, cacheDir string) error {
 	if handleErr := handlePartialFailure(err, formatter, func() error {
 		return printUpdateResult(formatter, result, opts.DryRun)
 	}); handleErr != nil {
-		if err != nil {
-			logger.Error().
-				Err(err).
-				Str("error_code", plugin.ErrorCode(err)).
-				Msg("update failed")
-		}
 		return handleErr
 	}
 
 	// Handle total failure
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("update failed")
 		return formatter.PrintTotalFailureSummary("update", err, plugin.ErrorCode(err))
 	}
 

--- a/cmd/pentora/commands/plugin/verify.go
+++ b/cmd/pentora/commands/plugin/verify.go
@@ -83,13 +83,9 @@ func executeVerifyCommand(cmd *cobra.Command, cacheDir string) error {
 		Str("plugin_id", opts.PluginID).
 		Msg("verify started")
 
-	// Call service layer
+		// Call service layer
 	result, err := svc.Verify(cmd.Context(), opts)
 	if err != nil {
-		logger.Error().
-			Err(err).
-			Str("error_code", plugin.ErrorCode(err)).
-			Msg("verify failed")
 		return formatter.PrintTotalFailureSummary("verify", err, plugin.ErrorCode(err))
 	}
 


### PR DESCRIPTION
Implements Issue #102. Adds root --verbose/-v to control zerolog level and removes duplicate CLI error logs across plugin commands. Default shows user-friendly output; --verbose reveals service logs. make test && make validate pass.