### PR TITLE
feat(api): add plugin endpoints request validation (Phase 2)

### DIFF
--- a/pkg/server/api/v1/validation.go
+++ b/pkg/server/api/v1/validation.go
@@ -2,10 +2,12 @@ package v1
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/pentora-ai/pentora/pkg/plugin"
 )
 
 var validate = validator.New()
@@ -77,4 +79,78 @@ func (e *ValidationError) Error() string {
 		return e.Field + ": invalid"
 	}
 	return e.Field + ": " + e.Reason
+}
+
+// ---- Plugin API validation helpers ----
+
+var pluginIDRe = regexp.MustCompile(`^[a-z][a-z0-9_-]{2,62}$`)
+
+// ValidatePluginID validates a plugin ID slug.
+func ValidatePluginID(id string) error {
+	if strings.TrimSpace(id) == "" {
+		return &ValidationError{Field: "id", Reason: "required"}
+	}
+	if !pluginIDRe.MatchString(id) {
+		return &ValidationError{Field: "id", Reason: "invalid format (lowercase alnum, hyphen/underscore, 3-63)"}
+	}
+	return nil
+}
+
+// ValidateSource validates a plugin source against whitelist.
+func ValidateSource(src string) error {
+	if src == "" {
+		return nil
+	}
+	if !plugin.IsValidSource(src) {
+		return &ValidationError{Field: "source", Reason: "invalid"}
+	}
+	return nil
+}
+
+// ValidateCategory validates plugin category against whitelist.
+func ValidateCategory(cat string) error {
+	if cat == "" {
+		return nil
+	}
+	if !plugin.IsValidCategory(cat) {
+		return &ValidationError{Field: "category", Reason: "invalid"}
+	}
+	return nil
+}
+
+// ParseInstallPlugin validates install request fields.
+func ParseInstallPlugin(req InstallPluginRequest) error {
+	if strings.TrimSpace(req.Target) == "" {
+		return &ValidationError{Field: "target", Reason: "required"}
+	}
+	// If not a known category, validate as plugin ID
+	if !plugin.IsValidCategory(req.Target) {
+		if err := ValidatePluginID(req.Target); err != nil {
+			return err
+		}
+	}
+	if err := ValidateSource(req.Source); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseUpdatePlugins validates update request fields.
+func ParseUpdatePlugins(req UpdatePluginsRequest) error {
+	if err := ValidateCategory(req.Category); err != nil {
+		return err
+	}
+	if err := ValidateSource(req.Source); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseListPlugins validates optional category filter in query (if present).
+func ParseListPlugins(r *http.Request) error {
+	cat := strings.TrimSpace(r.URL.Query().Get("category"))
+	if cat == "" {
+		return nil
+	}
+	return ValidateCategory(cat)
 }

--- a/pkg/server/api/v1/validation_test.go
+++ b/pkg/server/api/v1/validation_test.go
@@ -1,0 +1,149 @@
+package v1
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/pentora-ai/pentora/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- helper for request ---
+func newRequestWithQuery(params map[string]string) *http.Request {
+	q := url.Values{}
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	r, _ := http.NewRequest(http.MethodGet, "/api/v1/scans?"+q.Encode(), nil)
+	return r
+}
+
+func TestValidation_ParseListScansQuery_OK_Defaults(t *testing.T) {
+	r := newRequestWithQuery(nil)
+	got, err := ParseListScansQuery(r)
+	assert.NoError(t, err)
+	assert.Equal(t, 50, got.Limit)
+	assert.Equal(t, 0, got.Offset)
+	assert.Equal(t, "", got.Status)
+}
+
+func TestValidation_ParseListScansQuery_AllValid(t *testing.T) {
+	r := newRequestWithQuery(map[string]string{
+		"status": "pending",
+		"limit":  "10",
+		"offset": "2",
+	})
+	got, err := ParseListScansQuery(r)
+	assert.NoError(t, err)
+	assert.Equal(t, "pending", got.Status)
+	assert.Equal(t, 10, got.Limit)
+	assert.Equal(t, 2, got.Offset)
+}
+
+func TestValidation_ParseListScansQuery_InvalidStatus(t *testing.T) {
+	r := newRequestWithQuery(map[string]string{"status": "wrong"})
+	got, err := ParseListScansQuery(r)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status")
+}
+
+func TestValidation_ParseListScansQuery_InvalidLimit(t *testing.T) {
+	r := newRequestWithQuery(map[string]string{"limit": "abc"})
+	got, err := ParseListScansQuery(r)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "limit")
+}
+
+func TestValidation_ParseListScansQuery_LimitOutOfRange(t *testing.T) {
+	r := newRequestWithQuery(map[string]string{"limit": "101"})
+	got, err := ParseListScansQuery(r)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+}
+
+func TestValidation_ParseListScansQuery_InvalidOffset(t *testing.T) {
+	r := newRequestWithQuery(map[string]string{"offset": "-1"})
+	got, err := ParseListScansQuery(r)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+}
+
+func TestValidation_ErrorFormatting(t *testing.T) {
+	var e *ValidationError
+	assert.Equal(t, "", e.Error())
+
+	e = &ValidationError{}
+	assert.Equal(t, "validation failed", e.Error())
+
+	e = &ValidationError{Field: "limit"}
+	assert.Equal(t, "limit: invalid", e.Error())
+
+	e = &ValidationError{Field: "limit", Reason: "too high"}
+	assert.Equal(t, "limit: too high", e.Error())
+}
+
+func TestValidation_ValidatePluginID(t *testing.T) {
+	assert.Error(t, ValidatePluginID(""))              // required
+	assert.Error(t, ValidatePluginID("Invalid!"))      // invalid chars
+	assert.Error(t, ValidatePluginID("ab"))            // too short
+	assert.NoError(t, ValidatePluginID("abc"))         // ok
+	assert.NoError(t, ValidatePluginID("abc_123"))     // ok
+	assert.NoError(t, ValidatePluginID("abc-xyz_123")) // ok
+}
+
+func TestValidation_ParseUpdatePlugins(t *testing.T) {
+	t.Run("invalid category", func(t *testing.T) {
+		req := UpdatePluginsRequest{Category: "invalid-cat", Source: ""}
+		err := ParseUpdatePlugins(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "category")
+	})
+
+	t.Run("invalid source", func(t *testing.T) {
+		req := UpdatePluginsRequest{Category: "", Source: "invalid-src"}
+		err := ParseUpdatePlugins(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "source")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		req := UpdatePluginsRequest{}
+		err := ParseUpdatePlugins(req)
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidation_ValidateCategory(t *testing.T) {
+	t.Run("empty category returns nil", func(t *testing.T) {
+		err := ValidateCategory("")
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid category returns ValidationError", func(t *testing.T) {
+		err := ValidateCategory("something_invalid")
+		assert.Error(t, err)
+		assert.IsType(t, &ValidationError{}, err)
+		assert.Contains(t, err.Error(), "category")
+	})
+
+	t.Run("valid category returns nil", func(t *testing.T) {
+		// whitelist'ten geçerli bir kategori bul (varsa)
+		validCategory := ""
+		for _, c := range plugin.GetValidCategories() {
+			if ValidateCategory(c) == nil {
+				validCategory = c
+				break
+			}
+		}
+
+		if validCategory == "" {
+			t.Skip("no valid category found in plugin whitelist")
+		}
+
+		err := ValidateCategory(validCategory)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Summary
- Phase 2 of Issue #138 (API Request Validation)
- Adds request validation for plugin endpoints and extends tests
- Behavior: no functional changes beyond returning 400 for invalid input

Changes
- Validation helpers (v1/validation.go):
  - ValidatePluginID (slug regex), ValidateSource (whitelist), ValidateCategory (whitelist)
  - ParseInstallPlugin, ParseUpdatePlugins, ParseListPlugins
- Handlers (v1/plugins.go):
  - Install: use ParseInstallPlugin; INVALID_SOURCE message includes valid sources
  - Get/Uninstall: ValidatePluginID → 400 on empty/invalid (PLUGIN_ID_REQUIRED/INVALID_PLUGIN_ID)
  - List: validate optional category filter → 400 INVALID_QUERY when invalid
- Tests (v1/plugins_test.go):
  - Invalid source/empty target/invalid target ID for Install
  - Invalid category query for List
  - Empty/invalid IDs for Get and Uninstall

Validation
- make test && make validate pass locally

Notes
- List endpoint currently validates category query but does not filter (service interface remains unchanged)
- Consistent JSON errors via api.WriteJSONError

Refs #138