### PR TITLE
feat(cli/plugin): DRY global flags + output validation

### DIFF
--- a/cmd/pentora/commands/plugin/clean.go
+++ b/cmd/pentora/commands/plugin/clean.go
@@ -41,9 +41,6 @@ Use --dry-run to preview what would be deleted without actually deleting.`,
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
 	cmd.Flags().Bool("dry-run", false, "Preview what would be deleted without actually deleting")
 	cmd.Flags().String("older-than", "720h", "Remove cache entries older than this duration (e.g., 720h for 30 days)")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/embedded.go
+++ b/cmd/pentora/commands/plugin/embedded.go
@@ -73,9 +73,6 @@ for common security issues across SSH, HTTP, TLS, Database, and Network protocol
 
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information")
 	cmd.Flags().StringVar(&category, "category", "", "Filter by category (ssh, http, tls, database, network, misc)")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/info.go
+++ b/cmd/pentora/commands/plugin/info.go
@@ -37,9 +37,6 @@ installation path, and cache size.`,
 	}
 
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/install.go
+++ b/cmd/pentora/commands/plugin/install.go
@@ -49,9 +49,6 @@ You can install entire categories (ssh, http, tls, database, network) or specifi
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
 	cmd.Flags().String("source", "", "Install from specific source (e.g., 'official')")
 	cmd.Flags().Bool("force", false, "Force re-install even if already cached")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/list.go
+++ b/cmd/pentora/commands/plugin/list.go
@@ -43,9 +43,6 @@ found in the plugin cache directory.`,
 
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/root.go
+++ b/cmd/pentora/commands/plugin/root.go
@@ -6,6 +6,8 @@ package plugin
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/pentora-ai/pentora/cmd/pentora/internal/format"
 )
 
 // NewCommand creates the plugin command with all subcommands.
@@ -37,7 +39,17 @@ Use these commands to list, inspect, verify, and maintain your plugin cache.`,
 
   # Clean unused cache entries
   pentora plugin clean`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate global --output once for all subcommands
+			output, _ := cmd.Flags().GetString("output")
+			return format.ValidateMode(output)
+		},
 	}
+
+	// Global flags inherited by subcommands
+	cmd.PersistentFlags().String("output", "table", "Output format: json, table")
+	cmd.PersistentFlags().Bool("quiet", false, "Suppress non-essential output")
+	cmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
 
 	// Add subcommands
 	cmd.AddCommand(newListCommand())

--- a/cmd/pentora/commands/plugin/uninstall.go
+++ b/cmd/pentora/commands/plugin/uninstall.go
@@ -51,9 +51,6 @@ all plugins in a category, or all plugins at once.`,
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
 	cmd.Flags().Bool("all", false, "Uninstall all plugins")
 	cmd.Flags().String("category", "", "Uninstall all plugins from category (ssh, http, tls, database, network)")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/update.go
+++ b/cmd/pentora/commands/plugin/update.go
@@ -50,9 +50,6 @@ new or updated plugins to the local cache. By default, it downloads all core plu
 	cmd.Flags().String("category", "", "Download only plugins from category (ssh, http, tls, database, network)")
 	cmd.Flags().Bool("dry-run", false, "Show what would be downloaded without downloading")
 	cmd.Flags().Bool("force", false, "Force re-download even if already cached")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }

--- a/cmd/pentora/commands/plugin/verify.go
+++ b/cmd/pentora/commands/plugin/verify.go
@@ -43,9 +43,6 @@ Exit codes:
 
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Plugin cache directory (default: platform-specific, see storage config)")
 	cmd.Flags().String("plugin", "", "Verify specific plugin by name")
-	cmd.Flags().String("output", "table", "Output format: json, table")
-	cmd.Flags().Bool("quiet", false, "Suppress non-essential output")
-	cmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	return cmd
 }


### PR DESCRIPTION
This refactors plugin CLI to define shared flags at the plugin root and validates output mode once per invocation.

Changes
- Add PersistentFlags to plugin root: --output, --quiet, --no-color
- Add PersistentPreRunE to validate --output via format.ValidateMode
- Remove duplicated flag definitions from subcommands (list, install, update, uninstall, info, verify, clean, embedded)

Why
- DRY: remove repeated flag definitions across 8 subcommands
- Early validation: invalid --output fails fast with a clear message
- Consistency & maintainability: single source of truth for shared flags

Validation
- make validate: passed
- go test ./cmd/pentora/...: passed

Refs: #91