### PR TITLE
[TEST] fix(ci): add issues:write permission to fingerprint validation workflow

### DIFF
--- a/.github/workflows/validate-fingerprints.yaml
+++ b/.github/workflows/validate-fingerprints.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/pkg/fingerprint/testdata/README.md
+++ b/pkg/fingerprint/testdata/README.md
@@ -349,3 +349,9 @@ For questions about validation dataset:
 **Last Updated**: 2025-11-04
 **Total Test Cases**: 130 (90 TP, 40 TN, 10 edge)
 **Protocols Covered**: 16 (http, ssh, ftp, mysql, postgresql, redis, mongodb, memcached, elasticsearch, smtp, rdp, vnc, telnet, snmp, smb, dns)
+
+---
+
+## CI/CD Integration
+
+The fingerprint validation workflow automatically runs on every PR that touches `pkg/fingerprint/**`. It compares validation metrics between the PR branch and main baseline, posting results as a PR comment.


### PR DESCRIPTION
## Problem

PR #184 validation workflow was failing with 403 error when trying to post PR comments:

```
RequestError [HttpError]: Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

## Root Cause

The workflow had `pull-requests: write` permission but was missing `issues:write` permission. GitHub API requires **both** permissions to create comments on pull requests (PRs are issues under the hood).

## Solution

Added `issues:write` to the permissions block in `.github/workflows/validate-fingerprints.yaml`:

```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write          # ← Added this
```

## Testing

This is a TEST PR to verify the fix works. The workflow will:
1. Run validation suite on PR branch
2. Run validation suite on main baseline
3. Compare metrics
4. Post metrics diff as PR comment ← **This should work now**

## Security

- `issues: write` is safe - only allows creating/updating issue comments
- Scoped to this specific workflow job only
- No access to repo contents or settings

## Related

- Fixes validation workflow failure in PR #184
- Related to Phase 6: Fingerprint Validation Framework