### PR TITLE
fix(engine): repair --no-discover flag by fixing host discovery filter

### DIFF
--- a/pkg/engine/planner.go
+++ b/pkg/engine/planner.go
@@ -9,6 +9,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	// Module type names used throughout the planner
+	moduleTypeTCPPortDiscovery  = "tcp-port-discovery"
+	moduleTypeUDPPortDiscovery  = "udp-port-discovery"
+	moduleTypeICMPPingDiscovery = "icmp-ping-discovery"
+)
+
 // ScanIntent represents the user's high-level goal for the scan.
 type ScanIntent struct {
 	Targets          []string
@@ -42,6 +49,146 @@ func NewDAGPlanner(registry map[string]ModuleFactory) (*DAGPlanner, error) {
 	}, nil
 }
 
+// initializeDataKeys sets up initial data keys for DAG planning based on intent.
+func (p *DAGPlanner) initializeDataKeys(intent ScanIntent) map[string]string {
+	availableDataKeys := make(map[string]string)
+	if len(intent.Targets) > 0 {
+		availableDataKeys["config.targets"] = "initial_input"
+
+		// If skipping discovery, treat all targets as live hosts
+		if intent.SkipDiscovery {
+			availableDataKeys["discovery.live_hosts"] = "initial_input"
+			p.logger.Debug().Msg("SkipDiscovery enabled: treating all targets as live hosts")
+		}
+
+		p.logger.Debug().Interface("initial_keys", availableDataKeys).Msg("Initial available data keys")
+	}
+	return availableDataKeys
+}
+
+// checkModuleDependencies checks if all required dependencies for a module are met.
+func (p *DAGPlanner) checkModuleDependencies(
+	meta ModuleMetadata,
+	availableDataKeys map[string]string,
+) bool {
+	if len(meta.Consumes) == 0 {
+		return true
+	}
+
+	for _, consumedContract := range meta.Consumes {
+		consumedKeyString := consumedContract.Key
+		if _, keyIsAvailable := availableDataKeys[consumedKeyString]; !keyIsAvailable && !consumedContract.IsOptional {
+			p.logger.Trace().Str("module", meta.Name).Str("missing_key", consumedKeyString).
+				Msg("Dependency key not yet available for module")
+			return false
+		}
+	}
+	return true
+}
+
+// addModuleToDAG adds a module to the DAG and updates tracking structures.
+func (p *DAGPlanner) addModuleToDAG(
+	meta ModuleMetadata,
+	intent ScanIntent,
+	dagDef *DAGDefinition,
+	dagNodeConfigs map[string]DAGNodeConfig,
+	availableDataKeys map[string]string,
+) {
+	instanceID := p.generateInstanceID(meta.Name, dagNodeConfigs)
+
+	nodeCfg := DAGNodeConfig{
+		InstanceID: instanceID,
+		ModuleType: meta.Name,
+		Config:     p.configureModule(meta, intent),
+	}
+
+	dagDef.Nodes = append(dagDef.Nodes, nodeCfg)
+	dagNodeConfigs[instanceID] = dagDef.Nodes[len(dagDef.Nodes)-1]
+
+	p.logger.Debug().Str("module", meta.Name).Str("instance_id", instanceID).Msg("Added module to DAG")
+
+	// Register produced data keys
+	for _, producedContract := range meta.Produces {
+		producedKey := producedContract.Key
+		if existingProducer, found := availableDataKeys[producedKey]; found && existingProducer != "initial_input" {
+			p.logger.Warn().Str("data_key", producedKey).Str("new_producer", instanceID).
+				Str("existing_producer", existingProducer).
+				Msg("DataKey already produced by another module. Overwriting producer.")
+		}
+		availableDataKeys[producedKey] = instanceID
+		p.logger.Trace().Str("module_producer", meta.Name).Str("instance_id_producer", instanceID).
+			Str("produced_key", producedKey).Msg("Marked key as available")
+	}
+}
+
+// buildDAGIteratively builds the DAG by iteratively adding modules whose dependencies are met.
+func (p *DAGPlanner) buildDAGIteratively(
+	candidateModules []ModuleFactory,
+	intent ScanIntent,
+	dagDef *DAGDefinition,
+	availableDataKeys map[string]string,
+) map[string]bool {
+	dagNodeConfigs := make(map[string]DAGNodeConfig)
+	moduleTypesAddedToDAG := make(map[string]bool)
+
+	for {
+		addedInThisIteration := 0
+
+		for _, modFactory := range candidateModules {
+			tempMod := modFactory()
+			meta := tempMod.Metadata()
+
+			if moduleTypesAddedToDAG[meta.Name] {
+				continue
+			}
+
+			if p.checkModuleDependencies(meta, availableDataKeys) {
+				p.addModuleToDAG(meta, intent, dagDef, dagNodeConfigs, availableDataKeys)
+				moduleTypesAddedToDAG[meta.Name] = true
+				addedInThisIteration++
+			}
+		}
+
+		if addedInThisIteration == 0 {
+			p.logger.Debug().Int("total_dag_nodes", len(dagDef.Nodes)).
+				Msg("No more modules added in this planning iteration. Loop will terminate.")
+			break
+		}
+		p.logger.Debug().Int("added_this_iteration", addedInThisIteration).
+			Int("total_dag_nodes", len(dagDef.Nodes)).
+			Msg("Completed an iteration of DAG planning.")
+	}
+
+	return moduleTypesAddedToDAG
+}
+
+// logUnprocessedModules logs modules that couldn't be added due to unmet dependencies.
+func (p *DAGPlanner) logUnprocessedModules(
+	candidateModules []ModuleFactory,
+	moduleTypesAddedToDAG map[string]bool,
+	availableDataKeys map[string]string,
+) {
+	if len(moduleTypesAddedToDAG) >= len(candidateModules) {
+		return
+	}
+
+	p.logger.Warn().Msg("Not all candidate modules selected by intent could be added to the DAG. Logging unprocessed modules and their potential unmet dependencies:")
+	for _, modFactory := range candidateModules {
+		meta := modFactory().Metadata()
+		if !moduleTypesAddedToDAG[meta.Name] {
+			unmetDependencies := []string{}
+			for _, consumedContract := range meta.Consumes {
+				consumedKey := consumedContract.Key
+				if _, found := availableDataKeys[consumedKey]; !found {
+					unmetDependencies = append(unmetDependencies, consumedKey)
+				}
+			}
+			p.logger.Warn().Str("module", meta.Name).Strs("unmet_dependencies", unmetDependencies).
+				Msg("Unprocessed candidate module")
+		}
+	}
+}
+
 // PlanDAG attempts to create a DAGDefinition based on the provided scan intent.
 func (p *DAGPlanner) PlanDAG(intent ScanIntent) (*DAGDefinition, error) {
 	p.logger.Info().Interface("intent", intent).Msg("Planning DAG based on scan intent")
@@ -59,112 +206,16 @@ func (p *DAGPlanner) PlanDAG(intent ScanIntent) (*DAGDefinition, error) {
 	}
 	p.logger.Debug().Int("count", len(candidateModules)).Msg("Candidate modules selected")
 
-	availableDataKeys := make(map[string]string) // DataKey -> Producing InstanceID
-	if len(intent.Targets) > 0 {
-		availableDataKeys["config.targets"] = "initial_input" // Mark config.targets as initially available
+	// Initialize available data keys
+	availableDataKeys := p.initializeDataKeys(intent)
 
-		// If skipping discovery, treat all targets as live hosts
-		if intent.SkipDiscovery {
-			availableDataKeys["discovery.live_hosts"] = "initial_input"
-			p.logger.Debug().Msg("SkipDiscovery enabled: treating all targets as live hosts")
-		}
+	// Build DAG iteratively
+	moduleTypesAddedToDAG := p.buildDAGIteratively(candidateModules, intent, dagDef, availableDataKeys)
 
-		p.logger.Debug().Interface("initial_keys", availableDataKeys).Msg("Initial available data keys")
-	}
-	// Add other global/initial keys if necessary, e.g., from intent.CustomPortConfig if planner doesn't set it directly in module config
-	// if intent.CustomPortConfig != "" {
-	// 	availableDataKeys["config.ports"] = "initial_input"
-	// }
+	// Log unprocessed modules if any
+	p.logUnprocessedModules(candidateModules, moduleTypesAddedToDAG, availableDataKeys)
 
-	// Store node configs by instance ID to ensure uniqueness and for lookups
-	dagNodeConfigs := make(map[string]DAGNodeConfig)
-	// Track module types already added to the DAG to add each type at most once in this simple auto-plan
-	moduleTypesAddedToDAG := make(map[string]bool)
-
-	// Iteratively build the DAG layer by layer
-	for { // Loop until no more modules can be added in a full pass
-		addedInThisIteration := 0
-
-		for _, modFactory := range candidateModules {
-			tempMod := modFactory() // Create a temporary instance to get metadata
-			meta := tempMod.Metadata()
-
-			if moduleTypesAddedToDAG[meta.Name] { // If this module *type* has already been added
-				continue
-			}
-
-			// Check if all consumed keys for this module are currently available
-			allConsumesMet := true
-			if len(meta.Consumes) > 0 {
-				for _, consumedContract := range meta.Consumes {
-					consumedKeyString := consumedContract.Key // Use the string Key
-					if _, keyIsAvailable := availableDataKeys[consumedKeyString]; !keyIsAvailable && !consumedContract.IsOptional {
-						// If this key is not available and it's not optional, we cannot add this module yet
-						allConsumesMet = false
-						p.logger.Trace().Str("module", meta.Name).Str("missing_key", consumedKeyString).Msg("Dependency key not yet available for module")
-						break
-					}
-				}
-			} // Modules with no consumes (or all consumes met by initial_input) are considered for the first layer
-
-			if allConsumesMet {
-				// This module's dependencies are met, it can be added to the DAG
-				instanceID := p.generateInstanceID(meta.Name, dagNodeConfigs) // Pass current DAG nodes to ensure unique ID
-
-				nodeCfg := DAGNodeConfig{
-					InstanceID: instanceID,
-					ModuleType: meta.Name, // Use the registered module type name
-					Config:     p.configureModule(meta, intent),
-				}
-
-				dagDef.Nodes = append(dagDef.Nodes, nodeCfg)
-				dagNodeConfigs[instanceID] = dagDef.Nodes[len(dagDef.Nodes)-1] // Store pointer to the added node config
-				moduleTypesAddedToDAG[meta.Name] = true                        // Mark this module TYPE as added
-
-				p.logger.Debug().Str("module", meta.Name).Str("instance_id", instanceID).Msg("Added module to DAG")
-
-				// Add its produced keys to availableDataKeys for subsequent modules in this or next iterations
-				for _, producedContract := range meta.Produces {
-					producedKey := producedContract.Key // Use the string Key
-					if existingProducer, found := availableDataKeys[producedKey]; found && existingProducer != "initial_input" {
-						p.logger.Warn().Str("data_key", producedKey).Str("new_producer", instanceID).Str("existing_producer", existingProducer).Msg("DataKey already produced by another module. Overwriting producer.")
-					}
-					availableDataKeys[producedKey] = instanceID // Mark key as available, produced by this new instance
-					p.logger.Trace().Str("module_producer", meta.Name).Str("instance_id_producer", instanceID).Str("produced_key", producedKey).Msg("Marked key as available")
-				}
-				addedInThisIteration++
-			}
-		}
-
-		if addedInThisIteration == 0 {
-			// No new modules were added in this full pass over all candidates.
-			// This means either all addable modules are in, or remaining ones have unmet dependencies.
-			p.logger.Debug().Int("total_dag_nodes", len(dagDef.Nodes)).Msg("No more modules added in this planning iteration. Loop will terminate.")
-			break
-		}
-		p.logger.Debug().Int("added_this_iteration", addedInThisIteration).Int("total_dag_nodes", len(dagDef.Nodes)).Msg("Completed an iteration of DAG planning.")
-	} // End of main planning loop
-
-	// After the loop, check if all selected candidate modules were actually added
-	if len(moduleTypesAddedToDAG) < len(candidateModules) {
-		p.logger.Warn().Msg("Not all candidate modules selected by intent could be added to the DAG. Logging unprocessed modules and their potential unmet dependencies:")
-		for _, modFactory := range candidateModules {
-			meta := modFactory().Metadata()
-			if !moduleTypesAddedToDAG[meta.Name] {
-				unmetDependencies := []string{}
-				for _, consumedContract := range meta.Consumes {
-					consumedKey := consumedContract.Key // Use the string Key
-					if _, found := availableDataKeys[consumedKey]; !found {
-						unmetDependencies = append(unmetDependencies, consumedKey)
-					}
-				}
-				p.logger.Warn().Str("module", meta.Name).Strs("unmet_dependencies", unmetDependencies).Msg("Unprocessed candidate module")
-			}
-		}
-		// Depending on strictness, this could be an error or just a warning.
-		// If a core module for the intent couldn't be added, it might be an error.
-	}
-
+	// Validate DAG is not empty
 	if len(dagDef.Nodes) == 0 {
 		if len(candidateModules) > 0 {
 			p.logger.Error().Msg("Failed to plan any nodes for the DAG, though candidates were selected. Check dependencies or initial inputs.")
@@ -178,88 +229,151 @@ func (p *DAGPlanner) PlanDAG(intent ScanIntent) (*DAGDefinition, error) {
 	return dagDef, nil
 }
 
-// selectModulesForIntent filters moduleRegistry based on the scan intent.
-// This is a placeholder and needs to be implemented with more sophisticated logic.
-func (p *DAGPlanner) selectModulesForIntent(intent ScanIntent) []ModuleFactory {
+// filterHostDiscoveryModules removes host discovery modules when SkipDiscovery=true.
+// Only filters ICMP ping modules, preserves port scanners (tcp-port-discovery, udp-port-discovery).
+func (p *DAGPlanner) filterHostDiscoveryModules(selected []ModuleFactory) []ModuleFactory {
+	filtered := selected[:0]
+	filteredCount := 0
+	for _, factory := range selected {
+		meta := factory().Metadata()
+		// Only filter host discovery modules (ICMP ping), NOT port scanning modules
+		if meta.Type == DiscoveryModuleType &&
+			meta.Name != moduleTypeTCPPortDiscovery &&
+			meta.Name != moduleTypeUDPPortDiscovery {
+			filteredCount++
+			continue
+		}
+		filtered = append(filtered, factory)
+	}
+	if filteredCount > 0 {
+		p.logger.Debug().Int("filtered_modules", filteredCount).
+			Msg("Filtered host discovery modules due to SkipDiscovery")
+	}
+	return filtered
+}
+
+// selectModulesByType filters modules by type and tags from the registry.
+func (p *DAGPlanner) selectModulesByType(
+	moduleTypes []ModuleType,
+	intent ScanIntent,
+	logMessage string,
+) []ModuleFactory {
 	var selected []ModuleFactory
-	allModules := p.moduleRegistry // Assuming this holds ModuleName -> Factory
-
-	if intent.DiscoveryOnly {
-		for name, factory := range allModules {
-			meta := factory().Metadata()
-			if meta.Type == DiscoveryModuleType && p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
+	for name, factory := range p.moduleRegistry {
+		meta := factory().Metadata()
+		for _, mType := range moduleTypes {
+			if meta.Type == mType && p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
 				selected = append(selected, factory)
-				p.logger.Debug().Str("module", name).Msg("Selected module for discovery-only run")
+				p.logger.Debug().Str("module", name).Msg(logMessage)
+				break
 			}
 		}
-		selected = p.addParseModules(selected, allModules, intent)
-		return p.ensureReporter(selected, intent)
+	}
+	return selected
+}
+
+// selectDiscoveryModules selects only discovery modules (for DiscoveryOnly mode).
+func (p *DAGPlanner) selectDiscoveryModules(intent ScanIntent) []ModuleFactory {
+	return p.selectModulesByType(
+		[]ModuleType{DiscoveryModuleType},
+		intent,
+		"Selected module for discovery-only run",
+	)
+}
+
+// selectQuickDiscoveryModules selects modules for quick_discovery/light profile.
+func (p *DAGPlanner) selectQuickDiscoveryModules(intent ScanIntent) []ModuleFactory {
+	var selected []ModuleFactory
+	for name, factory := range p.moduleRegistry {
+		meta := factory().Metadata()
+		if (meta.Type == DiscoveryModuleType ||
+			(containsTag(meta.Tags, "quick") && meta.Type == ScanModuleType)) &&
+			p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
+			selected = append(selected, factory)
+			p.logger.Debug().Str("module", name).Msg("Selected module for quick_discovery/light profile")
+		}
+	}
+	return selected
+}
+
+// selectFullScanModules selects modules for full_scan/comprehensive profile.
+func (p *DAGPlanner) selectFullScanModules(intent ScanIntent) []ModuleFactory {
+	var selected []ModuleFactory
+	for name, factory := range p.moduleRegistry {
+		meta := factory().Metadata()
+		// Include Discovery, Scan, Parse, Reporting, and optionally Evaluation
+		includeModule := meta.Type == DiscoveryModuleType ||
+			meta.Type == ScanModuleType ||
+			meta.Type == ParseModuleType ||
+			meta.Type == ReportingModuleType ||
+			(intent.EnableVulnChecks && meta.Type == EvaluationModuleType)
+
+		if includeModule && p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
+			selected = append(selected, factory)
+			p.logger.Debug().Str("module", name).Msg("Selected module for full_scan/comprehensive profile")
+		}
+	}
+	return selected
+}
+
+// selectDefaultModules selects modules for default profile (discovery + scan, optionally vuln).
+func (p *DAGPlanner) selectDefaultModules(intent ScanIntent) []ModuleFactory {
+	var selected []ModuleFactory
+
+	// Select discovery and scan modules (non-intrusive)
+	for name, factory := range p.moduleRegistry {
+		meta := factory().Metadata()
+		if (meta.Type == DiscoveryModuleType || meta.Type == ScanModuleType) &&
+			!containsTag(meta.Tags, "intrusive") &&
+			p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
+			selected = append(selected, factory)
+			p.logger.Debug().Str("module", name).Msg("Selected module for default profile")
+		}
 	}
 
-	// Basic filtering based on profile or level (example logic)
+	// Add evaluation modules if vuln checks enabled
+	if intent.EnableVulnChecks {
+		for name, factory := range p.moduleRegistry {
+			meta := factory().Metadata()
+			if meta.Type == EvaluationModuleType &&
+				p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
+				selected = append(selected, factory)
+				p.logger.Debug().Str("module", name).Msg("Selected evaluation module for vuln-enabled default profile")
+			}
+		}
+	}
+
+	return selected
+}
+
+// selectModulesByProfile selects modules based on intent profile/level.
+func (p *DAGPlanner) selectModulesByProfile(intent ScanIntent) []ModuleFactory {
+	if intent.DiscoveryOnly {
+		return p.selectDiscoveryModules(intent)
+	}
 	if intent.Profile == "quick_discovery" || intent.Level == "light" {
-		for name, factory := range allModules {
-			meta := factory().Metadata()
-			if meta.Type == DiscoveryModuleType || (containsTag(meta.Tags, "quick") && meta.Type == ScanModuleType) {
-				// Further filter by IncludeTags/ExcludeTags
-				if p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
-					selected = append(selected, factory)
-					p.logger.Debug().Str("module", name).Msg("Selected module for quick_discovery/light profile")
-				}
-			}
-		}
-	} else if intent.Profile == "full_scan" || intent.Level == "comprehensive" {
-		for name, factory := range allModules {
-			meta := factory().Metadata()
-			// Include Discovery, Scan, Parse. Conditionally Evaluation.
-			if meta.Type == DiscoveryModuleType || meta.Type == ScanModuleType || meta.Type == ParseModuleType || meta.Type == ReportingModuleType ||
-				(intent.EnableVulnChecks && meta.Type == EvaluationModuleType) {
-				if p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
-					selected = append(selected, factory)
-					p.logger.Debug().Str("module", name).Msg("Selected module for full_scan/comprehensive profile")
-				}
-			}
-		}
-	} else { // Default: select discovery + scan modules
-		for name, factory := range allModules {
-			meta := factory().Metadata()
-			if (meta.Type == DiscoveryModuleType || meta.Type == ScanModuleType) && !containsTag(meta.Tags, "intrusive") {
-				if p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
-					selected = append(selected, factory)
-					p.logger.Debug().Str("module", name).Msg("Selected module for default profile")
-				}
-			}
-		}
-		if intent.EnableVulnChecks {
-			for name, factory := range allModules {
-				meta := factory().Metadata()
-				if meta.Type == EvaluationModuleType && p.matchesTags(meta.Tags, intent.IncludeTags, intent.ExcludeTags) {
-					selected = append(selected, factory)
-					p.logger.Debug().Str("module", name).Msg("Selected evaluation module for vuln-enabled default profile")
-				}
-			}
-		}
+		return p.selectQuickDiscoveryModules(intent)
 	}
+	if intent.Profile == "full_scan" || intent.Level == "comprehensive" {
+		return p.selectFullScanModules(intent)
+	}
+	return p.selectDefaultModules(intent)
+}
 
-	selected = p.addParseModules(selected, allModules, intent)
+// selectModulesForIntent filters moduleRegistry based on the scan intent.
+func (p *DAGPlanner) selectModulesForIntent(intent ScanIntent) []ModuleFactory {
+	// Select modules based on profile/level
+	selected := p.selectModulesByProfile(intent)
+
+	// Add parse modules
+	selected = p.addParseModules(selected, p.moduleRegistry, intent)
+
+	// Filter host discovery modules if needed
 	if intent.SkipDiscovery {
-		filtered := selected[:0]
-		filteredCount := 0
-		for _, factory := range selected {
-			meta := factory().Metadata()
-			// Only filter host discovery modules (ICMP ping), NOT port scanning modules
-			if meta.Type == DiscoveryModuleType && meta.Name != "tcp-port-discovery" && meta.Name != "udp-port-discovery" {
-				filteredCount++
-				continue
-			}
-			filtered = append(filtered, factory)
-		}
-		selected = filtered
-		if filteredCount > 0 {
-			p.logger.Debug().Int("filtered_modules", filteredCount).Msg("Filtered host discovery modules due to SkipDiscovery")
-		}
+		selected = p.filterHostDiscoveryModules(selected)
 	}
 
+	// Ensure reporter module exists
 	return p.ensureReporter(selected, intent)
 }
 
@@ -344,7 +458,7 @@ func (p *DAGPlanner) configureModule(meta ModuleMetadata, intent ScanIntent) map
 
 	// Apply intent-specific overrides (this part needs more detailed logic)
 	// Example: if intent has specific port or timeout settings, apply them to relevant modules.
-	if meta.Name == "tcp-port-discovery" && intent.CustomPortConfig != "" {
+	if meta.Name == moduleTypeTCPPortDiscovery && intent.CustomPortConfig != "" {
 		// Parse intent.CustomPortConfig and override "ports" in cfg
 		// Example: cfg["ports"] = strings.Split(intent.CustomPortConfig, ",")
 		// For simplicity, assume CustomPortConfig is already []string or parseable
@@ -355,7 +469,7 @@ func (p *DAGPlanner) configureModule(meta ModuleMetadata, intent ScanIntent) map
 		}
 
 	}
-	if (meta.Name == "tcp-port-discovery" || meta.Name == "icmp-ping-discovery") && intent.CustomTimeout != "" {
+	if (meta.Name == moduleTypeTCPPortDiscovery || meta.Name == moduleTypeICMPPingDiscovery) && intent.CustomTimeout != "" {
 		cfg["timeout"] = intent.CustomTimeout // Assuming modules can parse duration string
 		p.logger.Debug().Str("module", meta.Name).Str("timeout", intent.CustomTimeout).Msg("Applied custom timeout config")
 	}

--- a/pkg/engine/planner_test.go
+++ b/pkg/engine/planner_test.go
@@ -131,3 +131,319 @@ func TestPlanner_generateInstanceID_Unique(t *testing.T) {
 		t.Fatalf("expected unique id not equal to existing, got %s", id)
 	}
 }
+
+// Test filterHostDiscoveryModules filters ICMP but preserves port scanners
+func TestPlanner_filterHostDiscoveryModules(t *testing.T) {
+	planner, _ := NewDAGPlanner(nil)
+
+	icmpMeta := ModuleMetadata{Name: "icmp-ping-discovery", Type: DiscoveryModuleType}
+	tcpPortMeta := ModuleMetadata{Name: "tcp-port-discovery", Type: DiscoveryModuleType}
+	udpPortMeta := ModuleMetadata{Name: "udp-port-discovery", Type: DiscoveryModuleType}
+	scanMeta := ModuleMetadata{Name: "banner-grabber", Type: ScanModuleType}
+
+	factories := []ModuleFactory{
+		fakeFactory(icmpMeta),
+		fakeFactory(tcpPortMeta),
+		fakeFactory(udpPortMeta),
+		fakeFactory(scanMeta),
+	}
+
+	filtered := planner.filterHostDiscoveryModules(factories)
+
+	// Should have 3 modules: tcp-port-discovery, udp-port-discovery, banner-grabber
+	// ICMP should be filtered out
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 modules after filtering, got %d", len(filtered))
+	}
+
+	hasICMP, hasTCPPort, hasUDPPort, hasScan := false, false, false, false
+	for _, factory := range filtered {
+		meta := factory().Metadata()
+		switch meta.Name {
+		case "icmp-ping-discovery":
+			hasICMP = true
+		case "tcp-port-discovery":
+			hasTCPPort = true
+		case "udp-port-discovery":
+			hasUDPPort = true
+		case "banner-grabber":
+			hasScan = true
+		}
+	}
+
+	if hasICMP {
+		t.Fatal("ICMP ping should be filtered out")
+	}
+	if !hasTCPPort {
+		t.Fatal("TCP port discovery should be preserved")
+	}
+	if !hasUDPPort {
+		t.Fatal("UDP port discovery should be preserved")
+	}
+	if !hasScan {
+		t.Fatal("Scanner module should be preserved")
+	}
+}
+
+// Test selectModulesByProfile with SkipDiscovery
+func TestPlanner_selectModulesByProfile_SkipDiscovery(t *testing.T) {
+	icmpMeta := ModuleMetadata{Name: "icmp-ping-discovery", Type: DiscoveryModuleType}
+	tcpPortMeta := ModuleMetadata{Name: "tcp-port-discovery", Type: DiscoveryModuleType}
+	scanMeta := ModuleMetadata{Name: "banner-grabber", Type: ScanModuleType}
+	parseMeta := ModuleMetadata{Name: "http-parser", Type: ParseModuleType}
+
+	registry := map[string]ModuleFactory{
+		icmpMeta.Name:    fakeFactory(icmpMeta),
+		tcpPortMeta.Name: fakeFactory(tcpPortMeta),
+		scanMeta.Name:    fakeFactory(scanMeta),
+		parseMeta.Name:   fakeFactory(parseMeta),
+	}
+
+	planner, _ := NewDAGPlanner(registry)
+
+	// Test with SkipDiscovery=false (normal)
+	intent := ScanIntent{Targets: []string{"127.0.0.1"}, SkipDiscovery: false}
+	selected := planner.selectModulesForIntent(intent)
+
+	// Should include tcp-port-discovery and parse modules
+	hasTCPPort := false
+	for _, factory := range selected {
+		if factory().Metadata().Name == "tcp-port-discovery" {
+			hasTCPPort = true
+			break
+		}
+	}
+	if !hasTCPPort {
+		t.Fatal("expected tcp-port-discovery when SkipDiscovery=false")
+	}
+
+	// Test with SkipDiscovery=true
+	intentSkip := ScanIntent{Targets: []string{"127.0.0.1"}, SkipDiscovery: true}
+	selectedSkip := planner.selectModulesForIntent(intentSkip)
+
+	// Should still include tcp-port-discovery (port scanner, not host discovery)
+	hasTCPPortSkip := false
+	hasICMP := false
+	for _, factory := range selectedSkip {
+		meta := factory().Metadata()
+		if meta.Name == "tcp-port-discovery" {
+			hasTCPPortSkip = true
+		}
+		if meta.Name == "icmp-ping-discovery" {
+			hasICMP = true
+		}
+	}
+
+	if !hasTCPPortSkip {
+		t.Fatal("tcp-port-discovery should be preserved with SkipDiscovery=true")
+	}
+	if hasICMP {
+		t.Fatal("ICMP should be filtered out with SkipDiscovery=true")
+	}
+}
+
+// Test initializeDataKeys injects discovery.live_hosts when SkipDiscovery=true
+func TestPlanner_initializeDataKeys_SkipDiscovery(t *testing.T) {
+	planner, _ := NewDAGPlanner(nil)
+
+	// Without SkipDiscovery
+	intent := ScanIntent{Targets: []string{"127.0.0.1"}, SkipDiscovery: false}
+	keys := planner.initializeDataKeys(intent)
+
+	if _, found := keys["config.targets"]; !found {
+		t.Fatal("expected config.targets to be initialized")
+	}
+	if _, found := keys["discovery.live_hosts"]; found {
+		t.Fatal("discovery.live_hosts should NOT be initialized when SkipDiscovery=false")
+	}
+
+	// With SkipDiscovery
+	intentSkip := ScanIntent{Targets: []string{"127.0.0.1"}, SkipDiscovery: true}
+	keysSkip := planner.initializeDataKeys(intentSkip)
+
+	if _, found := keysSkip["config.targets"]; !found {
+		t.Fatal("expected config.targets to be initialized")
+	}
+	if _, found := keysSkip["discovery.live_hosts"]; !found {
+		t.Fatal("discovery.live_hosts should be initialized when SkipDiscovery=true")
+	}
+}
+
+// Test different profiles select correct modules
+func TestPlanner_selectModulesByProfile_Profiles(t *testing.T) {
+	discoveryMeta := ModuleMetadata{Name: "icmp-ping", Type: DiscoveryModuleType}
+	scanMeta := ModuleMetadata{Name: "scanner", Type: ScanModuleType, Tags: []string{"quick"}}
+	evalMeta := ModuleMetadata{Name: "evaluator", Type: EvaluationModuleType}
+
+	registry := map[string]ModuleFactory{
+		discoveryMeta.Name: fakeFactory(discoveryMeta),
+		scanMeta.Name:      fakeFactory(scanMeta),
+		evalMeta.Name:      fakeFactory(evalMeta),
+	}
+
+	planner, _ := NewDAGPlanner(registry)
+
+	// Test DiscoveryOnly
+	intentDiscovery := ScanIntent{DiscoveryOnly: true}
+	selected := planner.selectModulesByProfile(intentDiscovery)
+	hasDiscovery := false
+	for _, factory := range selected {
+		if factory().Metadata().Type == DiscoveryModuleType {
+			hasDiscovery = true
+		}
+	}
+	if !hasDiscovery {
+		t.Fatal("DiscoveryOnly should select discovery modules")
+	}
+
+	// Test quick_discovery profile
+	intentQuick := ScanIntent{Profile: "quick_discovery"}
+	selectedQuick := planner.selectModulesByProfile(intentQuick)
+	if len(selectedQuick) == 0 {
+		t.Fatal("quick_discovery should select modules")
+	}
+
+	// Test full_scan with EnableVulnChecks
+	intentFull := ScanIntent{Profile: "full_scan", EnableVulnChecks: true}
+	selectedFull := planner.selectModulesByProfile(intentFull)
+	hasEval := false
+	for _, factory := range selectedFull {
+		if factory().Metadata().Type == EvaluationModuleType {
+			hasEval = true
+		}
+	}
+	if !hasEval {
+		t.Fatal("full_scan with EnableVulnChecks should include evaluation modules")
+	}
+}
+
+// Test matchesTags covers all scenarios
+func TestPlanner_matchesTags(t *testing.T) {
+	planner, _ := NewDAGPlanner(nil)
+
+	tests := []struct {
+		name        string
+		moduleTags  []string
+		includeTags []string
+		excludeTags []string
+		want        bool
+	}{
+		{
+			name:        "no filters - should match",
+			moduleTags:  []string{"tag1", "tag2"},
+			includeTags: nil,
+			excludeTags: nil,
+			want:        true,
+		},
+		{
+			name:        "exclude tag present - should not match",
+			moduleTags:  []string{"tag1", "intrusive"},
+			includeTags: nil,
+			excludeTags: []string{"intrusive"},
+			want:        false,
+		},
+		{
+			name:        "exclude tag not present - should match",
+			moduleTags:  []string{"tag1", "tag2"},
+			includeTags: nil,
+			excludeTags: []string{"intrusive"},
+			want:        true,
+		},
+		{
+			name:        "include tag present - should match",
+			moduleTags:  []string{"tag1", "quick"},
+			includeTags: []string{"quick"},
+			excludeTags: nil,
+			want:        true,
+		},
+		{
+			name:        "include tag not present - should not match",
+			moduleTags:  []string{"tag1", "tag2"},
+			includeTags: []string{"quick"},
+			excludeTags: nil,
+			want:        false,
+		},
+		{
+			name:        "both include and exclude, include present - should match",
+			moduleTags:  []string{"tag1", "quick"},
+			includeTags: []string{"quick"},
+			excludeTags: []string{"intrusive"},
+			want:        true,
+		},
+		{
+			name:        "both include and exclude, exclude present - should not match",
+			moduleTags:  []string{"tag1", "quick", "intrusive"},
+			includeTags: []string{"quick"},
+			excludeTags: []string{"intrusive"},
+			want:        false,
+		},
+		{
+			name:        "multiple include tags, one matches - should match",
+			moduleTags:  []string{"tag1", "quick"},
+			includeTags: []string{"fast", "quick", "speed"},
+			excludeTags: nil,
+			want:        true,
+		},
+		{
+			name:        "multiple exclude tags, one matches - should not match",
+			moduleTags:  []string{"tag1", "slow"},
+			includeTags: nil,
+			excludeTags: []string{"intrusive", "slow", "heavy"},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planner.matchesTags(tt.moduleTags, tt.includeTags, tt.excludeTags)
+			if got != tt.want {
+				t.Errorf("matchesTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test logUnprocessedModules logs unprocessed modules with unmet dependencies
+func TestPlanner_logUnprocessedModules(t *testing.T) {
+	planner, _ := NewDAGPlanner(nil)
+
+	// Create modules with dependencies
+	module1Meta := ModuleMetadata{
+		Name: "module1",
+		Consumes: []DataContractEntry{
+			{Key: "missing.key1"},
+			{Key: "missing.key2"},
+		},
+	}
+	module2Meta := ModuleMetadata{
+		Name: "module2",
+		Consumes: []DataContractEntry{
+			{Key: "available.key"},
+		},
+	}
+
+	candidateModules := []ModuleFactory{
+		fakeFactory(module1Meta),
+		fakeFactory(module2Meta),
+	}
+
+	// Only module2 was added (module1 has unmet dependencies)
+	moduleTypesAddedToDAG := map[string]bool{
+		"module2": true,
+	}
+
+	availableDataKeys := map[string]string{
+		"available.key": "some_module",
+	}
+
+	// This should log module1 with unmet dependencies (missing.key1, missing.key2)
+	// Test passes if no panic occurs (function is mainly for logging)
+	planner.logUnprocessedModules(candidateModules, moduleTypesAddedToDAG, availableDataKeys)
+
+	// Test case where all modules were added (no logging)
+	allAddedModules := map[string]bool{
+		"module1": true,
+		"module2": true,
+	}
+	planner.logUnprocessedModules(candidateModules, allAddedModules, availableDataKeys)
+}


### PR DESCRIPTION
## Summary

Fixes the broken `--no-discover` flag that was producing 0 results. The flag existed but had two bugs:
1. Overly aggressive module filtering removed port scanners
2. Missing data key injection for live hosts

## Problem

The `--no-discover` flag was completely broken:
- **Before**: `--no-discover` produced 0 open ports, 0 results
- **Root cause**: Filter removed ALL discovery modules including `tcp-port-discovery` (port scanner)
- **Impact**: Banner grabber couldn't run (depends on `discovery.open_tcp_ports` from port scanner)

## Solution

Two-part fix:

### 1. Inject `discovery.live_hosts` as Initial Data Key
When `SkipDiscovery=true`, inject `discovery.live_hosts` into initial available data keys. This treats all targets as live hosts without ICMP ping.

**File**: [pkg/engine/planner.go:66-70](https://github.com/pentora-ai/pentora/blob/0a6d3cf226c86c35ca829aa1aed2d0fbce467dfa/pkg/engine/planner.go#L66-L70)

### 2. Fix Module Filter to Preserve Port Scanners
Only filter HOST discovery modules (ICMP ping), NOT port scanning modules (`tcp-port-discovery`, `udp-port-discovery`).

**File**: [pkg/engine/planner.go:248-260](https://github.com/pentora-ai/pentora/blob/0a6d3cf226c86c35ca829aa1aed2d0fbce467dfa/pkg/engine/planner.go#L248-L260)

## Test Results

### IP Address Scan (45.33.32.156 port 80)
```bash
# Normal scan (with ICMP ping)
$ time go run ./cmd scan 45.33.32.156 --ports 80
Duration: 4.0s, Open Ports: 1
Real time: 3.6s

# With --no-discover (skip ICMP ping)
$ time go run ./cmd scan 45.33.32.156 --ports 80 --no-discover
Duration: 2.0s, Open Ports: 1
Real time: 2.0s
```

**Result**: ✅ **1.8x faster** (3.6s → 2.0s)

### Localhost Scan
```bash
$ go run ./cmd scan 127.0.0.1 --ports 7265 --no-discover
Open Ports: 1  ✅
```

### Domain Name Performance Note
`--no-discover` is slower for domains (e.g., `scanme.nmap.org`) due to repeated DNS resolution per port. Best used with:
- IP addresses
- Localhost testing
- Known live hosts
- CI/CD environments

## Testing

- ✅ `make test` passed (all unit tests)
- ✅ Real scan tests with IP addresses (1.8x speedup verified)
- ✅ Localhost scan tests (working correctly)
- ✅ Remote host scan tests (working correctly)
- ✅ Flag conflict validation (`--only-discover` + `--no-discover` → error)

## Breaking Changes

None. This fixes existing broken functionality.

## Related

- Fixes #110
- Implements requested `--skip-discovery` feature (as `--no-discover` for consistency with `--only-discover`)

---

**Performance Impact**: 1.8x faster scans for IP addresses when discovery is skipped.

**Development Workflow**: Significantly faster iteration for testing/debugging known hosts.