### PR TITLE
feat(fingerprint): Schema + Helpers for rule-based resolver (Phase 1)

### DIFF
--- a/pkg/fingerprint/resolver_helpers.go
+++ b/pkg/fingerprint/resolver_helpers.go
@@ -1,0 +1,75 @@
+package fingerprint
+
+import (
+	"regexp"
+	"strings"
+)
+
+// isHardRejected returns true if any exclude pattern matches the banner.
+func isHardRejected(banner string, exclude []*regexp.Regexp) bool {
+	if len(exclude) == 0 {
+		return false
+	}
+	for _, rx := range exclude {
+		if rx.MatchString(banner) {
+			return true
+		}
+	}
+	return false
+}
+
+// softExcludePenalty returns cumulative penalty based on soft-exclude matches.
+// Each match applies the provided perMatchPenalty (e.g., 0.20).
+func softExcludePenalty(banner string, soft []*regexp.Regexp, perMatchPenalty float64) float64 {
+	if len(soft) == 0 || perMatchPenalty <= 0 {
+		return 0
+	}
+	penalty := 0.0
+	for _, rx := range soft {
+		if rx.MatchString(banner) {
+			penalty += perMatchPenalty
+		}
+	}
+	if penalty < 0 {
+		return 0
+	}
+	if penalty > 1 {
+		return 1
+	}
+	return penalty
+}
+
+// calculateConfidence computes a confidence score based on pattern strength,
+// soft-exclude penalties, and optional port bonuses.
+func calculateConfidence(base float64, softPenalty float64, portBonus float64) float64 {
+	conf := base - softPenalty + portBonus
+	if conf < 0 {
+		conf = 0
+	}
+	if conf > 1 {
+		conf = 1
+	}
+	return conf
+}
+
+// sigmoid maps a value to (0,1) range; can be used to smooth scores.
+// sigmoid is currently unused; keep it for Phase 2 when scoring smoothing is introduced.
+// Temporarily comment out to satisfy lint until used.
+// func sigmoid(x float64) float64 {
+//     return x
+// }
+
+// normalizeVersion trims and lowercases a version-like string.
+func normalizeVersion(s string) string {
+	return strings.TrimSpace(strings.ToLower(s))
+}
+
+// containsInt checks if a target port is present in a slice.
+func containsPort(ports []int, p int) bool {
+	for _, v := range ports {
+		if v == p {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/fingerprint/resolver_helpers_test.go
+++ b/pkg/fingerprint/resolver_helpers_test.go
@@ -1,0 +1,86 @@
+package fingerprint
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestIsHardRejected(t *testing.T) {
+	banner := "server: myapp version 1.2.3 (test build)"
+	rx := []*regexp.Regexp{regexp.MustCompile(`test build`)}
+	if !isHardRejected(banner, rx) {
+		t.Fatalf("expected hard reject when pattern matches")
+	}
+	if isHardRejected(banner, []*regexp.Regexp{regexp.MustCompile(`nope`)}) {
+		t.Fatalf("did not expect hard reject for non-matching pattern")
+	}
+}
+
+func TestSoftExcludePenalty(t *testing.T) {
+	banner := "server: foo test build; debug mode"
+	soft := []*regexp.Regexp{
+		regexp.MustCompile(`test build`),
+		regexp.MustCompile(`debug`),
+		regexp.MustCompile(`nope`),
+	}
+	p := softExcludePenalty(banner, soft, 0.20)
+	if p <= 0 {
+		t.Fatalf("expected positive penalty, got %v", p)
+	}
+	if p < 0.39 || p > 0.41 { // two matches ~ 0.40
+		t.Fatalf("expected ~0.40 penalty, got %v", p)
+	}
+}
+
+func TestCalculateConfidence(t *testing.T) {
+	// base 0.8 - 0.4 + 0.1 = 0.5
+	if got := calculateConfidence(0.8, 0.4, 0.1); got < 0.49 || got > 0.51 {
+		t.Fatalf("expected ~0.5, got %v", got)
+	}
+	// clamp low
+	if got := calculateConfidence(0.1, 0.5, 0.0); got != 0 {
+		t.Fatalf("expected clamp to 0, got %v", got)
+	}
+	// clamp high
+	if got := calculateConfidence(0.9, 0.0, 0.2); got != 1 {
+		t.Fatalf("expected clamp to 1, got %v", got)
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	if got := normalizeVersion("  V1.2.3 "); got != "v1.2.3" {
+		t.Fatalf("expected 'v1.2.3', got %q", got)
+	}
+	if got := normalizeVersion("\t 1.0.0-RC \n"); got != "1.0.0-rc" {
+		t.Fatalf("expected '1.0.0-rc', got %q", got)
+	}
+}
+
+func TestContainsPort(t *testing.T) {
+	ports := []int{22, 80, 443}
+	if !containsPort(ports, 80) {
+		t.Fatalf("expected to contain 80")
+	}
+	if containsPort(ports, 21) {
+		t.Fatalf("did not expect to contain 21")
+	}
+}
+
+func TestSoftExcludePenalty_NoPatternsOrZeroPenalty(t *testing.T) {
+	if p := softExcludePenalty("anything", nil, 0.20); p != 0 {
+		t.Fatalf("expected 0 with nil patterns, got %v", p)
+	}
+	rx := []*regexp.Regexp{regexp.MustCompile(`match`)}
+	if p := softExcludePenalty("match", rx, 0.0); p != 0 {
+		t.Fatalf("expected 0 with zero perMatchPenalty, got %v", p)
+	}
+}
+
+func TestCalculateConfidence_ClampEdges(t *testing.T) {
+	if got := calculateConfidence(-0.5, 0.0, 0.0); got != 0 {
+		t.Fatalf("expected clamp to 0, got %v", got)
+	}
+	if got := calculateConfidence(2.0, 0.0, 0.5); got != 1 {
+		t.Fatalf("expected clamp to 1, got %v", got)
+	}
+}

--- a/pkg/fingerprint/resolver_rulebased_test.go
+++ b/pkg/fingerprint/resolver_rulebased_test.go
@@ -1,0 +1,82 @@
+package fingerprint
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPrepareRules_DefaultsAndCompilation(t *testing.T) {
+	rules := []StaticRule{{
+		ID:                  "r1",
+		Protocol:            "http",
+		Match:               `server: myhttp`,
+		VersionExtraction:   `myhttp/(\d+\.\d+\.\d+)`,
+		ExcludePatterns:     []string{`nothttp`},
+		SoftExcludePatterns: []string{`test build`},
+		// PatternStrength intentionally zero to trigger defaulting
+	}}
+
+	out := prepareRules(rules)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(out))
+	}
+	r := out[0]
+
+	if r.PatternStrength < 0.79 || r.PatternStrength > 0.81 {
+		t.Fatalf("expected default PatternStrength ~0.80, got %v", r.PatternStrength)
+	}
+	if r.matchRegex == nil {
+		t.Fatalf("expected matchRegex compiled")
+	}
+	if r.versionRegex == nil {
+		t.Fatalf("expected versionRegex compiled")
+	}
+	if len(r.excludeRegex) != 1 || len(r.softExRegex) != 1 {
+		t.Fatalf("expected compiled exclude and soft-exclude regexes, got %d/%d", len(r.excludeRegex), len(r.softExRegex))
+	}
+}
+
+func TestResolve_BackwardCompatibility(t *testing.T) {
+	// Ensure existing behavior still works with new fields present but unused
+	rules := []StaticRule{{
+		ID:                "r1",
+		Protocol:          "http",
+		Product:           "MyHTTP",
+		Vendor:            "Acme",
+		CPE:               "cpe:/a:acme:myhttp",
+		Match:             `server: myhttp`,
+		VersionExtraction: `myhttp/(\d+\.\d+\.\d+)`,
+		// New fields left empty to avoid affecting current Resolve()
+	}}
+	rb := NewRuleBasedResolver(rules)
+
+	res, err := rb.Resolve(context.TODO(), Input{Protocol: "http", Banner: "Server: MyHTTP myhttp/1.2.3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Product != "MyHTTP" || res.Vendor != "Acme" || res.Version != "1.2.3" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.Confidence != 1.0 {
+		t.Fatalf("expected confidence 1.0, got %v", res.Confidence)
+	}
+}
+
+func TestPrepareRules_EmptyAndNoVersionRegex(t *testing.T) {
+	rules := []StaticRule{{
+		ID:       "r2",
+		Protocol: "ssh",
+		Match:    `^ssh-2.0-`,
+		// no VersionExtraction
+	}}
+	out := prepareRules(rules)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(out))
+	}
+	if out[0].versionRegex != nil {
+		t.Fatalf("expected nil versionRegex when VersionExtraction is empty")
+	}
+	if out[0].matchRegex == nil {
+		t.Fatalf("expected matchRegex compiled")
+	}
+}

--- a/pkg/server/api/v1/validation.go
+++ b/pkg/server/api/v1/validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+
 	"github.com/pentora-ai/pentora/pkg/plugin"
 )
 

--- a/pkg/server/api/v1/validation_test.go
+++ b/pkg/server/api/v1/validation_test.go
@@ -5,8 +5,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pentora-ai/pentora/pkg/plugin"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pentora-ai/pentora/pkg/plugin"
 )
 
 // --- helper for request ---


### PR DESCRIPTION
## Problem
Resolver refactor needs foundational schema and helpers for anti-patterns, dynamic confidence, and binary verification.

## Changes
- Extend StaticRule with exclude_patterns, soft_exclude_patterns
- Add pattern_strength (default 0.80), port_bonuses
- Add binary_min_length, binary_magic
- prepareRules(): compile match/version and exclude/soft-exclude regex; default pattern_strength
- New resolver_helpers.go: isHardRejected, softExcludePenalty, calculateConfidence, normalizeVersion, containsPort (sigmoid reserved for Phase 2)
- Unit tests for helpers and prepareRules + backward-compat Resolve()

## Impact
- No behavioral change yet; Resolve() refactor in PR 2
- Backward compatible with existing rules

## Testing
- go build ./... passes
- go test ./pkg/fingerprint -cover passes (coverage ~90.9%)
- make fmt/lint/test run locally; CI will validate

## Related
Part of #159 (PR 1 of 2)