### PR TITLE
feat(api): implement cursor-based pagination for scans endpoint

### DIFF
--- a/pkg/scanexec/service_test.go
+++ b/pkg/scanexec/service_test.go
@@ -180,6 +180,11 @@ func (m *memScans) GetAnalytics(ctx context.Context, orgID string, period storag
 	return nil, storage.ErrNotSupported
 }
 
+func (m *memScans) ListPaginated(ctx context.Context, orgID string, filter storage.ScanFilter, cursor string, limit int) ([]*storage.ScanMetadata, string, int, error) {
+	// Simple mock implementation: return created scans (no actual pagination)
+	return m.created, "", len(m.created), nil
+}
+
 type memBackend struct{ scans *memScans }
 
 func (b *memBackend) Scans() storage.ScanStore             { return b.scans }

--- a/pkg/server/api/errors.go
+++ b/pkg/server/api/errors.go
@@ -51,11 +51,17 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	} else {
 		// Check for storage errors
 		var notFoundErr *storage.NotFoundError
+		var invalidInputErr *storage.InvalidInputError
 		if errors.As(err, &notFoundErr) {
 			statusCode = http.StatusNotFound
 			errorType = "Not Found"
 			errorCode = "RESOURCE_NOT_FOUND"
 			message = notFoundErr.Error()
+		} else if errors.As(err, &invalidInputErr) {
+			statusCode = http.StatusBadRequest
+			errorType = "Bad Request"
+			errorCode = "INVALID_INPUT"
+			message = invalidInputErr.Error()
 		} else {
 			// Generic error - return 500
 			statusCode = http.StatusInternalServerError

--- a/pkg/server/api/v1/validation.go
+++ b/pkg/server/api/v1/validation.go
@@ -14,7 +14,7 @@ var validate = validator.New()
 type ListScansQuery struct {
 	Status string
 	Limit  int
-	Offset int
+	Cursor string // Opaque cursor for pagination (empty for first page)
 }
 
 // ParseListScansQuery parses and validates query params.
@@ -41,15 +41,10 @@ func ParseListScansQuery(r *http.Request) (*ListScansQuery, error) {
 		}
 		res.Limit = n
 	}
-	if v := strings.TrimSpace(q.Get("offset")); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, &ValidationError{Field: "offset", Reason: "must be an integer"}
-		}
-		if err := validate.Var(n, "min=0"); err != nil {
-			return nil, &ValidationError{Field: "offset", Reason: "must be >= 0"}
-		}
-		res.Offset = n
+
+	// Cursor parameter (opaque string, no validation needed beyond trimming)
+	if v := strings.TrimSpace(q.Get("cursor")); v != "" {
+		res.Cursor = v
 	}
 
 	// Defaults

--- a/pkg/storage/backend.go
+++ b/pkg/storage/backend.go
@@ -78,7 +78,28 @@ type ScanStore interface {
 	//
 	// Returns empty slice if no scans match the filter.
 	// Returns error if the operation fails.
+	//
+	// Deprecated: Use ListPaginated for better scalability with large datasets.
 	List(ctx context.Context, orgID string, filter ScanFilter) ([]*ScanMetadata, error)
+
+	// ListPaginated returns a paginated list of scans matching the given filter.
+	//
+	// Parameters:
+	//   - ctx: Request context
+	//   - orgID: Organization identifier (OSS uses "default")
+	//   - filter: Filtering criteria (status, etc.)
+	//   - cursor: Pagination cursor (empty string for first page)
+	//   - limit: Maximum number of results (1-100, default 50)
+	//
+	// Returns:
+	//   - scans: List of scan metadata (up to limit items)
+	//   - nextCursor: Cursor for next page (empty if no more results)
+	//   - total: Total count of scans matching filter
+	//   - error: Error if operation fails
+	//
+	// The cursor is an opaque string that should be passed as-is to get the next page.
+	// Cursors are base64-encoded and URL-safe.
+	ListPaginated(ctx context.Context, orgID string, filter ScanFilter, cursor string, limit int) (scans []*ScanMetadata, nextCursor string, total int, err error)
 
 	// Get retrieves metadata for a specific scan.
 	//

--- a/pkg/storage/cursor.go
+++ b/pkg/storage/cursor.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// Cursor represents a pagination cursor for scan listing.
+// It contains the last scan ID and timestamp to enable efficient pagination.
+type Cursor struct {
+	LastScanID string `json:"id"`
+	LastTime   int64  `json:"ts"` // Unix timestamp in nanoseconds
+}
+
+// EncodeCursor encodes a cursor to a base64 URL-safe string.
+// Returns empty string if cursor is nil or invalid.
+func EncodeCursor(c *Cursor) string {
+	if c == nil || c.LastScanID == "" {
+		return ""
+	}
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		return ""
+	}
+
+	return base64.URLEncoding.EncodeToString(data)
+}
+
+// DecodeCursor decodes a base64-encoded cursor string.
+// Returns nil and no error for empty cursor (first page).
+// Returns error if cursor is malformed.
+func DecodeCursor(encoded string) (*Cursor, error) {
+	if encoded == "" {
+		return nil, nil // First page
+	}
+
+	data, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+
+	var c Cursor
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("invalid cursor format: %w", err)
+	}
+
+	if c.LastScanID == "" {
+		return nil, fmt.Errorf("invalid cursor: missing scan ID")
+	}
+
+	return &c, nil
+}

--- a/pkg/storage/cursor_test.go
+++ b/pkg/storage/cursor_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ✅ happy path – encode and decode roundtrip
+func TestCursor_EncodeDecode_Success(t *testing.T) {
+	c := &Cursor{LastScanID: "scan-123", LastTime: 1234567890}
+	encoded := EncodeCursor(c)
+	require.NotEmpty(t, encoded)
+
+	decoded, err := DecodeCursor(encoded)
+	require.NoError(t, err)
+	require.Equal(t, c.LastScanID, decoded.LastScanID)
+	require.Equal(t, c.LastTime, decoded.LastTime)
+}
+
+// ✅ nil cursor returns empty string
+func TestCursor_Encode_NilCursor(t *testing.T) {
+	require.Equal(t, "", EncodeCursor(nil))
+}
+
+// ✅ empty ID returns empty string
+func TestCursor_Encode_EmptyID(t *testing.T) {
+	c := &Cursor{LastScanID: "", LastTime: 123}
+	require.Equal(t, "", EncodeCursor(c))
+}
+
+// TestCursor_Encode_JSONError removed - can't trigger marshal error with normal Cursor struct
+// EncodeCursor silently returns empty string on marshal error (defensive programming)
+
+// ✅ empty string input -> first page (returns nil, nil)
+func TestCursor_Decode_EmptyString(t *testing.T) {
+	c, err := DecodeCursor("")
+	require.NoError(t, err)
+	require.Nil(t, c)
+}
+
+// ✅ invalid base64 string
+func TestCursor_Decode_InvalidBase64(t *testing.T) {
+	c, err := DecodeCursor("%%%not-base64%%%")
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.Contains(t, err.Error(), "invalid cursor encoding")
+}
+
+// ✅ invalid JSON structure
+func TestCursor_Decode_InvalidJSON(t *testing.T) {
+	// base64 of plain string, not JSON
+	encoded := base64.URLEncoding.EncodeToString([]byte("not-json"))
+	c, err := DecodeCursor(encoded)
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.Contains(t, err.Error(), "invalid cursor format")
+}
+
+// ✅ missing LastScanID
+func TestCursor_Decode_MissingScanID(t *testing.T) {
+	c := Cursor{LastScanID: "", LastTime: 111}
+	data, _ := json.Marshal(c)
+	encoded := base64.URLEncoding.EncodeToString(data)
+
+	out, err := DecodeCursor(encoded)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.Contains(t, err.Error(), "missing scan ID")
+}


### PR DESCRIPTION
## Summary

Implements cursor-based pagination for the `/api/v1/scans` endpoint to replace offset-based in-memory pagination. This improves scalability and performance by moving pagination logic into the storage layer.

**Resolves #139**

## Changes

### Storage Layer
- Added `ListPaginated()` method to `ScanStore` interface
- Created `pkg/storage/cursor.go` with cursor encoding/decoding utilities
- Implemented cursor-based pagination in `LocalBackend`
  - Cursor format: Base64-encoded JSON with `{LastScanID, LastTime}`
  - Sorting: By `StartedAt` DESC for consistent cursor behavior
  - Default limit: 50, Max limit: 100
- Refactored implementation into helper functions to reduce cyclomatic complexity

### API Layer
- Updated query parameter parsing: `offset` → `cursor` (opaque string)
- Changed response format from `[]ScanMetadata` to `{scans, next_cursor, total}`
- Added `InvalidInputError` → 400 mapping in error handler
- Maintained backward compatibility: workspace fallback returns legacy array format

### Testing
- Updated all API tests to expect new response format
- Added cursor validation to mock implementations
- Removed obsolete offset-based tests
- All tests pass (`make test` ✅)
- All validation checks pass (`make validate` ✅)

## Migration Notes

**Breaking Change for API Clients:**

Old response format:
```json
[
  {"id": "scan-1", "status": "completed", "start_time": "..."},
  {"id": "scan-2", "status": "running", "start_time": "..."}
]
```

New response format:
```json
{
  "scans": [
    {"id": "scan-1", "status": "completed", "start_time": "..."},
    {"id": "scan-2", "status": "running", "start_time": "..."}
  ],
  "next_cursor": "eyJpZCI6InNjYW4tMiIsInRzIjoxNzA0MTU4NDAwMDAwMDAwMDAwfQ==",
  "total": 100
}
```

**Query Parameters:**
- Old: `?offset=50&limit=25`
- New: `?cursor=<opaque>&limit=25` (cursor is optional, empty for first page)

## Testing

```bash
# Unit tests
make test

# Validation (lint, format, spell check)
make validate
```

All checks passing ✅

## Related

- Issue #139: API Pagination with Cursor Support (P0)
- PR #142: Input Validation for API Endpoints (Phase 1 - uses offset)