### PR TITLE
ci(fingerprint): remove PR comment step for fork compatibility

### DIFF
--- a/.github/workflows/validate-fingerprints.yaml
+++ b/.github/workflows/validate-fingerprints.yaml
@@ -34,41 +34,10 @@ jobs:
           git checkout -f FETCH_HEAD
           go test -v ./pkg/fingerprint -run TestValidationRunner 2>&1 | tee baseline.log
 
-      - name: Compare metrics
+      - name: Compare metrics and validate
         run: |
           set -e
-          bash scripts/compare-validation-metrics.sh baseline.log validation.log > metrics_diff.md
-
-      - name: Post metrics diff comment
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PENTORABOT_ISSUE_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('metrics_diff.md', 'utf8');
-            // Create or update a sticky comment identified by a marker
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const marker = '<!-- FINGERPRINT_VALIDATION_SUMMARY -->';
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            const finalBody = `${marker}\n` + body;
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: finalBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: finalBody,
-              });
-            }
+          bash scripts/compare-validation-metrics.sh baseline.log validation.log
+          # Script exits with error status if regressions >5% detected
+          # Metrics output is visible in workflow logs
 

--- a/pkg/fingerprint/testdata/README.md
+++ b/pkg/fingerprint/testdata/README.md
@@ -354,6 +354,4 @@ For questions about validation dataset:
 
 ## CI/CD Integration
 
-The fingerprint validation workflow automatically runs on every PR that touches `pkg/fingerprint/**`. It compares validation metrics between the PR branch and main baseline, posting results as a PR comment.
-
-**Bot Authentication**: The workflow uses `PENTORABOT_ISSUE_TOKEN` secret to post comments as `pentorabot`, which allows it to work with both main repo PRs and fork PRs without permission issues.
+The fingerprint validation workflow automatically runs on every PR that touches `pkg/fingerprint/**`. It compares validation metrics between the PR branch and main baseline, failing the workflow if regressions >5% are detected. Metrics output is visible in the workflow logs.


### PR DESCRIPTION
## Problem

PR #184 and #185 (fork PRs) fail validation because the comment posting step requires repository secrets (`PENTORABOT_ISSUE_TOKEN`), which are **not available to fork PRs** due to GitHub's security policy.

**Previous Fix Attempt (PR #187)**: Used bot token instead of GITHUB_TOKEN, but this didn't solve the fundamental issue - fork PRs still can't access repository secrets.

## Root Cause

GitHub security model:
- `pull_request` event runs in fork's context → no access to base repo secrets
- `pull_request_target` event runs in base repo's context → has secret access BUT security risk (fork code could exfiltrate secrets)

## Solution

**Remove PR comment posting step entirely**:
- ✅ Fork PRs work without secret access
- ✅ Validation still functions correctly (metrics comparison + regression detection)
- ✅ No security risks from `pull_request_target`
- ✅ Metrics visible in workflow logs
- ℹ️ Comment posting deemed "not critical" by maintainers

## Changes

**Workflow Changes** (`.github/workflows/validate-fingerprints.yaml`):
- Removed "Post metrics diff comment" step (lines 42-73)
- Simplified "Compare metrics" step (just runs script, no markdown file generation)
- Script still exits with error if regressions >5% detected

**Documentation Updates** (`pkg/fingerprint/testdata/README.md`):
- Updated CI/CD Integration section
- Removed bot token documentation (no longer needed)
- Clarified that metrics are in workflow logs

## Validation Still Works

The workflow continues to:
1. Run validation on PR branch
2. Run validation on main baseline
3. Compare metrics between branches
4. **Fail the workflow if regressions >5% detected** (via script exit code)
5. Display metrics in workflow logs for manual review

## Testing

After merge:
- Fork PRs (like #184, #185) should pass validation checks
- Main repo PRs continue to work
- Regressions still detected and fail workflow

## Related

- PR #187: Bot token fix (didn't solve fork PR issue)
- PR #186: Permission fix attempt
- PR #184: Fork PR from mirakodes (currently failing)
- PR #185: Fork PR from lukgoph (currently failing)