### PR TITLE
fix(api): update validation tests for cursor-based pagination

### DIFF
--- a/pkg/server/api/v1/validation_test.go
+++ b/pkg/server/api/v1/validation_test.go
@@ -24,7 +24,7 @@ func TestValidation_ParseListScansQuery_OK_Defaults(t *testing.T) {
 	got, err := ParseListScansQuery(r)
 	assert.NoError(t, err)
 	assert.Equal(t, 50, got.Limit)
-	assert.Equal(t, 0, got.Offset)
+	assert.Equal(t, "", got.Cursor)
 	assert.Equal(t, "", got.Status)
 }
 
@@ -32,13 +32,13 @@ func TestValidation_ParseListScansQuery_AllValid(t *testing.T) {
 	r := newRequestWithQuery(map[string]string{
 		"status": "pending",
 		"limit":  "10",
-		"offset": "2",
+		"cursor": "eyJpZCI6InNjYW4tMTIzIiwidHMiOjE3MzA1NTI0MDAwMDAwMDAwMDB9",
 	})
 	got, err := ParseListScansQuery(r)
 	assert.NoError(t, err)
 	assert.Equal(t, "pending", got.Status)
 	assert.Equal(t, 10, got.Limit)
-	assert.Equal(t, 2, got.Offset)
+	assert.Equal(t, "eyJpZCI6InNjYW4tMTIzIiwidHMiOjE3MzA1NTI0MDAwMDAwMDAwMDB9", got.Cursor)
 }
 
 func TestValidation_ParseListScansQuery_InvalidStatus(t *testing.T) {
@@ -59,13 +59,6 @@ func TestValidation_ParseListScansQuery_InvalidLimit(t *testing.T) {
 
 func TestValidation_ParseListScansQuery_LimitOutOfRange(t *testing.T) {
 	r := newRequestWithQuery(map[string]string{"limit": "101"})
-	got, err := ParseListScansQuery(r)
-	assert.Nil(t, got)
-	assert.Error(t, err)
-}
-
-func TestValidation_ParseListScansQuery_InvalidOffset(t *testing.T) {
-	r := newRequestWithQuery(map[string]string{"offset": "-1"})
 	got, err := ParseListScansQuery(r)
 	assert.Nil(t, got)
 	assert.Error(t, err)


### PR DESCRIPTION
## Problem

After PR #144 (cursor-based pagination) was merged, GitHub Actions CI failed with compilation errors:

```
pkg/server/api/v1/validation_test.go:27:25: got.Offset undefined (type *ListScansQuery has no field or method Offset)
pkg/server/api/v1/validation_test.go:41:25: got.Offset undefined (type *ListScansQuery has no field or method Offset)
```

**Root Cause:** PR #144 changed `ListScansQuery` struct from `Offset` to `Cursor`, but `validation_test.go` wasn't updated in the squash merge.

## Changes

- ✅ Replace `got.Offset` with `got.Cursor` in test assertions
- ✅ Update test data to use base64-encoded cursor instead of numeric offset
- ✅ Remove deprecated `TestValidation_ParseListScansQuery_InvalidOffset` test

## Testing

```bash
make test && make validate
```

All tests pass locally and pre-commit hooks pass.

## Fixes

Resolves CI failure caused by PR #144 merge.