### PR TITLE
feat(engine): ModuleLifecycle + orchestrator lifecycle; noop example

### DIFF
--- a/pkg/engine/module.go
+++ b/pkg/engine/module.go
@@ -119,3 +119,18 @@ type Module interface {
 	// and a channel to send its outputs.
 	Execute(ctx context.Context, inputs map[string]interface{}, outputChan chan<- ModuleOutput) error
 }
+
+// ModuleLifecycle is an optional lifecycle interface that a Module can implement
+// to participate in orchestrator-managed setup/start/teardown phases. This is
+// opt-in and does not change the existing Module API.
+//
+// Note: Method names are prefixed with Lifecycle to avoid clashing with the
+// existing Module.Init signature.
+type ModuleLifecycle interface {
+	// LifecycleInit performs runtime initialization with a context (e.g., open connections).
+	LifecycleInit(ctx context.Context) error
+	// LifecycleStart activates long-running resources before Execute.
+	LifecycleStart(ctx context.Context) error
+	// LifecycleStop releases resources; orchestrator calls this best-effort with a timeout.
+	LifecycleStop(ctx context.Context) error
+}

--- a/pkg/engine/orchestrator_lifecycle_test.go
+++ b/pkg/engine/orchestrator_lifecycle_test.go
@@ -1,0 +1,153 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testLifecycleModule is a stub implementing Module and ModuleLifecycle for testing.
+type testLifecycleModule struct {
+	id        string
+	calls     *[]string
+	mu        *sync.Mutex
+	failInit  bool
+	failStart bool
+	execDelay time.Duration
+}
+
+func (m *testLifecycleModule) Metadata() ModuleMetadata {
+	return ModuleMetadata{Name: "test.lifecycle", Type: ParseModuleType}
+}
+
+func (m *testLifecycleModule) Init(instanceID string, _ map[string]interface{}) error {
+	m.id = instanceID
+	return nil
+}
+
+func (m *testLifecycleModule) Execute(ctx context.Context, _ map[string]interface{}, out chan<- ModuleOutput) error {
+	if m.execDelay > 0 {
+		time.Sleep(m.execDelay)
+	}
+	return nil
+}
+
+// Lifecycle
+func (m *testLifecycleModule) LifecycleInit(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	*m.calls = append(*m.calls, m.id+":init")
+	if m.failInit {
+		return fmt.Errorf("init fail")
+	}
+	return nil
+}
+
+func (m *testLifecycleModule) LifecycleStart(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	*m.calls = append(*m.calls, m.id+":start")
+	if m.failStart {
+		return fmt.Errorf("start fail")
+	}
+	return nil
+}
+
+func (m *testLifecycleModule) LifecycleStop(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	*m.calls = append(*m.calls, m.id+":stop")
+	return nil
+}
+
+func newTestLifecycleFactory(calls *[]string, mu *sync.Mutex) ModuleFactory {
+	return func() Module { return &testLifecycleModule{calls: calls, mu: mu} }
+}
+
+func TestOrchestrator_Lifecycle_OrderAndTeardown(t *testing.T) {
+	// Register factories for two nodes A->B (B depends on A by consumes key)
+	// To force a dependency, advertise production/consumption of a shared key
+	calls := []string{}
+	var mu sync.Mutex
+
+	// Register unique names to avoid global pollution between tests
+	RegisterModuleFactory("tlm-a", newTestLifecycleFactory(&calls, &mu))
+	RegisterModuleFactory("tlm-b", newTestLifecycleFactory(&calls, &mu))
+
+	// Build DAG: A then B via explicit dependency
+	dag := &DAGDefinition{
+		Name: "lifecycle-dag",
+		Nodes: []DAGNodeConfig{
+			{InstanceID: "A", ModuleType: "tlm-a", Config: map[string]interface{}{}},
+			{InstanceID: "B", ModuleType: "tlm-b", Config: map[string]interface{}{"__depends_on": []string{"A"}}},
+		},
+	}
+
+	orc, err := NewOrchestrator(dag)
+	require.NoError(t, err)
+
+	_, err = orc.Run(context.Background(), nil)
+	require.NoError(t, err)
+
+	// Expect lifecycle order: A.init, B.init, A.start, B.start, ... stops in reverse: B.stop, A.stop
+	// Execute does not add markers; we only validate lifecycle hooks and stop reverse order
+	// Since goroutines are concurrent, starts may interleave but A.start should occur before B.start due to dependency
+	// Validate prefix/suffix sets
+	// Collect positions
+	idx := func(tag string) int {
+		for i, v := range calls {
+			if v == tag {
+				return i
+			}
+		}
+		return -1
+	}
+
+	require.NotEqual(t, -1, idx("A:init"))
+	require.NotEqual(t, -1, idx("B:init"))
+	require.True(t, idx("A:init") < idx("B:init"))
+
+	require.NotEqual(t, -1, idx("A:start"))
+	require.NotEqual(t, -1, idx("B:start"))
+	// Because B depends on A, A:start must precede B:start
+	require.True(t, idx("A:start") < idx("B:start"))
+
+	// Stops must be present and in reverse order: B.stop before A.stop
+	require.NotEqual(t, -1, idx("A:stop"))
+	require.NotEqual(t, -1, idx("B:stop"))
+	require.True(t, idx("B:stop") < idx("A:stop"))
+}
+
+func TestOrchestrator_Lifecycle_StartFailureSkipsExecute(t *testing.T) {
+	calls := []string{}
+	var mu sync.Mutex
+
+	RegisterModuleFactory("tlm-fail", func() Module { return &testLifecycleModule{calls: &calls, mu: &mu, failStart: true} })
+
+	dag := &DAGDefinition{
+		Name:  "lifecycle-fail",
+		Nodes: []DAGNodeConfig{{InstanceID: "X", ModuleType: "tlm-fail"}},
+	}
+	orc, err := NewOrchestrator(dag)
+	require.NoError(t, err)
+
+	_, err = orc.Run(context.Background(), nil)
+	require.Error(t, err)
+
+	// Ensure start and stop recorded, and stop follows best-effort teardown
+	idx := func(tag string) int {
+		for i, v := range calls {
+			if v == tag {
+				return i
+			}
+		}
+		return -1
+	}
+	require.NotEqual(t, -1, idx("X:init"))
+	require.NotEqual(t, -1, idx("X:start"))
+	require.NotEqual(t, -1, idx("X:stop"))
+}

--- a/pkg/modules/parse/noop_lifecycle.go
+++ b/pkg/modules/parse/noop_lifecycle.go
@@ -1,0 +1,61 @@
+// pkg/modules/parse/noop_lifecycle.go
+package parse
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/pentora-ai/pentora/pkg/engine"
+)
+
+// noopLifecycleModule is a minimal example module that implements ModuleLifecycle.
+// It does not produce or consume any data; it only logs lifecycle transitions.
+type noopLifecycleModule struct {
+	instanceID string
+}
+
+func (m *noopLifecycleModule) Metadata() engine.ModuleMetadata {
+	return engine.ModuleMetadata{
+		ID:          "noop-lifecycle",
+		Name:        "noop-lifecycle",
+		Description: "Example module demonstrating LifecycleInit/Start/Stop",
+		Version:     "0.1.0",
+		Type:        engine.ParseModuleType,
+	}
+}
+
+func (m *noopLifecycleModule) Init(instanceID string, _ map[string]interface{}) error {
+	m.instanceID = instanceID
+	return nil
+}
+
+func (m *noopLifecycleModule) Execute(ctx context.Context, _ map[string]interface{}, _ chan<- engine.ModuleOutput) error {
+	// No-op
+	_ = ctx
+	return nil
+}
+
+// Implement ModuleLifecycle
+func (m *noopLifecycleModule) LifecycleInit(ctx context.Context) error {
+	log.Info().Str("component", "noop-lifecycle").Str("instance", m.instanceID).Msg("LifecycleInit")
+	_ = ctx
+	return nil
+}
+
+func (m *noopLifecycleModule) LifecycleStart(ctx context.Context) error {
+	log.Info().Str("component", "noop-lifecycle").Str("instance", m.instanceID).Msg("LifecycleStart")
+	_ = ctx
+	return nil
+}
+
+func (m *noopLifecycleModule) LifecycleStop(ctx context.Context) error {
+	log.Info().Str("component", "noop-lifecycle").Str("instance", m.instanceID).Msg("LifecycleStop")
+	_ = ctx
+	return nil
+}
+
+// Register the module factory at init time.
+func init() { //nolint:gochecknoinits // simple registration
+	engine.RegisterModuleFactory("noop-lifecycle", func() engine.Module { return &noopLifecycleModule{} })
+}

--- a/pkg/modules/parse/noop_lifecycle_test.go
+++ b/pkg/modules/parse/noop_lifecycle_test.go
@@ -1,0 +1,72 @@
+package parse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pentora-ai/pentora/pkg/engine"
+)
+
+func TestNoopLifecycle_FullCoverage(t *testing.T) {
+	factory := func() engine.Module { return &noopLifecycleModule{} }
+	modIface := factory()
+	mod, ok := modIface.(*noopLifecycleModule)
+	if !ok {
+		t.Fatalf("expected *noopLifecycleModule, got %T", modIface)
+	}
+
+	// ---- Metadata ----
+	meta := mod.Metadata()
+	if meta.ID != "noop-lifecycle" {
+		t.Errorf("expected ID noop-lifecycle, got %s", meta.ID)
+	}
+	if meta.Name != "noop-lifecycle" {
+		t.Errorf("expected Name noop-lifecycle, got %s", meta.Name)
+	}
+	if meta.Description == "" {
+		t.Errorf("expected non-empty Description")
+	}
+	if meta.Version != "0.1.0" {
+		t.Errorf("expected Version 0.1.0, got %s", meta.Version)
+	}
+	if meta.Type != engine.ParseModuleType {
+		t.Errorf("unexpected Type: %v", meta.Type)
+	}
+
+	// ---- Init ----
+	err := mod.Init("abc123", nil)
+	if err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if mod.instanceID != "abc123" {
+		t.Errorf("expected instanceID abc123, got %s", mod.instanceID)
+	}
+
+	// ---- Execute ----
+	ctx := context.Background()
+	if err := mod.Execute(ctx, nil, nil); err != nil {
+		t.Errorf("Execute returned error: %v", err)
+	}
+
+	// ---- Lifecycle ----
+	if err := mod.LifecycleInit(ctx); err != nil {
+		t.Errorf("LifecycleInit returned error: %v", err)
+	}
+	if err := mod.LifecycleStart(ctx); err != nil {
+		t.Errorf("LifecycleStart returned error: %v", err)
+	}
+	if err := mod.LifecycleStop(ctx); err != nil {
+		t.Errorf("LifecycleStop returned error: %v", err)
+	}
+}
+
+// TestNoopLifecycle_FactoryRegistration simply ensures RegisterModuleFactory can be called without panic.
+func TestNoopLifecycle_FactoryRegistration(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RegisterModuleFactory should not panic: %v", r)
+		}
+	}()
+
+	engine.RegisterModuleFactory("noop-lifecycle", func() engine.Module { return &noopLifecycleModule{} })
+}


### PR DESCRIPTION
This PR introduces an optional ModuleLifecycle (LifecycleInit/Start/Stop) and wires it into the Orchestrator.

Highlights
- Optional, backward compatible lifecycle
- Orchestrator calls LifecycleInit at instantiation, LifecycleStart before Execute, and LifecycleStop in reverse order after run (5s timeout, best-effort)
- Unit tests validate ordering and start-failure handling
- Adds a noop-lifecycle module demonstrating the lifecycle hooks

Rationale
- Improves orchestrator maturity: deterministic setup/teardown, resource hygiene
- Keeps existing Module API unchanged; modules opt-in as needed

Validation
- make test && make validate passing

Next
- Optional: per-module stop timeout, integration test with goroutine leak check

