### PR TITLE
feat(engine): typed DataContext schema + generic helpers (Iteration 1 for #137)

### DIFF
--- a/pkg/engine/datacontext.go
+++ b/pkg/engine/datacontext.go
@@ -1,0 +1,214 @@
+package engine
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// Cardinality mirrors DataCardinality but as an internal enum for schema storage.
+// We reuse DataCardinality string values from module.go to avoid duplication.
+type Cardinality = DataCardinality
+
+// dataKeySchema stores expected type and cardinality for a key.
+type dataKeySchema struct {
+	typ         reflect.Type
+	cardinality Cardinality
+}
+
+// DataContext provides typed accessors with a schema for runtime validation.
+type DataContext struct {
+	mu     sync.RWMutex
+	schema map[string]dataKeySchema
+	data   map[string]interface{}
+}
+
+// Expose RLock/RUnlock to satisfy legacy tests expecting embedded RWMutex methods.
+func (dc *DataContext) RLock()   { dc.mu.RLock() }
+func (dc *DataContext) RUnlock() { dc.mu.RUnlock() }
+
+func NewDataContext() *DataContext {
+	return &DataContext{
+		schema: make(map[string]dataKeySchema),
+		data:   make(map[string]interface{}),
+	}
+}
+
+// --- Legacy-compatible helpers used by orchestrator (to keep build green) ---
+
+// SetInitial stores an initial input value directly, overwriting if exists.
+// Note: Does not validate against schema; reserved for bootstrap paths.
+func (dc *DataContext) SetInitial(key string, value interface{}) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	dc.data[key] = value
+}
+
+// AddOrAppendToList appends to a list value, promoting existing non-list to list when necessary.
+func (dc *DataContext) AddOrAppendToList(key string, value interface{}) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if existing, ok := dc.data[key]; ok {
+		if list, ok := existing.([]interface{}); ok {
+			dc.data[key] = append(list, value)
+		} else {
+			dc.data[key] = []interface{}{existing, value}
+		}
+	} else {
+		dc.data[key] = []interface{}{value}
+	}
+}
+
+// Set is a legacy alias for AddOrAppendToList, preserved for tests.
+func (dc *DataContext) Set(key string, value interface{}) { dc.AddOrAppendToList(key, value) }
+
+// Get returns untyped value and found flag (legacy accessor).
+func (dc *DataContext) Get(key string) (interface{}, bool) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	v, ok := dc.data[key]
+	return v, ok
+}
+
+// GetAll returns a shallow copy of the internal map (legacy accessor).
+func (dc *DataContext) GetAll() map[string]interface{} {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	out := make(map[string]interface{}, len(dc.data))
+	for k, v := range dc.data {
+		out[k] = v
+	}
+	return out
+}
+
+// Register declares a key with expected type T and cardinality.
+// RegisterType declares a key with expected reflect.Type and cardinality.
+func (dc *DataContext) RegisterType(key string, typ reflect.Type, card Cardinality) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if typ == nil {
+		return fmt.Errorf("nil type for key %s", key)
+	}
+	dc.schema[key] = dataKeySchema{typ: typ, cardinality: card}
+	return nil
+}
+
+// PublishValue sets the entire value for a key (CardinalitySingle) with runtime validation.
+func (dc *DataContext) PublishValue(key string, value interface{}) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	sch, ok := dc.schema[key]
+	if !ok {
+		return fmt.Errorf("key not registered: %s", key)
+	}
+	if sch.cardinality != CardinalitySingle {
+		return fmt.Errorf("key %s is not CardinalitySingle", key)
+	}
+	if err := dc.checkTypeLocked(sch, value); err != nil {
+		return err
+	}
+	dc.data[key] = value
+	return nil
+}
+
+// AppendValue adds a single item for list cardinality keys. The stored value becomes a slice.
+func (dc *DataContext) AppendValue(key string, item interface{}) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	sch, ok := dc.schema[key]
+	if !ok {
+		return fmt.Errorf("key not registered: %s", key)
+	}
+	if sch.cardinality != CardinalityList {
+		return fmt.Errorf("key %s is not CardinalityList", key)
+	}
+	// For list, schema type is []T. Accept either first append to create []T or append to existing []T.
+	// Build a new slice of the expected element type.
+	// Validate by comparing against schema typ for []T.
+	// Derive []T type from schema.typ.
+	expected := sch.typ // expected is a slice type, e.g., []T
+	// Ensure stored value is a slice of expected element type.
+	cur, exists := dc.data[key]
+	if !exists {
+		// Initialize new slice with item
+		slice := reflect.MakeSlice(expected, 0, 1)
+		slice = reflect.Append(slice, reflect.ValueOf(item))
+		dc.data[key] = slice.Interface()
+		return nil
+	}
+	rv := reflect.ValueOf(cur)
+	if rv.Type() != expected {
+		return fmt.Errorf("type mismatch for key %s: expected %s, got %s", key, expected, rv.Type())
+	}
+	dc.data[key] = reflect.Append(rv, reflect.ValueOf(item)).Interface()
+	return nil
+}
+
+// GetValue returns the stored value for a key with validation against schema type.
+func (dc *DataContext) GetValue(key string) (interface{}, error) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	sch, ok := dc.schema[key]
+	if !ok {
+		return nil, fmt.Errorf("key not registered: %s", key)
+	}
+	v, ok := dc.data[key]
+	if !ok {
+		return nil, fmt.Errorf("key has no value: %s", key)
+	}
+	// Validate type
+	if err := dc.checkTypeLocked(sch, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (dc *DataContext) checkTypeLocked(sch dataKeySchema, v interface{}) error {
+	vt := reflect.TypeOf(v)
+	if vt == nil { // allow nil set only if expected is a pointer/interface
+		if sch.typ.Kind() != reflect.Interface && sch.typ.Kind() != reflect.Pointer && sch.typ.Kind() != reflect.Slice && sch.typ.Kind() != reflect.Map {
+			return fmt.Errorf("type mismatch: expected %s, got <nil>", sch.typ)
+		}
+		return nil
+	}
+	if vt != sch.typ {
+		return fmt.Errorf("type mismatch: expected %s, got %s", sch.typ, vt)
+	}
+	return nil
+}
+
+// ---------- Generic helper functions (package-level, not methods) ----------
+
+// Register registers schema with type parameter by forwarding to RegisterType.
+func Register[T any](dc *DataContext, key string, card Cardinality) error {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t == nil {
+		t = reflect.TypeOf((*T)(nil)).Elem()
+	}
+	return dc.RegisterType(key, t, card)
+}
+
+// Publish publishes a typed value using runtime validation.
+func Publish[T any](dc *DataContext, key string, value T) error {
+	return dc.PublishValue(key, value)
+}
+
+// Append appends a typed item to a list key.
+func Append[T any](dc *DataContext, key string, item T) error {
+	return dc.AppendValue(key, item)
+}
+
+// Get retrieves a typed value with a type assertion after validation.
+func Get[T any](dc *DataContext, key string) (T, error) {
+	var zero T
+	v, err := dc.GetValue(key)
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := v.(T)
+	if !ok {
+		return zero, fmt.Errorf("type assertion failed for key %s", key)
+	}
+	return typed, nil
+}

--- a/pkg/engine/datacontext_test.go
+++ b/pkg/engine/datacontext_test.go
@@ -1,0 +1,178 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testProfile struct{ ID string }
+
+func TestDataContext_RegisterPublishGet_Single(t *testing.T) {
+	dc := NewDataContext()
+	if err := Register[[]string](dc, "config.targets", CardinalitySingle); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if err := Publish(dc, "config.targets", []string{"10.0.0.0/24"}); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+	got, err := Get[[]string](dc, "config.targets")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != "10.0.0.0/24" {
+		t.Fatalf("unexpected value: %#v", got)
+	}
+}
+
+func TestDataContext_RegisterAppendGet_List(t *testing.T) {
+	dc := NewDataContext()
+	// For list, register expected stored type as []testProfile
+	if err := Register[[]testProfile](dc, "asset.profiles", CardinalityList); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if err := Append(dc, "asset.profiles", testProfile{ID: "a"}); err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+	if err := Append(dc, "asset.profiles", testProfile{ID: "b"}); err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+	got, err := Get[[]testProfile](dc, "asset.profiles")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("unexpected list: %#v", got)
+	}
+}
+
+func TestDataContext_TypeMismatch(t *testing.T) {
+	dc := NewDataContext()
+	if err := Register[[]string](dc, "config.targets", CardinalitySingle); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	// wrong type
+	if err := Publish(dc, "config.targets", "not-a-slice"); err == nil {
+		t.Fatalf("expected type mismatch error")
+	}
+}
+
+func TestRegisterType_NilTypeError(t *testing.T) {
+	dc := NewDataContext()
+	err := dc.RegisterType("nil.key", nil, CardinalitySingle)
+	if err == nil {
+		t.Fatal("expected error for nil type")
+	}
+}
+
+func TestPublishValue_Errors(t *testing.T) {
+	dc := NewDataContext()
+	// Unregistered key
+	err := dc.PublishValue("unreg", "x")
+	if err == nil {
+		t.Fatal("expected error for unregistered key")
+	}
+
+	// Wrong cardinality
+	_ = dc.RegisterType("key.list", reflect.TypeOf([]string{}), CardinalityList)
+	err = dc.PublishValue("key.list", []string{"a"})
+	if err == nil {
+		t.Fatal("expected error for wrong cardinality")
+	}
+
+	// Type mismatch
+	_ = dc.RegisterType("key.single", reflect.TypeOf([]string{}), CardinalitySingle)
+	err = dc.PublishValue("key.single", "not-a-slice")
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+}
+
+func TestAppendValue_Errors(t *testing.T) {
+	dc := NewDataContext()
+	// Unregistered key
+	err := dc.AppendValue("missing", "item")
+	if err == nil {
+		t.Fatal("expected error for unregistered key")
+	}
+
+	// Wrong cardinality
+	_ = dc.RegisterType("single.key", reflect.TypeOf("string"), CardinalitySingle)
+	err = dc.AppendValue("single.key", "item")
+	if err == nil {
+		t.Fatal("expected error for non-list key")
+	}
+
+	// Type mismatch on existing slice
+	_ = dc.RegisterType("list.key", reflect.TypeOf([]string{}), CardinalityList)
+	dc.data["list.key"] = []int{1}
+	err = dc.AppendValue("list.key", "item")
+	if err == nil {
+		t.Fatal("expected type mismatch for slice element type")
+	}
+}
+
+func TestGetValue_Errors(t *testing.T) {
+	dc := NewDataContext()
+	_, err := dc.GetValue("unregistered")
+	if err == nil {
+		t.Fatal("expected error for unregistered key")
+	}
+
+	_ = dc.RegisterType("key", reflect.TypeOf([]string{}), CardinalitySingle)
+	_, err = dc.GetValue("key")
+	if err == nil {
+		t.Fatal("expected error for missing value")
+	}
+
+	dc.data["key"] = "wrong-type"
+	_, err = dc.GetValue("key")
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+}
+
+func TestCheckTypeLocked_AllPaths(t *testing.T) {
+	dc := NewDataContext()
+	sch := dataKeySchema{typ: reflect.TypeOf(""), cardinality: CardinalitySingle}
+
+	// nil value with non-interface/pointer should error
+	err := dc.checkTypeLocked(sch, nil)
+	if err == nil {
+		t.Fatal("expected error for nil value with non-pointer type")
+	}
+
+	// type mismatch
+	err = dc.checkTypeLocked(sch, 123)
+	if err == nil {
+		t.Fatal("expected type mismatch")
+	}
+
+	// correct type
+	err = dc.checkTypeLocked(sch, "ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGenericHelpers_Get_TypeAssertionFail(t *testing.T) {
+	dc := NewDataContext()
+	_ = dc.RegisterType("key", reflect.TypeOf([]string{}), CardinalitySingle)
+	_ = dc.PublishValue("key", []string{"a"})
+	_, err := Get[string](dc, "key")
+	if err == nil {
+		t.Fatal("expected type assertion failure")
+	}
+}
+
+func TestAddOrAppendToList_PromoteAndGetAll(t *testing.T) {
+	dc := NewDataContext()
+	dc.SetInitial("direct.key", "x")
+	dc.AddOrAppendToList("direct.key", "y")
+	got, ok := dc.Get("direct.key")
+	require.True(t, ok)
+	require.Equal(t, []interface{}{"x", "y"}, got)
+	all := dc.GetAll()
+	require.Contains(t, all, "direct.key")
+}


### PR DESCRIPTION
feat(engine): typed DataContext schema + generic helpers (Iteration 1 for #137)

Introduce a schema-backed DataContext with runtime validation and package-level generic helpers, while preserving the legacy API to keep the orchestrator and tests green.

Changes:
- New: `pkg/engine/datacontext.go` (RegisterType/PublishValue/AppendValue/GetValue + helpers Register/Publish/Append/Get)
- Legacy compatibility: SetInitial, AddOrAppendToList, Get, GetAll, Set, and RLock/RUnlock wrappers
- Tests: `pkg/engine/datacontext_test.go` covers single publish/get, list append/get, and mismatch
- Formatted via gofumpt

Rationale:
- Avoid method-level generics (tooling/build constraints); keep backward compatibility to minimize blast radius.

Validation:
- `make test` (unit) on changed packages
- `make lint`: 0 issues

Next:
- Register/validate `config.targets` and `asset.profiles` via helpers
- Add a small orchestrator adapter test for the typed validation path

Refs: #137
