### PR TITLE
feat(format): suggestions for NO_PLUGINS_FOUND (better network/DNS UX)

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,1 @@
+/Users/yahya/Code/pentora/pentora/.pre-commit

--- a/cmd/pentora/internal/format/summary.go
+++ b/cmd/pentora/internal/format/summary.go
@@ -241,6 +241,15 @@ func GetSuggestions(errorCode string, operation string) []string {
 			fmt.Sprintf("See full details:        pentora plugin %s --output json", operation),
 		)
 
+	case "NO_PLUGINS_FOUND":
+		suggestions = append(suggestions,
+			"Check network connection",
+			"Verify DNS resolution",
+			fmt.Sprintf("Try GitHub source:       pentora plugin %s <name> --source github", operation),
+			fmt.Sprintf("Force re-download:       pentora plugin %s --force", operation),
+			"List cached plugins:     pentora plugin list",
+		)
+
 	case "INVALID_CATEGORY":
 		suggestions = append(suggestions,
 			"Valid categories: ssh, http, tls, database, network, web, iot, misc",


### PR DESCRIPTION
Implements Issue #113.

- Add actionable suggestions for NO_PLUGINS_FOUND in formatter
  - Check network connection
  - Verify DNS resolution
  - Try GitHub source fallback (install/update)
  - Force re-download
  - List cached plugins

Behavior
- When NO_PLUGINS_FOUND is returned by plugin commands, the total failure summary now includes hints similar to PLUGIN_NOT_FOUND and others.

Validation
- make test && make validate pass locally.