### PR TITLE
feat(validation): per-protocol metrics and JSON export (Phase 6.6, #179)

### DIFF
--- a/pkg/fingerprint/validation.go
+++ b/pkg/fingerprint/validation.go
@@ -73,6 +73,25 @@ type ValidationMetrics struct {
 	PassPerformance bool `json:"pass_performance"`
 
 	MetricsPassed int `json:"metrics_passed"` // Count of passed metrics (out of 10)
+
+	// Per-protocol breakdown
+	PerProtocol map[string]ProtocolMetrics `json:"per_protocol"`
+}
+
+// ProtocolMetrics represents metrics for a single protocol
+type ProtocolMetrics struct {
+	Protocol          string  `json:"protocol"`
+	TruePositives     int     `json:"true_positives"`
+	FalsePositives    int     `json:"false_positives"`
+	FalseNegatives    int     `json:"false_negatives"`
+	TrueNegatives     int     `json:"true_negatives"`
+	FalsePositiveRate float64 `json:"false_positive_rate"`
+	TruePositiveRate  float64 `json:"true_positive_rate"`
+	Precision         float64 `json:"precision"`
+	F1Score           float64 `json:"f1_score"`
+	TestCases         int     `json:"test_cases"`
+	AvgConfidence     float64 `json:"avg_confidence"`
+	AvgDetectTimeUs   int64   `json:"avg_detection_time_us"`
 }
 
 // ValidationRunner executes validation tests and computes metrics.


### PR DESCRIPTION
## Summary
Add per-protocol metrics to the validation framework to identify protocol-specific accuracy and performance gaps (Phase 6.6, Issue #179). JSON export now includes a `per_protocol` section for downstream analysis and CI surfacing.

## Changes
- ValidationMetrics
  - Add `PerProtocol map[string]ProtocolMetrics` to expose per-protocol metrics in JSON
- ProtocolMetrics
  - New struct with counts (TP/FP/FN/TN), FPR, TPR, Precision, F1, TestCases, AvgConfidence, AvgDetectionTimeUs
- CalculateMetrics
  - Now computes and populates `PerProtocol` via a new helper
- calculateProtocolMetrics
  - Per-protocol aggregation of counts, confidence averages, and timing; derives metric rates using existing pure helpers
- Tests
  - Add `TestCalculateMetrics_PerProtocolBreakdown` to verify counts, averages, and map population

## Impact
- Enables targeted improvements by protocol (e.g., identify protocols with high FPR or low TPR)
- Backward compatible: additive JSON field `per_protocol`; existing consumers unaffected

## Usage
- Programmatic: `metrics.PerProtocol["http"]` → `ProtocolMetrics`
- JSON: `.per_protocol.http.{true_positives, false_positives, ...}`

## Notes
- Confidence averages computed from true positives; timing averages computed from all cases per protocol
- Thresholds remain governed by existing validation targets; this PR only adds breakdowns

## Related
- Issue #179 (Phase 6.6: Per-Protocol Metrics & Analysis)
- Follow-up to PR #176 (Validation & Benchmarking Framework)
