### PR TITLE
fix(server,cli): add JSON error code/suggestion; warn on PluginService type mismatch

### DIFF
--- a/cmd/pentora/internal/format/format.go
+++ b/cmd/pentora/internal/format/format.go
@@ -12,6 +12,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/fatih/color"
+
+	"github.com/pentora-ai/pentora/pkg/plugin"
 )
 
 // OutputMode defines the output format for CLI commands
@@ -154,8 +156,10 @@ func (f *formatter) PrintError(err error) error {
 	if f.mode == ModeJSON {
 		// JSON mode: error object to stdout (machine-readable)
 		return f.PrintJSON(map[string]any{
-			"success": false,
-			"error":   err.Error(),
+			"success":    false,
+			"error":      err.Error(),
+			"code":       plugin.ErrorCode(err),
+			"suggestion": plugin.GetSuggestion(err),
 		})
 	}
 


### PR DESCRIPTION
Summary
- Scope: Issue #90 — API/CLI error handling improvements
- Impact: Machine-readable errors in CLI and better router observability
- Risk: Low; additive fields and logs only (no behavior change)

CLI (JSON error output)
- In JSON mode, the error payload now includes `code` and `suggestion` in addition to existing `success:false` and `error` fields
- `code`: produced via `plugin.ErrorCode(err)`
- `suggestion`: produced via `plugin.GetSuggestion(err)`
- Backward compatible: existing fields are preserved; schema is extended

Server/Router (observability)
- When mounting plugin routes:
  - Correct type → info: "mounting plugin API routes"
  - Wrong type → warn: "PluginService type assertion failed … NOT mounted" + `actual_type`
  - Nil service → info: "PluginService not provided – skipping plugin API routes"

Tests
- CLI: Added/updated tests to assert presence and correctness of `code` and `suggestion` across representative errors (NotFound, InvalidInput, Unavailable)
- Router: Added tests for nil/wrong/correct PluginService types; assert route behavior and corresponding log messages

Validation
- `make test && make validate` pass locally

Closes
- Resolves #90