### PR TITLE
feat(cli): add suggestion-driven errors to core commands

### DIFF
--- a/cmd/pentora/commands/dag/export_test.go
+++ b/cmd/pentora/commands/dag/export_test.go
@@ -5,6 +5,7 @@
 package dag
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -181,18 +182,20 @@ func TestExportCommand_NoDiscover(t *testing.T) {
 }
 
 func TestExportCommand_InvalidFormat(t *testing.T) {
-	opts := bind.DAGExportOptions{
-		Output:     "",
-		Format:     "xml", // Invalid format
-		Targets:    "192.168.1.1",
-		Ports:      "80",
-		Vuln:       false,
-		NoDiscover: false,
-	}
+	cmd := newExportCommand()
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
 
-	err := runExport(opts)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported format")
+	cmd.SetArgs([]string{"--format", "xml"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	require.Contains(t, output, "✗ Failed to export DAG")
+	require.Contains(t, output, "Use --format yaml or --format json")
 }
 
 func TestExportCommand_InvalidOutputPath(t *testing.T) {

--- a/cmd/pentora/commands/dag/validate_test.go
+++ b/cmd/pentora/commands/dag/validate_test.go
@@ -5,6 +5,7 @@
 package dag
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -160,6 +161,24 @@ nodes:
 	err = runValidate(dagFile, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load DAG")
+}
+
+func TestValidateCommand_MissingFileSuggestions(t *testing.T) {
+	cmd := newValidateCommand()
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	cmd.SetArgs([]string{"/nonexistent/file.yaml"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	require.Contains(t, output, "✗ Failed to validate DAG")
+	require.Contains(t, output, "Verify the DAG file path exists")
+	require.Contains(t, output, "Ensure the file is valid YAML or JSON")
 }
 
 func TestValidateCommand_JSONFormat(t *testing.T) {

--- a/cmd/pentora/commands/fingerprint_test.go
+++ b/cmd/pentora/commands/fingerprint_test.go
@@ -1,26 +1,26 @@
 package commands
 
 import (
-	"context"
-	"os"
-	"path/filepath"
+	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestFingerprintSyncCommandFromFile(t *testing.T) {
-	cmd := newFingerprintSyncCommand()
-	tempDir := t.TempDir()
-	catalogPath := filepath.Join("..", "..", "..", "pkg", "fingerprint", "data", "probes.yaml")
+func TestFingerprintSyncCommand_SourceRequiredSuggestions(t *testing.T) {
+	cmd := NewFingerprintCommand()
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
 
-	cmd.SetArgs([]string{"--file", catalogPath, "--cache-dir", tempDir})
-	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"sync"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("sync command failed: %v", err)
-	}
+	err := cmd.Execute()
+	require.NoError(t, err)
 
-	cached := filepath.Join(tempDir, "probe.catalog.yaml")
-	if _, err := os.Stat(cached); err != nil {
-		t.Fatalf("expected cached catalog at %s: %v", cached, err)
-	}
+	output := out.String()
+	require.Contains(t, output, "✗ Failed to sync fingerprint catalog")
+	require.Contains(t, output, "--file <path> or --url <address>")
+	require.Contains(t, output, "pentora fingerprint sync --url")
 }

--- a/cmd/pentora/commands/server/start_test.go
+++ b/cmd/pentora/commands/server/start_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartCommand_InvalidPortShowsSuggestions(t *testing.T) {
+	cmd := newStartServerCommand()
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	cmd.SetArgs([]string{"--port", "0"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := out.String()
+	require.Contains(t, output, "✗ Failed to start server")
+	require.Contains(t, output, "Use a port between 1 and 65535")
+	require.Contains(t, output, "pentora server start --port 8080")
+}

--- a/cmd/pentora/internal/bind/fingerprint.go
+++ b/cmd/pentora/internal/bind/fingerprint.go
@@ -2,6 +2,8 @@ package bind
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/pentora-ai/pentora/pkg/fingerprint"
 )
 
 // FingerprintOptions holds configuration options for the fingerprint command.
@@ -31,6 +33,14 @@ func BindFingerprintOptions(cmd *cobra.Command) (FingerprintOptions, error) {
 		FilePath: filePath,
 		URL:      url,
 		CacheDir: cacheDir,
+	}
+
+	if filePath == "" && url == "" {
+		return opts, fingerprint.NewSourceRequiredError()
+	}
+
+	if filePath != "" && url != "" {
+		return opts, fingerprint.NewSourceConflictError()
 	}
 
 	return opts, nil

--- a/cmd/pentora/internal/bind/fingerprint_test.go
+++ b/cmd/pentora/internal/bind/fingerprint_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pentora-ai/pentora/pkg/fingerprint"
 )
 
 func TestBindFingerprintOptions(t *testing.T) {
@@ -21,12 +23,7 @@ func TestBindFingerprintOptions(t *testing.T) {
 				"url":       "https://example.com/catalog",
 				"cache-dir": "/custom/cache",
 			},
-			want: FingerprintOptions{
-				FilePath: "/path/to/catalog.yaml",
-				URL:      "https://example.com/catalog",
-				CacheDir: "/custom/cache",
-			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "only file set",
@@ -63,12 +60,7 @@ func TestBindFingerprintOptions(t *testing.T) {
 				"url":       "",
 				"cache-dir": "",
 			},
-			want: FingerprintOptions{
-				FilePath: "",
-				URL:      "",
-				CacheDir: "",
-			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 
@@ -79,6 +71,12 @@ func TestBindFingerprintOptions(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				switch tt.name {
+				case "all flags set":
+					require.ErrorIs(t, err, fingerprint.ErrSourceConflict)
+				case "defaults (all empty)":
+					require.ErrorIs(t, err, fingerprint.ErrSourceRequired)
+				}
 				return
 			}
 

--- a/cmd/pentora/internal/bind/scan.go
+++ b/cmd/pentora/internal/bind/scan.go
@@ -1,8 +1,6 @@
 package bind
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pentora-ai/pentora/pkg/scanexec"
@@ -52,7 +50,7 @@ func BindScanOptions(cmd *cobra.Command, targets []string) (scanexec.Params, err
 
 	// Validate conflicting flags
 	if onlyDiscover && skipDiscover {
-		return scanexec.Params{}, fmt.Errorf("cannot use --only-discover and --no-discover together")
+		return scanexec.Params{}, scanexec.ErrConflictingDiscoveryFlags
 	}
 
 	// If only-discover is set, disable vuln automatically

--- a/cmd/pentora/internal/bind/scan_test.go
+++ b/cmd/pentora/internal/bind/scan_test.go
@@ -253,6 +253,7 @@ func TestBindScanOptions(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				require.ErrorIs(t, err, scanexec.ErrConflictingDiscoveryFlags)
 				if tt.errMsg != "" {
 					require.Contains(t, err.Error(), tt.errMsg)
 				}

--- a/cmd/pentora/internal/bind/server.go
+++ b/cmd/pentora/internal/bind/server.go
@@ -1,9 +1,9 @@
 package bind
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+
+	srv "github.com/pentora-ai/pentora/pkg/server"
 )
 
 // ServerOptions holds configuration options for the server start command.
@@ -40,17 +40,17 @@ func BindServerOptions(cmd *cobra.Command) (ServerOptions, error) {
 
 	// Validate port range
 	if port < 1 || port > 65535 {
-		return ServerOptions{}, fmt.Errorf("invalid port %d: must be between 1 and 65535", port)
+		return ServerOptions{}, srv.NewInvalidPortError(port)
 	}
 
 	// Validate concurrency
 	if concurrency < 1 {
-		return ServerOptions{}, fmt.Errorf("invalid concurrency %d: must be at least 1", concurrency)
+		return ServerOptions{}, srv.NewInvalidConcurrencyError(concurrency)
 	}
 
 	// Validate that at least UI or API is enabled
 	if noUI && noAPI {
-		return ServerOptions{}, fmt.Errorf("cannot disable both UI and API: at least one must be enabled")
+		return ServerOptions{}, srv.NewFeaturesDisabledError()
 	}
 
 	opts := ServerOptions{

--- a/cmd/pentora/internal/bind/server_test.go
+++ b/cmd/pentora/internal/bind/server_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	srv "github.com/pentora-ai/pentora/pkg/server"
 )
 
 func TestBindServerOptions(t *testing.T) {
@@ -163,6 +165,15 @@ func TestBindServerOptions(t *testing.T) {
 				require.Error(t, err)
 				if tt.errMsg != "" {
 					require.Contains(t, err.Error(), tt.errMsg)
+				}
+
+				switch tt.name {
+				case "invalid port - too low", "invalid port - too high":
+					require.ErrorIs(t, err, srv.ErrInvalidPort)
+				case "invalid concurrency":
+					require.ErrorIs(t, err, srv.ErrInvalidConcurrency)
+				case "both UI and API disabled":
+					require.ErrorIs(t, err, srv.ErrFeaturesDisabled)
 				}
 				return
 			}

--- a/cmd/pentora/internal/format/cobra.go
+++ b/cmd/pentora/internal/format/cobra.go
@@ -1,0 +1,43 @@
+package format
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+// FromCommand builds a Formatter using cobra command output/error writers and common flags.
+func FromCommand(cmd *cobra.Command) Formatter {
+	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
+
+	outputMode := ModeTable
+	if flag := cmd.Flags().Lookup("output"); flag != nil {
+		outputMode = ParseMode(flag.Value.String())
+	}
+
+	quiet := false
+	if flag := cmd.Flags().Lookup("quiet"); flag != nil {
+		if val, err := strconv.ParseBool(flag.Value.String()); err == nil {
+			quiet = val
+		}
+	}
+
+	color := true
+	if flag := cmd.Flags().Lookup("no-color"); flag != nil {
+		if val, err := strconv.ParseBool(flag.Value.String()); err == nil && val {
+			color = false
+		}
+	}
+
+	// Cobra defaults to stderr being nil in some paths; ensure we have a fallback.
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	return New(stdout, stderr, outputMode, quiet, color)
+}

--- a/cmd/pentora/internal/format/cobra_test.go
+++ b/cmd/pentora/internal/format/cobra_test.go
@@ -1,0 +1,31 @@
+package format
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromCommandRespectsFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("output", "table", "")
+	cmd.Flags().Bool("quiet", false, "")
+	cmd.Flags().Bool("no-color", false, "")
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	require.NoError(t, cmd.Flags().Set("output", "json"))
+	require.NoError(t, cmd.Flags().Set("quiet", "true"))
+	require.NoError(t, cmd.Flags().Set("no-color", "true"))
+
+	formatter := FromCommand(cmd)
+	require.True(t, formatter.IsJSON())
+
+	require.NoError(t, formatter.PrintSummary("should be suppressed"))
+	require.Equal(t, "", out.String())
+}

--- a/cmd/pentora/internal/format/format_test.go
+++ b/cmd/pentora/internal/format/format_test.go
@@ -364,6 +364,20 @@ func TestParseMode(t *testing.T) {
 	}
 }
 
+func TestGetSuggestionsNewCodes(t *testing.T) {
+	t.Run("invalid target", func(t *testing.T) {
+		suggestions := GetSuggestions("INVALID_TARGET", "scan")
+		require.NotEmpty(t, suggestions)
+		require.Contains(t, suggestions[0], "pentora scan")
+	})
+
+	t.Run("no retention policy", func(t *testing.T) {
+		suggestions := GetSuggestions("NO_RETENTION_POLICY", "garbage collection")
+		require.NotEmpty(t, suggestions)
+		require.Contains(t, suggestions[0], "pentora storage gc")
+	})
+}
+
 func TestPrintTableColorSupport(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	f := New(&stdout, &stderr, ModeTable, false, true) // color enabled

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -1,0 +1,189 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	errorCodeLoadFailed        = "DAG_LOAD_FAILED"
+	errorCodeUnsupportedFormat = "DAG_UNSUPPORTED_FORMAT"
+	errorCodeMarshalFailed     = "DAG_MARSHAL_FAILED"
+	errorCodeWriteFailed       = "DAG_WRITE_FAILED"
+	errorCodeInvalidDAG        = "DAG_INVALID"
+)
+
+var (
+	// ErrLoadFailed indicates the DAG definition could not be loaded.
+	ErrLoadFailed = errors.New("dag load failed")
+
+	// ErrUnsupportedFormat indicates an unsupported export format.
+	ErrUnsupportedFormat = errors.New("unsupported dag export format")
+
+	// ErrWriteFailed indicates a write to disk failed.
+	ErrWriteFailed = errors.New("dag write failed")
+
+	// ErrInvalidDAG indicates the generated DAG did not pass validation.
+	ErrInvalidDAG = errors.New("dag invalid")
+)
+
+type errorCoder interface {
+	error
+	Code() string
+}
+
+type withCodeError struct {
+	error
+	code string
+}
+
+func (e *withCodeError) Code() string {
+	return e.code
+}
+
+func (e *withCodeError) Unwrap() error {
+	return e.error
+}
+
+// WithErrorCode annotates err with a DAG error code.
+func WithErrorCode(err error, code string) error {
+	if err == nil {
+		return nil
+	}
+	return &withCodeError{error: err, code: code}
+}
+
+// WrapLoadError annotates a DAG load failure.
+func WrapLoadError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(fmt.Errorf("%w: failed to load DAG: %w", ErrLoadFailed, err), errorCodeLoadFailed)
+}
+
+// NewUnsupportedFormatError formats an unsupported export format error.
+func NewUnsupportedFormatError(format string) error {
+	return WithErrorCode(fmt.Errorf("%w: unsupported format: %s (use yaml or json)", ErrUnsupportedFormat, format), errorCodeUnsupportedFormat)
+}
+
+// WrapMarshalError annotates marshal errors.
+func WrapMarshalError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(fmt.Errorf("failed to marshal DAG: %w", err), errorCodeMarshalFailed)
+}
+
+// WrapWriteError annotates output write failures.
+func WrapWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(fmt.Errorf("%w: failed to write output file: %w", ErrWriteFailed, err), errorCodeWriteFailed)
+}
+
+// WrapInvalidDAG annotates invalid generated DAG errors.
+func WrapInvalidDAG(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(fmt.Errorf("%w: %v", ErrInvalidDAG, err), errorCodeInvalidDAG)
+}
+
+// ErrorCode resolves an error to its DAG error code.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var coded errorCoder
+	if errors.As(err, &coded) {
+		if code := coded.Code(); code != "" {
+			return code
+		}
+	}
+
+	switch {
+	case errors.Is(err, ErrLoadFailed):
+		return errorCodeLoadFailed
+	case errors.Is(err, ErrUnsupportedFormat):
+		return errorCodeUnsupportedFormat
+	case errors.Is(err, ErrWriteFailed):
+		return errorCodeWriteFailed
+	case errors.Is(err, ErrInvalidDAG):
+		return errorCodeInvalidDAG
+	default:
+		return errorCodeMarshalFailed
+	}
+}
+
+// ExitCode maps errors to CLI exit codes.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	switch {
+	case errors.Is(err, ErrUnsupportedFormat):
+		return 2
+	case errors.Is(err, ErrLoadFailed):
+		return 4
+	case errors.Is(err, ErrWriteFailed):
+		return 1
+	case errors.Is(err, ErrInvalidDAG):
+		return 2
+	default:
+		return 1
+	}
+}
+
+// HTTPStatus maps errors to HTTP status codes (future-proof for API usage).
+func HTTPStatus(err error) int {
+	if err == nil {
+		return 200
+	}
+
+	switch {
+	case errors.Is(err, ErrUnsupportedFormat),
+		errors.Is(err, ErrInvalidDAG):
+		return 400
+	case errors.Is(err, ErrLoadFailed):
+		return 404
+	case errors.Is(err, ErrWriteFailed):
+		return 500
+	default:
+		return 500
+	}
+}
+
+// Suggestions provides human readable guidance for CLI usage.
+func Suggestions(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	code := ErrorCode(err)
+	switch code {
+	case errorCodeLoadFailed:
+		return []string{
+			"Verify the DAG file path exists",
+			"Ensure the file is valid YAML or JSON",
+		}
+	case errorCodeUnsupportedFormat:
+		return []string{
+			"Use --format yaml or --format json",
+		}
+	case errorCodeWriteFailed:
+		return []string{
+			"Ensure destination path is writable",
+			"Retry without --output to print to stdout",
+		}
+	case errorCodeInvalidDAG:
+		return []string{
+			"Run pentora dag validate on the export output",
+			"Fix reported validation errors before exporting again",
+		}
+	default:
+		return nil
+	}
+}

--- a/pkg/engine/errors_test.go
+++ b/pkg/engine/errors_test.go
@@ -1,0 +1,179 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEngineError_WithErrorCodeAndUnwrap(t *testing.T) {
+	if WithErrorCode(nil, "X") != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	base := errors.New("base")
+	wrapped := WithErrorCode(base, "CODE123")
+	if wrapped.(*withCodeError).Code() != "CODE123" {
+		t.Errorf("expected CODE123")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Errorf("unwrap mismatch")
+	}
+}
+
+func TestEngineError_WrapLoadError(t *testing.T) {
+	if WrapLoadError(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	base := errors.New("loadfail")
+	err := WrapLoadError(base)
+	if !errors.Is(err, ErrLoadFailed) {
+		t.Errorf("expected ErrLoadFailed")
+	}
+	if ErrorCode(err) != errorCodeLoadFailed {
+		t.Errorf("expected load failed code")
+	}
+}
+
+func TestEngineError_NewUnsupportedFormatError(t *testing.T) {
+	err := NewUnsupportedFormatError("xml")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Errorf("expected unsupported format error")
+	}
+	if ErrorCode(err) != errorCodeUnsupportedFormat {
+		t.Errorf("expected unsupported format code")
+	}
+}
+
+func TestEngineError_WrapMarshalError(t *testing.T) {
+	if WrapMarshalError(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	e := errors.New("marshal")
+	err := WrapMarshalError(e)
+	if !errors.Is(err, e) {
+		t.Errorf("expected unwrap to original error")
+	}
+	if ErrorCode(err) != errorCodeMarshalFailed {
+		t.Errorf("expected marshal failed code")
+	}
+}
+
+func TestEngineError_WrapWriteError(t *testing.T) {
+	if WrapWriteError(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	e := errors.New("write")
+	err := WrapWriteError(e)
+	if !errors.Is(err, ErrWriteFailed) {
+		t.Errorf("expected ErrWriteFailed")
+	}
+	if ErrorCode(err) != errorCodeWriteFailed {
+		t.Errorf("expected write failed code")
+	}
+}
+
+func TestEngineError_WrapInvalidDAG(t *testing.T) {
+	if WrapInvalidDAG(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	e := errors.New("invalid")
+	err := WrapInvalidDAG(e)
+	if !errors.Is(err, ErrInvalidDAG) {
+		t.Errorf("expected ErrInvalidDAG")
+	}
+	if ErrorCode(err) != errorCodeInvalidDAG {
+		t.Errorf("expected invalid dag code")
+	}
+}
+
+func TestEngineError_ErrorCodeBranches(t *testing.T) {
+	if ErrorCode(nil) != "" {
+		t.Errorf("expected empty for nil")
+	}
+
+	coded := WithErrorCode(errors.New("x"), "CUSTOM")
+	if ErrorCode(coded) != "CUSTOM" {
+		t.Errorf("expected CUSTOM")
+	}
+
+	if ErrorCode(ErrLoadFailed) != errorCodeLoadFailed {
+		t.Errorf("expected load failed code")
+	}
+	if ErrorCode(ErrUnsupportedFormat) != errorCodeUnsupportedFormat {
+		t.Errorf("expected unsupported format code")
+	}
+	if ErrorCode(ErrWriteFailed) != errorCodeWriteFailed {
+		t.Errorf("expected write failed code")
+	}
+	if ErrorCode(ErrInvalidDAG) != errorCodeInvalidDAG {
+		t.Errorf("expected invalid dag code")
+	}
+	if ErrorCode(errors.New("other")) != errorCodeMarshalFailed {
+		t.Errorf("expected marshal failed default code")
+	}
+}
+
+func TestEngineError_ExitCode(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 0},
+		{ErrUnsupportedFormat, 2},
+		{ErrLoadFailed, 4},
+		{ErrWriteFailed, 1},
+		{ErrInvalidDAG, 2},
+		{errors.New("unknown"), 1}, // default branch
+	}
+	for _, tt := range tests {
+		got := ExitCode(tt.err)
+		if got != tt.expected {
+			t.Errorf("ExitCode(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestEngineError_HTTPStatus(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 200},
+		{ErrUnsupportedFormat, 400},
+		{ErrInvalidDAG, 400},
+		{ErrLoadFailed, 404},
+		{ErrWriteFailed, 500},
+		{errors.New("other"), 500}, // default branch
+	}
+	for _, tt := range tests {
+		got := HTTPStatus(tt.err)
+		if got != tt.expected {
+			t.Errorf("HTTPStatus(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestEngineError_Suggestions(t *testing.T) {
+	tests := []struct {
+		code string
+		want bool
+	}{
+		{errorCodeLoadFailed, true},
+		{errorCodeUnsupportedFormat, true},
+		{errorCodeWriteFailed, true},
+		{errorCodeInvalidDAG, true},
+		{"UNKNOWN_CODE", false},
+	}
+	for _, tt := range tests {
+		err := WithErrorCode(errors.New("x"), tt.code)
+		sugs := Suggestions(err)
+		if tt.want && len(sugs) == 0 {
+			t.Errorf("expected suggestions for %v", tt.code)
+		}
+		if !tt.want && sugs != nil {
+			t.Errorf("expected nil for %v", tt.code)
+		}
+	}
+	if Suggestions(nil) != nil {
+		t.Errorf("expected nil for nil err")
+	}
+}

--- a/pkg/fingerprint/errors.go
+++ b/pkg/fingerprint/errors.go
@@ -1,0 +1,162 @@
+package fingerprint
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	errorCodeSourceRequired  = "FINGERPRINT_SOURCE_REQUIRED"
+	errorCodeSourceConflict  = "FINGERPRINT_SOURCE_CONFLICT"
+	errorCodeStorageDisabled = "FINGERPRINT_STORAGE_DISABLED"
+	errorCodeSyncFailed      = "FINGERPRINT_SYNC_FAILED"
+)
+
+var (
+	// ErrSourceRequired indicates neither --file nor --url was provided.
+	ErrSourceRequired = errors.New("source required")
+	// ErrSourceConflict indicates both --file and --url were provided.
+	ErrSourceConflict = errors.New("multiple sources provided")
+	// ErrStorageDisabled indicates the CLI context lacks storage configuration.
+	ErrStorageDisabled = errors.New("storage disabled")
+)
+
+type errorCoder interface {
+	error
+	Code() string
+}
+
+type withCodeError struct {
+	error
+	code string
+}
+
+func (e *withCodeError) Code() string {
+	return e.code
+}
+
+func (e *withCodeError) Unwrap() error {
+	return e.error
+}
+
+// WithErrorCode annotates err with a fingerprint error code.
+func WithErrorCode(err error, code string) error {
+	if err == nil {
+		return nil
+	}
+	return &withCodeError{error: err, code: code}
+}
+
+// NewSourceRequiredError formats a missing source error.
+func NewSourceRequiredError() error {
+	return WithErrorCode(fmt.Errorf("%w: either --file or --url must be provided", ErrSourceRequired), errorCodeSourceRequired)
+}
+
+// NewSourceConflictError formats a conflicting source error.
+func NewSourceConflictError() error {
+	return WithErrorCode(fmt.Errorf("%w: only one of --file or --url may be provided at a time", ErrSourceConflict), errorCodeSourceConflict)
+}
+
+// NewStorageDisabledError formats a storage disabled error.
+func NewStorageDisabledError() error {
+	return WithErrorCode(fmt.Errorf("%w: storage disabled; specify --cache-dir", ErrStorageDisabled), errorCodeStorageDisabled)
+}
+
+// WrapSyncError annotates a sync failure.
+func WrapSyncError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(err, errorCodeSyncFailed)
+}
+
+// ErrorCode resolves an error to its fingerprint error code.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var coded errorCoder
+	if errors.As(err, &coded) {
+		if code := coded.Code(); code != "" {
+			return code
+		}
+	}
+
+	switch {
+	case errors.Is(err, ErrSourceRequired):
+		return errorCodeSourceRequired
+	case errors.Is(err, ErrSourceConflict):
+		return errorCodeSourceConflict
+	case errors.Is(err, ErrStorageDisabled):
+		return errorCodeStorageDisabled
+	default:
+		return errorCodeSyncFailed
+	}
+}
+
+// ExitCode maps fingerprint errors to CLI exit codes.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	switch {
+	case errors.Is(err, ErrSourceRequired),
+		errors.Is(err, ErrSourceConflict):
+		return 2
+	case errors.Is(err, ErrStorageDisabled):
+		return 7
+	default:
+		return 1
+	}
+}
+
+// HTTPStatus maps fingerprint errors to HTTP status codes.
+func HTTPStatus(err error) int {
+	if err == nil {
+		return 200
+	}
+
+	switch {
+	case errors.Is(err, ErrSourceRequired),
+		errors.Is(err, ErrSourceConflict):
+		return 400
+	case errors.Is(err, ErrStorageDisabled):
+		return 503
+	default:
+		return 500
+	}
+}
+
+// Suggestions provides CLI hints for fingerprint errors.
+func Suggestions(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	switch ErrorCode(err) {
+	case errorCodeSourceRequired:
+		return []string{
+			"Provide a source:          --file <path> or --url <address>",
+			"Example:                   pentora fingerprint sync --url https://example/catalog.yaml",
+		}
+	case errorCodeSourceConflict:
+		return []string{
+			"Use only one source flag",
+			"Remove either --file or --url",
+		}
+	case errorCodeStorageDisabled:
+		return []string{
+			"Set cache directory:       pentora fingerprint sync --cache-dir <path>",
+			"Enable storage via CLI root command",
+		}
+	case errorCodeSyncFailed:
+		return []string{
+			"Retry with --url pointing to a reachable catalog",
+			"Check network connectivity and cache directory permissions",
+		}
+	default:
+		return nil
+	}
+}

--- a/pkg/fingerprint/errors_test.go
+++ b/pkg/fingerprint/errors_test.go
@@ -1,0 +1,153 @@
+package fingerprint
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFingerprintError_WithErrorCodeAndUnwrap(t *testing.T) {
+	if WithErrorCode(nil, "X") != nil {
+		t.Errorf("expected nil when err is nil")
+	}
+
+	base := errors.New("base")
+	wrapped := WithErrorCode(base, "CODE123")
+	if wrapped.(*withCodeError).Code() != "CODE123" {
+		t.Errorf("expected CODE123")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Errorf("unwrap mismatch")
+	}
+}
+
+func TestFingerprintError_NewSourceRequiredError(t *testing.T) {
+	err := NewSourceRequiredError()
+	if !errors.Is(err, ErrSourceRequired) {
+		t.Errorf("expected ErrSourceRequired")
+	}
+	if ErrorCode(err) != errorCodeSourceRequired {
+		t.Errorf("expected code source required")
+	}
+}
+
+func TestFingerprintError_NewSourceConflictError(t *testing.T) {
+	err := NewSourceConflictError()
+	if !errors.Is(err, ErrSourceConflict) {
+		t.Errorf("expected ErrSourceConflict")
+	}
+	if ErrorCode(err) != errorCodeSourceConflict {
+		t.Errorf("expected code source conflict")
+	}
+}
+
+func TestFingerprintError_NewStorageDisabledError(t *testing.T) {
+	err := NewStorageDisabledError()
+	if !errors.Is(err, ErrStorageDisabled) {
+		t.Errorf("expected ErrStorageDisabled")
+	}
+	if ErrorCode(err) != errorCodeStorageDisabled {
+		t.Errorf("expected code storage disabled")
+	}
+}
+
+func TestFingerprintError_WrapSyncError(t *testing.T) {
+	if WrapSyncError(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	e := errors.New("sync fail")
+	err := WrapSyncError(e)
+	if !errors.Is(err, e) {
+		t.Errorf("unwrap mismatch")
+	}
+	if ErrorCode(err) != errorCodeSyncFailed {
+		t.Errorf("expected sync failed code")
+	}
+}
+
+func TestFingerprintError_ErrorCodeBranches(t *testing.T) {
+	if ErrorCode(nil) != "" {
+		t.Errorf("expected empty for nil")
+	}
+
+	coded := WithErrorCode(errors.New("x"), "CUSTOM")
+	if ErrorCode(coded) != "CUSTOM" {
+		t.Errorf("expected CUSTOM")
+	}
+
+	if ErrorCode(ErrSourceRequired) != errorCodeSourceRequired {
+		t.Errorf("expected source required code")
+	}
+	if ErrorCode(ErrSourceConflict) != errorCodeSourceConflict {
+		t.Errorf("expected source conflict code")
+	}
+	if ErrorCode(ErrStorageDisabled) != errorCodeStorageDisabled {
+		t.Errorf("expected storage disabled code")
+	}
+	if ErrorCode(errors.New("other")) != errorCodeSyncFailed {
+		t.Errorf("expected sync failed default code")
+	}
+}
+
+func TestFingerprintError_ExitCode(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 0},
+		{ErrSourceRequired, 2},
+		{ErrSourceConflict, 2},
+		{ErrStorageDisabled, 7},
+		{errors.New("other"), 1}, // default branch
+	}
+	for _, tt := range tests {
+		got := ExitCode(tt.err)
+		if got != tt.expected {
+			t.Errorf("ExitCode(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestFingerprintError_HTTPStatus(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 200},
+		{ErrSourceRequired, 400},
+		{ErrSourceConflict, 400},
+		{ErrStorageDisabled, 503},
+		{errors.New("other"), 500}, // default branch
+	}
+	for _, tt := range tests {
+		got := HTTPStatus(tt.err)
+		if got != tt.expected {
+			t.Errorf("HTTPStatus(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestFingerprintError_Suggestions(t *testing.T) {
+	tests := []struct {
+		code string
+		want bool
+	}{
+		{errorCodeSourceRequired, true},
+		{errorCodeSourceConflict, true},
+		{errorCodeStorageDisabled, true},
+		{errorCodeSyncFailed, true},
+		{"UNKNOWN_CODE", false},
+	}
+	for _, tt := range tests {
+		err := WithErrorCode(errors.New("x"), tt.code)
+		sugs := Suggestions(err)
+		if tt.want && len(sugs) == 0 {
+			t.Errorf("expected suggestions for %v", tt.code)
+		}
+		if !tt.want && sugs != nil {
+			t.Errorf("expected nil for %v", tt.code)
+		}
+	}
+	if Suggestions(nil) != nil {
+		t.Errorf("expected nil for nil err")
+	}
+}

--- a/pkg/scanexec/errors.go
+++ b/pkg/scanexec/errors.go
@@ -1,0 +1,135 @@
+package scanexec
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common CLI failures.
+var (
+	// ErrNoTargets indicates that no scan targets were supplied.
+	ErrNoTargets = errors.New("no scan targets specified")
+
+	// ErrConflictingDiscoveryFlags indicates conflicting discovery flags.
+	ErrConflictingDiscoveryFlags = errors.New("cannot use --only-discover and --no-discover together")
+)
+
+// Error codes for scan failures used by CLI suggestion system.
+const (
+	errorCodeInvalidTarget        = "INVALID_TARGET"
+	errorCodeConflictingDiscovery = "CONFLICTING_DISCOVERY_FLAGS"
+	errorCodeScanFailure          = "SCAN_FAILURE"
+)
+
+// codedError wraps an error with an explicit error code.
+type codedError struct {
+	error
+	code string
+}
+
+func (e *codedError) Error() string {
+	return e.error.Error()
+}
+
+func (e *codedError) Unwrap() error {
+	return e.error
+}
+
+func (e *codedError) Code() string {
+	return e.code
+}
+
+// WithErrorCode wraps err with a specific CLI error code.
+func WithErrorCode(err error, code string) error {
+	if err == nil {
+		return nil
+	}
+	return &codedError{error: err, code: code}
+}
+
+// ErrorCode resolves a pentora scan error into a CLI error code.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var coded interface{ Code() string }
+	if errors.As(err, &coded) {
+		if code := coded.Code(); code != "" {
+			return code
+		}
+	}
+
+	switch {
+	case errors.Is(err, ErrNoTargets):
+		return errorCodeInvalidTarget
+	case errors.Is(err, ErrConflictingDiscoveryFlags):
+		return errorCodeConflictingDiscovery
+	}
+
+	return errorCodeScanFailure
+}
+
+// ExitCode maps scan errors to CLI exit codes.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	switch ErrorCode(err) {
+	case errorCodeInvalidTarget,
+		errorCodeConflictingDiscovery:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// HTTPStatus maps scan errors to HTTP status codes.
+func HTTPStatus(err error) int {
+	if err == nil {
+		return 200
+	}
+
+	switch ErrorCode(err) {
+	case errorCodeInvalidTarget,
+		errorCodeConflictingDiscovery:
+		return 400
+	default:
+		return 500
+	}
+}
+
+// Suggestions provides CLI hints for scan errors.
+func Suggestions(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	switch ErrorCode(err) {
+	case errorCodeInvalidTarget:
+		return []string{
+			"Provide a target:           pentora scan 192.168.1.0/24",
+			"Scan multiple hosts:        pentora scan 10.0.0.1 10.0.0.2",
+		}
+	case errorCodeConflictingDiscovery:
+		return []string{
+			"Remove either --only-discover or --no-discover",
+			"Run help for options:       pentora scan --help",
+		}
+	default:
+		return []string{
+			"Retry with verbose logs:    pentora scan <target> --verbose",
+			"Enable progress output:     pentora scan <target> --progress",
+		}
+	}
+}
+
+// NewInvalidTargetError annotates an invalid target input with context.
+func NewInvalidTargetError(input string, reason error) error {
+	base := ErrNoTargets
+	if input != "" {
+		base = fmt.Errorf("invalid target %q: %w", input, reason)
+	}
+	return WithErrorCode(base, errorCodeInvalidTarget)
+}

--- a/pkg/scanexec/errors_test.go
+++ b/pkg/scanexec/errors_test.go
@@ -1,0 +1,119 @@
+package scanexec
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestScanexecError_WithErrorCodeAndMethods(t *testing.T) {
+	// nil input
+	if WithErrorCode(nil, "X") != nil {
+		t.Errorf("expected nil for nil input")
+	}
+
+	base := errors.New("base")
+	wrapped := WithErrorCode(base, "CODE123").(*codedError)
+	if wrapped.Code() != "CODE123" {
+		t.Errorf("expected CODE123")
+	}
+	if wrapped.Error() != "base" {
+		t.Errorf("unexpected message")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Errorf("unwrap mismatch")
+	}
+}
+
+func TestScanexecError_ErrorCodeBranches(t *testing.T) {
+	if ErrorCode(nil) != "" {
+		t.Errorf("expected empty for nil")
+	}
+
+	// coded error path
+	coded := WithErrorCode(errors.New("x"), "CUSTOM")
+	if ErrorCode(coded) != "CUSTOM" {
+		t.Errorf("expected CUSTOM")
+	}
+
+	if ErrorCode(ErrNoTargets) != errorCodeInvalidTarget {
+		t.Errorf("expected invalid target code")
+	}
+	if ErrorCode(ErrConflictingDiscoveryFlags) != errorCodeConflictingDiscovery {
+		t.Errorf("expected conflicting discovery code")
+	}
+	if ErrorCode(errors.New("random")) != errorCodeScanFailure {
+		t.Errorf("expected scan failure default")
+	}
+}
+
+func TestScanexecError_ExitCode(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 0},
+		{WithErrorCode(errors.New("x"), errorCodeInvalidTarget), 2},
+		{WithErrorCode(errors.New("x"), errorCodeConflictingDiscovery), 2},
+		{WithErrorCode(errors.New("x"), "UNKNOWN"), 1}, // default
+	}
+	for _, tt := range tests {
+		if got := ExitCode(tt.err); got != tt.expected {
+			t.Errorf("ExitCode(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestScanexecError_HTTPStatus(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 200},
+		{WithErrorCode(errors.New("x"), errorCodeInvalidTarget), 400},
+		{WithErrorCode(errors.New("x"), errorCodeConflictingDiscovery), 400},
+		{WithErrorCode(errors.New("x"), "OTHER"), 500}, // default
+	}
+	for _, tt := range tests {
+		if got := HTTPStatus(tt.err); got != tt.expected {
+			t.Errorf("HTTPStatus(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestScanexecError_Suggestions(t *testing.T) {
+	tests := []struct {
+		code string
+		want int
+	}{
+		{errorCodeInvalidTarget, 2},
+		{errorCodeConflictingDiscovery, 2},
+		{errorCodeScanFailure, 2}, // default suggestions
+	}
+	for _, tt := range tests {
+		err := WithErrorCode(errors.New("x"), tt.code)
+		sugs := Suggestions(err)
+		if len(sugs) != tt.want {
+			t.Errorf("expected %d suggestions for %v, got %d", tt.want, tt.code, len(sugs))
+		}
+	}
+	if Suggestions(nil) != nil {
+		t.Errorf("expected nil for nil err")
+	}
+}
+
+func TestScanexecError_NewInvalidTargetError(t *testing.T) {
+	reason := errors.New("reason")
+	// input provided
+	err1 := NewInvalidTargetError("host", reason)
+	if ErrorCode(err1) != errorCodeInvalidTarget {
+		t.Errorf("expected invalid target code")
+	}
+	if err1.Error() == "" {
+		t.Errorf("expected message")
+	}
+	// empty input, should wrap ErrNoTargets
+	err2 := NewInvalidTargetError("", reason)
+	if !errors.Is(err2, ErrNoTargets) {
+		t.Errorf("expected ErrNoTargets")
+	}
+}

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -1,0 +1,234 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	errorCodeInvalidPort        = "SERVER_INVALID_PORT"
+	errorCodeInvalidConcurrency = "SERVER_INVALID_CONCURRENCY"
+	errorCodeFeaturesDisabled   = "SERVER_FEATURES_DISABLED"
+	errorCodeConfigUnavailable  = "SERVER_CONFIG_UNAVAILABLE"
+	errorCodeInvalidConfig      = "SERVER_INVALID_CONFIG"
+	errorCodeStorageInitFailed  = "SERVER_STORAGE_INIT_FAILED"
+	errorCodePluginInitFailed   = "SERVER_PLUGIN_INIT_FAILED"
+	errorCodeAppInitFailed      = "SERVER_INIT_FAILED"
+	errorCodeRuntimeFailed      = "SERVER_RUNTIME_FAILED"
+)
+
+var (
+	// ErrInvalidPort indicates an invalid port flag value.
+	ErrInvalidPort = errors.New("invalid port")
+	// ErrInvalidConcurrency indicates an invalid jobs concurrency value.
+	ErrInvalidConcurrency = errors.New("invalid jobs concurrency")
+	// ErrFeaturesDisabled indicates UI and API were both disabled.
+	ErrFeaturesDisabled = errors.New("ui and api disabled")
+	// ErrConfigUnavailable indicates the CLI context lacked a config manager.
+	ErrConfigUnavailable = errors.New("config manager unavailable")
+)
+
+type errorCoder interface {
+	error
+	Code() string
+}
+
+type withCodeError struct {
+	error
+	code string
+}
+
+func (e *withCodeError) Code() string {
+	return e.code
+}
+
+func (e *withCodeError) Unwrap() error {
+	return e.error
+}
+
+// WithErrorCode annotates err with a server error code.
+func WithErrorCode(err error, code string) error {
+	if err == nil {
+		return nil
+	}
+	return &withCodeError{error: err, code: code}
+}
+
+// NewInvalidPortError formats an invalid port error with context.
+func NewInvalidPortError(port int) error {
+	return WithErrorCode(fmt.Errorf("%w: invalid port %d: must be between 1 and 65535", ErrInvalidPort, port), errorCodeInvalidPort)
+}
+
+// NewInvalidConcurrencyError formats an invalid concurrency error.
+func NewInvalidConcurrencyError(concurrency int) error {
+	return WithErrorCode(fmt.Errorf("%w: invalid concurrency %d: must be at least 1", ErrInvalidConcurrency, concurrency), errorCodeInvalidConcurrency)
+}
+
+// NewFeaturesDisabledError reports mutually-disabled UI/API flags.
+func NewFeaturesDisabledError() error {
+	return WithErrorCode(fmt.Errorf("%w: cannot disable both UI and API: at least one must be enabled", ErrFeaturesDisabled), errorCodeFeaturesDisabled)
+}
+
+// WrapInvalidConfig annotates server config validation errors.
+func WrapInvalidConfig(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(fmt.Errorf("invalid server configuration: %w", err), errorCodeInvalidConfig)
+}
+
+// WrapStorageInit annotates storage backend initialization failures.
+func WrapStorageInit(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(err, errorCodeStorageInitFailed)
+}
+
+// WrapPluginInit annotates plugin service initialization failures.
+func WrapPluginInit(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(err, errorCodePluginInitFailed)
+}
+
+// WrapAppInit annotates server app creation failures.
+func WrapAppInit(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(err, errorCodeAppInitFailed)
+}
+
+// WrapRuntime annotates server runtime failures.
+func WrapRuntime(err error) error {
+	if err == nil {
+		return nil
+	}
+	return WithErrorCode(err, errorCodeRuntimeFailed)
+}
+
+// ErrorCode resolves a server error to its error code.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var coded errorCoder
+	if errors.As(err, &coded) {
+		if code := coded.Code(); code != "" {
+			return code
+		}
+	}
+
+	switch {
+	case errors.Is(err, ErrInvalidPort):
+		return errorCodeInvalidPort
+	case errors.Is(err, ErrInvalidConcurrency):
+		return errorCodeInvalidConcurrency
+	case errors.Is(err, ErrFeaturesDisabled):
+		return errorCodeFeaturesDisabled
+	case errors.Is(err, ErrConfigUnavailable):
+		return errorCodeConfigUnavailable
+	default:
+		return errorCodeRuntimeFailed
+	}
+}
+
+// ExitCode maps server errors to CLI exit codes.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	switch {
+	case errors.Is(err, ErrInvalidPort),
+		errors.Is(err, ErrInvalidConcurrency),
+		errors.Is(err, ErrFeaturesDisabled):
+		return 2
+	case errors.Is(err, ErrConfigUnavailable):
+		return 1
+	case ErrorCode(err) == errorCodeStorageInitFailed,
+		ErrorCode(err) == errorCodePluginInitFailed,
+		ErrorCode(err) == errorCodeAppInitFailed:
+		return 7
+	default:
+		return 1
+	}
+}
+
+// HTTPStatus maps server errors to HTTP status codes.
+func HTTPStatus(err error) int {
+	if err == nil {
+		return 200
+	}
+
+	switch {
+	case errors.Is(err, ErrInvalidPort),
+		errors.Is(err, ErrInvalidConcurrency),
+		errors.Is(err, ErrFeaturesDisabled):
+		return 400
+	case errors.Is(err, ErrConfigUnavailable):
+		return 500
+	default:
+		return 500
+	}
+}
+
+// Suggestions provides CLI hints for server errors.
+func Suggestions(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	switch ErrorCode(err) {
+	case errorCodeInvalidPort:
+		return []string{
+			"Use a port between 1 and 65535",
+			"Example:                 pentora server start --port 8080",
+		}
+	case errorCodeInvalidConcurrency:
+		return []string{
+			"Set jobs concurrency to at least 1",
+			"Example:                 pentora server start --jobs-concurrency 4",
+		}
+	case errorCodeFeaturesDisabled:
+		return []string{
+			"Enable either UI or API flags",
+			"Remove one of --no-ui / --no-api",
+		}
+	case errorCodeConfigUnavailable:
+		return []string{
+			"Run via the pentora CLI so AppManager initializes",
+			"Avoid calling server start from custom scripts without init",
+		}
+	case errorCodeInvalidConfig:
+		return []string{
+			"Check configuration values in config file",
+			"Retry with --verbose for detailed validation errors",
+		}
+	case errorCodeStorageInitFailed:
+		return []string{
+			"Verify storage directory permissions",
+			"Override storage root:     pentora server start --storage-dir <path>",
+		}
+	case errorCodePluginInitFailed:
+		return []string{
+			"Check plugin cache directory access",
+			"Retry after running:      pentora plugin clean",
+		}
+	case errorCodeAppInitFailed:
+		return []string{
+			"Retry with verbose logging: pentora server start --verbose",
+			"Review configuration for invalid values",
+		}
+	case errorCodeRuntimeFailed:
+		return []string{
+			"Check server logs for runtime errors",
+			"Ensure no other process is using the selected port",
+		}
+	default:
+		return nil
+	}
+}

--- a/pkg/server/errors_test.go
+++ b/pkg/server/errors_test.go
@@ -1,0 +1,204 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestServerError_WithErrorCodeAndUnwrap(t *testing.T) {
+	if WithErrorCode(nil, "X") != nil {
+		t.Errorf("expected nil when err is nil")
+	}
+
+	base := errors.New("base")
+	wrapped := WithErrorCode(base, "CODE123")
+	if wrapped.(*withCodeError).Code() != "CODE123" {
+		t.Errorf("expected CODE123")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Errorf("unwrap mismatch")
+	}
+}
+
+func TestServerError_NewInvalidPortError(t *testing.T) {
+	err := NewInvalidPortError(99999)
+	if !errors.Is(err, ErrInvalidPort) {
+		t.Errorf("expected invalid port err")
+	}
+	if ErrorCode(err) != errorCodeInvalidPort {
+		t.Errorf("expected code invalid_port")
+	}
+}
+
+func TestServerError_NewInvalidConcurrencyError(t *testing.T) {
+	err := NewInvalidConcurrencyError(0)
+	if !errors.Is(err, ErrInvalidConcurrency) {
+		t.Errorf("expected invalid concurrency err")
+	}
+	if ErrorCode(err) != errorCodeInvalidConcurrency {
+		t.Errorf("expected code invalid_concurrency")
+	}
+}
+
+func TestServerError_NewFeaturesDisabledError(t *testing.T) {
+	err := NewFeaturesDisabledError()
+	if !errors.Is(err, ErrFeaturesDisabled) {
+		t.Errorf("expected features disabled err")
+	}
+	if ErrorCode(err) != errorCodeFeaturesDisabled {
+		t.Errorf("expected code features_disabled")
+	}
+}
+
+func TestServerError_WrapInvalidConfig(t *testing.T) {
+	if WrapInvalidConfig(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	e := errors.New("bad")
+	err := WrapInvalidConfig(e)
+	if !errors.Is(err, e) {
+		t.Errorf("unwrap mismatch")
+	}
+	if ErrorCode(err) != errorCodeInvalidConfig {
+		t.Errorf("expected invalid_config code")
+	}
+}
+
+func TestServerError_WrapStorageInit(t *testing.T) {
+	if WrapStorageInit(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	err := WrapStorageInit(errors.New("s"))
+	if ErrorCode(err) != errorCodeStorageInitFailed {
+		t.Errorf("expected storage_init_failed code")
+	}
+}
+
+func TestServerError_WrapPluginInit(t *testing.T) {
+	if WrapPluginInit(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	err := WrapPluginInit(errors.New("s"))
+	if ErrorCode(err) != errorCodePluginInitFailed {
+		t.Errorf("expected plugin_init_failed code")
+	}
+}
+
+func TestServerError_WrapAppInit(t *testing.T) {
+	if WrapAppInit(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	err := WrapAppInit(errors.New("s"))
+	if ErrorCode(err) != errorCodeAppInitFailed {
+		t.Errorf("expected app_init_failed code")
+	}
+}
+
+func TestServerError_WrapRuntime(t *testing.T) {
+	if WrapRuntime(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+	err := WrapRuntime(errors.New("s"))
+	if ErrorCode(err) != errorCodeRuntimeFailed {
+		t.Errorf("expected runtime_failed code")
+	}
+}
+
+func TestServerError_ErrorCodeBranches(t *testing.T) {
+	if ErrorCode(nil) != "" {
+		t.Errorf("expected empty for nil")
+	}
+
+	coded := WithErrorCode(errors.New("x"), "CUSTOM")
+	if ErrorCode(coded) != "CUSTOM" {
+		t.Errorf("expected CUSTOM")
+	}
+
+	if ErrorCode(ErrInvalidPort) != errorCodeInvalidPort {
+		t.Errorf("expected invalid port code")
+	}
+	if ErrorCode(ErrInvalidConcurrency) != errorCodeInvalidConcurrency {
+		t.Errorf("expected invalid concurrency code")
+	}
+	if ErrorCode(ErrFeaturesDisabled) != errorCodeFeaturesDisabled {
+		t.Errorf("expected features disabled code")
+	}
+	if ErrorCode(ErrConfigUnavailable) != errorCodeConfigUnavailable {
+		t.Errorf("expected config unavailable code")
+	}
+	if ErrorCode(errors.New("random")) != errorCodeRuntimeFailed {
+		t.Errorf("expected runtime_failed fallback")
+	}
+}
+
+func TestServerError_ExitCode(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 0},
+		{ErrInvalidPort, 2},
+		{ErrInvalidConcurrency, 2},
+		{ErrFeaturesDisabled, 2},
+		{ErrConfigUnavailable, 1},
+		{WithErrorCode(errors.New("x"), errorCodeStorageInitFailed), 7},
+		{WithErrorCode(errors.New("x"), errorCodePluginInitFailed), 7},
+		{WithErrorCode(errors.New("x"), errorCodeAppInitFailed), 7},
+		{WithErrorCode(errors.New("x"), "UNKNOWN_CODE"), 1}, // default branch
+	}
+	for _, tt := range tests {
+		if got := ExitCode(tt.err); got != tt.expected {
+			t.Errorf("ExitCode(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestServerError_HTTPStatus(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected int
+	}{
+		{nil, 200},
+		{ErrInvalidPort, 400},
+		{ErrInvalidConcurrency, 400},
+		{ErrFeaturesDisabled, 400},
+		{ErrConfigUnavailable, 500},
+		{errors.New("x"), 500}, // default branch
+	}
+	for _, tt := range tests {
+		if got := HTTPStatus(tt.err); got != tt.expected {
+			t.Errorf("HTTPStatus(%v)=%d, want %d", tt.err, got, tt.expected)
+		}
+	}
+}
+
+func TestServerError_Suggestions(t *testing.T) {
+	tests := []struct {
+		code string
+		want bool
+	}{
+		{errorCodeInvalidPort, true},
+		{errorCodeInvalidConcurrency, true},
+		{errorCodeFeaturesDisabled, true},
+		{errorCodeConfigUnavailable, true},
+		{errorCodeInvalidConfig, true},
+		{errorCodeStorageInitFailed, true},
+		{errorCodePluginInitFailed, true},
+		{errorCodeAppInitFailed, true},
+		{errorCodeRuntimeFailed, true},
+		{"UNKNOWN_CODE", false},
+	}
+	for _, tt := range tests {
+		err := WithErrorCode(errors.New("x"), tt.code)
+		sugs := Suggestions(err)
+		if tt.want && len(sugs) == 0 {
+			t.Errorf("expected suggestions for %v", tt.code)
+		}
+		if !tt.want && sugs != nil {
+			t.Errorf("expected nil for %v", tt.code)
+		}
+	}
+	if Suggestions(nil) != nil {
+		t.Errorf("expected nil for nil err")
+	}
+}


### PR DESCRIPTION
## Summary
- extend server, fingerprint, dag, and scan/storage commands to use total failure summaries
- add CLI error code helpers with rich suggestions across packages
- cover new UX with integration-style tests for command entry points

## Testing
- make test
- make validate

Closes #97