### PR TITLE
docs(api,plugin): document DTO Evolution Policy (refs #92)

### DIFF
--- a/pkg/plugin/service_types.go
+++ b/pkg/plugin/service_types.go
@@ -6,6 +6,29 @@ package plugin
 
 import "time"
 
+// DTO Evolution Policy
+//
+// These types form the public API contract used by CLI, HTTP API, and future gRPC.
+// To avoid breaking existing clients, follow these rules:
+//
+// 1. Additive-only changes:
+//    - You MAY add new optional fields
+//    - You MAY NOT remove or rename existing fields
+//    - Breaking changes require a new API version (v2)
+//
+// 2. Zero-value semantics:
+//    - New fields MUST have safe zero-value behavior
+//    - Zero-value MUST preserve existing behavior
+//    - Use `omitempty` for optional JSON fields
+//
+// 3. Examples:
+//    ✓ Adding `Timeout time.Duration` (zero = no timeout, preserves old behavior)
+//    ✓ Adding `Tags []string \`json:"tags,omitempty"\`` (zero = empty, backward compatible)
+//    ✗ Removing `Force bool` (old clients still send it)
+//    ✗ Making an optional field required (old clients don't send it)
+//
+// See Issue #92 for background and rationale.
+
 // Service layer types for plugin operations
 // These types are used by the service layer to abstract business logic
 // from the CMD and API layers.

--- a/pkg/server/api/errors.go
+++ b/pkg/server/api/errors.go
@@ -11,6 +11,15 @@ import (
 	"github.com/pentora-ai/pentora/pkg/storage"
 )
 
+// Note on API Error DTOs and Evolution Policy
+//
+// The JSON error payloads produced here (error, code, message, etc.) are part of the
+// public API contract. Apply the DTO Evolution Policy:
+// - Additive-only: add optional fields; do not remove/rename existing fields
+// - Zero-value semantics: new fields must have safe zero-values; prefer `omitempty`
+// - Breaking changes should be introduced under a new API version (v2)
+// See Issue #92 for background.
+
 // ErrorResponse represents a standard JSON error response.
 // Used consistently across all API endpoints for error responses.
 //

--- a/pkg/server/api/v1/plugins.go
+++ b/pkg/server/api/v1/plugins.go
@@ -13,6 +13,26 @@ import (
 	"github.com/pentora-ai/pentora/pkg/server/api"
 )
 
+// DTO Evolution Policy
+//
+// These request/response DTOs are part of the public API contract used by CLI and HTTP API clients.
+// To evolve them safely without breaking existing clients:
+//
+// 1) Additive-only changes
+//    - You MAY add new optional fields
+//    - You MAY NOT remove or rename existing fields
+//    - Breaking changes require a new API version (v2)
+//
+// 2) Zero-value semantics
+//    - New fields MUST have safe zero-value behavior
+//    - Use `omitempty` for optional JSON fields to preserve old behavior
+//
+// 3) Examples
+//    ✓ Add `Tags []string \`json:"tags,omitempty"\`` (backward compatible)
+//    ✗ Remove or rename existing fields (breaks older clients)
+//
+// See Issue #92 for context and rationale.
+
 // formatSourceList formats a string slice as a comma-separated list.
 // Helper function for generating user-friendly error messages.
 func formatSourceList(items []string) string {

--- a/pkg/server/api/v1/scans.go
+++ b/pkg/server/api/v1/scans.go
@@ -9,6 +9,26 @@ import (
 	"github.com/pentora-ai/pentora/pkg/storage"
 )
 
+// DTO Evolution Policy
+//
+// The request/response payloads handled in this file are part of the public API
+// contract. To evolve them safely without breaking existing clients:
+//
+// 1) Additive-only changes
+//    - You MAY add new optional fields
+//    - You MAY NOT remove or rename existing fields
+//    - Breaking changes require a new API version (v2)
+//
+// 2) Zero-value semantics
+//    - New fields MUST have safe zero-value behavior
+//    - Prefer `omitempty` for optional JSON fields to preserve old behavior
+//
+// 3) Examples
+//    ✓ Add `Tags []string \`json:"tags,omitempty"\`` (backward compatible)
+//    ✗ Remove or rename existing fields (breaks older clients)
+//
+// See Issue #92 for context and rationale.
+
 // ListScansHandler handles GET /api/v1/scans
 //
 // Returns paginated scan metadata with cursor-based pagination for scalability.


### PR DESCRIPTION
Adds DTO Evolution Policy comment blocks to public-contract types:

- pkg/plugin/service_types.go (service layer DTOs)
- pkg/server/api/v1/plugins.go (plugin API DTOs)
- pkg/server/api/v1/scans.go (scans API DTOs)
- pkg/server/api/errors.go (API error DTO note)

Policy: additive-only changes, safe zero-value semantics, and v2 for breaking changes.

All tests and validation pass.

Refs: #92