### PR TITLE
feat(fingerprint): add JSON export and configurable thresholds for validation metrics (Issue #178)

### DIFF
--- a/pkg/fingerprint/validation_runner_test.go
+++ b/pkg/fingerprint/validation_runner_test.go
@@ -53,7 +53,10 @@ func TestRunTestCase_Branches(t *testing.T) {
 func TestRun_AggregatesAndTargets(t *testing.T) {
 	// Two cases: one TP (resolver returns match), one TN (resolver returns error)
 	// Return match for http, error for ssh to produce TP and TN
-	r := &ValidationRunner{resolver: stubResolver{res: Result{Product: "nginx", Vendor: "nginx", Version: "", Confidence: 0.8}, err: fmt.Errorf("no matching rule found"), errProto: "ssh"}}
+	r := &ValidationRunner{
+		resolver:   stubResolver{res: Result{Product: "nginx", Vendor: "nginx", Version: "", Confidence: 0.8}, err: fmt.Errorf("no matching rule found"), errProto: "ssh"},
+		thresholds: DefaultThresholds(),
+	}
 	r.dataset = &ValidationDataset{
 		TruePositives: []ValidationTestCase{{Protocol: "http", Banner: "Server: nginx", ExpectedProduct: "nginx"}},
 		TrueNegatives: []ValidationTestCase{{Protocol: "ssh", Banner: "HTTP/1.1 200 OK", ExpectedMatch: func() *bool { b := false; return &b }()}},

--- a/pkg/fingerprint/validation_thresholds.go
+++ b/pkg/fingerprint/validation_thresholds.go
@@ -1,0 +1,138 @@
+package fingerprint
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+)
+
+// ValidationThresholds represents configurable validation targets.
+// These thresholds determine the pass/fail criteria for validation metrics.
+type ValidationThresholds struct {
+	TargetFPR         float64 `json:"target_fpr"`          // False Positive Rate target (lower is better, default <10%)
+	TargetTPR         float64 `json:"target_tpr"`          // True Positive Rate target (higher is better, default >80%)
+	TargetPrecision   float64 `json:"target_precision"`    // Precision target (higher is better, default >85%)
+	TargetF1          float64 `json:"target_f1"`           // F1 Score target (higher is better, default >0.82)
+	TargetProtocols   int     `json:"target_protocols"`    // Protocol coverage target (default 20+)
+	TargetVersionRate float64 `json:"target_version_rate"` // Version extraction rate target (default >70%)
+	TargetPerfMs      float64 `json:"target_perf_ms"`      // Performance target in milliseconds (default <50ms)
+}
+
+// DefaultThresholds returns production-ready validation thresholds.
+// These values represent the minimum acceptable quality for fingerprint detection.
+func DefaultThresholds() ValidationThresholds {
+	return ValidationThresholds{
+		TargetFPR:         0.10, // <10% false positive rate
+		TargetTPR:         0.80, // >80% true positive rate (recall)
+		TargetPrecision:   0.85, // >85% precision
+		TargetF1:          0.82, // >0.82 F1 score (harmonic mean of precision and recall)
+		TargetProtocols:   20,   // 20+ protocols covered
+		TargetVersionRate: 0.70, // >70% version extraction rate
+		TargetPerfMs:      50.0, // <50ms average detection time
+	}
+}
+
+// StrictThresholds returns stricter validation thresholds for high-quality requirements.
+// Use this profile when accuracy is more important than coverage.
+func StrictThresholds() ValidationThresholds {
+	return ValidationThresholds{
+		TargetFPR:         0.05, // <5% false positive rate (very strict)
+		TargetTPR:         0.90, // >90% true positive rate
+		TargetPrecision:   0.92, // >92% precision
+		TargetF1:          0.88, // >0.88 F1 score
+		TargetProtocols:   25,   // 25+ protocols
+		TargetVersionRate: 0.80, // >80% version extraction
+		TargetPerfMs:      30.0, // <30ms detection time
+	}
+}
+
+// RelaxedThresholds returns more permissive validation thresholds.
+// Use this profile during development or for experimental protocols.
+func RelaxedThresholds() ValidationThresholds {
+	return ValidationThresholds{
+		TargetFPR:         0.15,  // <15% false positive rate
+		TargetTPR:         0.70,  // >70% true positive rate
+		TargetPrecision:   0.75,  // >75% precision
+		TargetF1:          0.70,  // >0.70 F1 score
+		TargetProtocols:   15,    // 15+ protocols
+		TargetVersionRate: 0.60,  // >60% version extraction
+		TargetPerfMs:      100.0, // <100ms detection time
+	}
+}
+
+// loadFloatEnv loads a float from environment variable with validation (0.0-1.0 range).
+// Returns defaultVal if env var is missing, invalid, or out of range.
+func loadFloatEnv(key string, defaultVal float64) float64 {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil || f < 0 || f > 1 {
+		return defaultVal
+	}
+	return f
+}
+
+// loadPositiveFloatEnv loads a positive float from environment variable.
+// Returns defaultVal if env var is missing, invalid, or not positive.
+func loadPositiveFloatEnv(key string, defaultVal float64) float64 {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil || f <= 0 {
+		return defaultVal
+	}
+	return f
+}
+
+// loadPositiveIntEnv loads a positive int from environment variable.
+// Returns defaultVal if env var is missing, invalid, or not positive.
+func loadPositiveIntEnv(key string, defaultVal int) int {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil || i <= 0 {
+		return defaultVal
+	}
+	return i
+}
+
+// LoadThresholdsFromEnv loads validation thresholds from environment variables.
+// Environment variables override default values. Supported variables:
+//   - PENTORA_VALIDATION_TARGET_FPR: False positive rate target (0.0-1.0)
+//   - PENTORA_VALIDATION_TARGET_TPR: True positive rate target (0.0-1.0)
+//   - PENTORA_VALIDATION_TARGET_PRECISION: Precision target (0.0-1.0)
+//   - PENTORA_VALIDATION_TARGET_F1: F1 score target (0.0-1.0)
+//   - PENTORA_VALIDATION_TARGET_PROTOCOLS: Protocol coverage target (int)
+//   - PENTORA_VALIDATION_TARGET_VERSION_RATE: Version extraction rate target (0.0-1.0)
+//   - PENTORA_VALIDATION_TARGET_PERF_MS: Performance target in milliseconds (float)
+//
+// Invalid values are silently ignored, falling back to defaults.
+func LoadThresholdsFromEnv() ValidationThresholds {
+	defaults := DefaultThresholds()
+	return ValidationThresholds{
+		TargetFPR:         loadFloatEnv("PENTORA_VALIDATION_TARGET_FPR", defaults.TargetFPR),
+		TargetTPR:         loadFloatEnv("PENTORA_VALIDATION_TARGET_TPR", defaults.TargetTPR),
+		TargetPrecision:   loadFloatEnv("PENTORA_VALIDATION_TARGET_PRECISION", defaults.TargetPrecision),
+		TargetF1:          loadFloatEnv("PENTORA_VALIDATION_TARGET_F1", defaults.TargetF1),
+		TargetProtocols:   loadPositiveIntEnv("PENTORA_VALIDATION_TARGET_PROTOCOLS", defaults.TargetProtocols),
+		TargetVersionRate: loadFloatEnv("PENTORA_VALIDATION_TARGET_VERSION_RATE", defaults.TargetVersionRate),
+		TargetPerfMs:      loadPositiveFloatEnv("PENTORA_VALIDATION_TARGET_PERF_MS", defaults.TargetPerfMs),
+	}
+}
+
+// ToJSON exports ValidationThresholds as formatted JSON.
+func (vt *ValidationThresholds) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(vt, "", "  ")
+}
+
+// ToJSON exports ValidationMetrics as formatted JSON for machine-readable output.
+// This is useful for CI/CD integration, metrics tracking, and programmatic analysis.
+func (vm *ValidationMetrics) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(vm, "", "  ")
+}

--- a/pkg/fingerprint/validation_thresholds_test.go
+++ b/pkg/fingerprint/validation_thresholds_test.go
@@ -1,0 +1,289 @@
+package fingerprint
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultThresholds(t *testing.T) {
+	thresholds := DefaultThresholds()
+
+	require.Equal(t, 0.10, thresholds.TargetFPR)
+	require.Equal(t, 0.80, thresholds.TargetTPR)
+	require.Equal(t, 0.85, thresholds.TargetPrecision)
+	require.Equal(t, 0.82, thresholds.TargetF1)
+	require.Equal(t, 20, thresholds.TargetProtocols)
+	require.Equal(t, 0.70, thresholds.TargetVersionRate)
+	require.Equal(t, 50.0, thresholds.TargetPerfMs)
+}
+
+func TestStrictThresholds(t *testing.T) {
+	thresholds := StrictThresholds()
+
+	// Strict profile should have more demanding thresholds
+	require.Less(t, thresholds.TargetFPR, DefaultThresholds().TargetFPR, "Strict FPR should be lower")
+	require.Greater(t, thresholds.TargetTPR, DefaultThresholds().TargetTPR, "Strict TPR should be higher")
+	require.Greater(t, thresholds.TargetPrecision, DefaultThresholds().TargetPrecision, "Strict Precision should be higher")
+	require.Greater(t, thresholds.TargetF1, DefaultThresholds().TargetF1, "Strict F1 should be higher")
+	require.Greater(t, thresholds.TargetProtocols, DefaultThresholds().TargetProtocols, "Strict protocols should be higher")
+	require.Greater(t, thresholds.TargetVersionRate, DefaultThresholds().TargetVersionRate, "Strict version rate should be higher")
+	require.Less(t, thresholds.TargetPerfMs, DefaultThresholds().TargetPerfMs, "Strict performance should be faster")
+}
+
+func TestRelaxedThresholds(t *testing.T) {
+	thresholds := RelaxedThresholds()
+
+	// Relaxed profile should have more permissive thresholds
+	require.Greater(t, thresholds.TargetFPR, DefaultThresholds().TargetFPR, "Relaxed FPR should be higher")
+	require.Less(t, thresholds.TargetTPR, DefaultThresholds().TargetTPR, "Relaxed TPR should be lower")
+	require.Less(t, thresholds.TargetPrecision, DefaultThresholds().TargetPrecision, "Relaxed Precision should be lower")
+	require.Less(t, thresholds.TargetF1, DefaultThresholds().TargetF1, "Relaxed F1 should be lower")
+	require.Less(t, thresholds.TargetProtocols, DefaultThresholds().TargetProtocols, "Relaxed protocols should be lower")
+	require.Less(t, thresholds.TargetVersionRate, DefaultThresholds().TargetVersionRate, "Relaxed version rate should be lower")
+	require.Greater(t, thresholds.TargetPerfMs, DefaultThresholds().TargetPerfMs, "Relaxed performance can be slower")
+}
+
+func TestLoadThresholdsFromEnv(t *testing.T) {
+	t.Run("default when no env vars", func(t *testing.T) {
+		// Clear all env vars
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_FPR")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_TPR")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_PRECISION")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_F1")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_PROTOCOLS")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_VERSION_RATE")
+		os.Unsetenv("PENTORA_VALIDATION_TARGET_PERF_MS")
+
+		thresholds := LoadThresholdsFromEnv()
+		defaults := DefaultThresholds()
+
+		require.Equal(t, defaults, thresholds)
+	})
+
+	t.Run("override individual thresholds", func(t *testing.T) {
+		// Set custom env vars
+		os.Setenv("PENTORA_VALIDATION_TARGET_FPR", "0.05")
+		os.Setenv("PENTORA_VALIDATION_TARGET_TPR", "0.90")
+		os.Setenv("PENTORA_VALIDATION_TARGET_PROTOCOLS", "25")
+		defer func() {
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_FPR")
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_TPR")
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_PROTOCOLS")
+		}()
+
+		thresholds := LoadThresholdsFromEnv()
+
+		require.Equal(t, 0.05, thresholds.TargetFPR)
+		require.Equal(t, 0.90, thresholds.TargetTPR)
+		require.Equal(t, 25, thresholds.TargetProtocols)
+		// Other thresholds should be default
+		require.Equal(t, DefaultThresholds().TargetPrecision, thresholds.TargetPrecision)
+		require.Equal(t, DefaultThresholds().TargetF1, thresholds.TargetF1)
+	})
+
+	t.Run("ignore invalid values", func(t *testing.T) {
+		// Set invalid env vars
+		os.Setenv("PENTORA_VALIDATION_TARGET_FPR", "invalid")
+		os.Setenv("PENTORA_VALIDATION_TARGET_TPR", "-1.5")
+		os.Setenv("PENTORA_VALIDATION_TARGET_PROTOCOLS", "not_a_number")
+		defer func() {
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_FPR")
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_TPR")
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_PROTOCOLS")
+		}()
+
+		thresholds := LoadThresholdsFromEnv()
+
+		// Should fall back to defaults when values are invalid
+		require.Equal(t, DefaultThresholds().TargetFPR, thresholds.TargetFPR)
+		require.Equal(t, DefaultThresholds().TargetTPR, thresholds.TargetTPR)
+		require.Equal(t, DefaultThresholds().TargetProtocols, thresholds.TargetProtocols)
+	})
+
+	t.Run("validate range constraints", func(t *testing.T) {
+		// FPR > 1.0 should be ignored
+		os.Setenv("PENTORA_VALIDATION_TARGET_FPR", "1.5")
+		defer os.Unsetenv("PENTORA_VALIDATION_TARGET_FPR")
+
+		thresholds := LoadThresholdsFromEnv()
+		require.Equal(t, DefaultThresholds().TargetFPR, thresholds.TargetFPR, "Should ignore out-of-range value")
+	})
+}
+
+func TestThresholdsJSONExport(t *testing.T) {
+	t.Run("export default thresholds", func(t *testing.T) {
+		thresholds := DefaultThresholds()
+
+		jsonData, err := thresholds.ToJSON()
+		require.NoError(t, err)
+		require.NotEmpty(t, jsonData)
+
+		// Verify it's valid JSON
+		var parsed ValidationThresholds
+		err = json.Unmarshal(jsonData, &parsed)
+		require.NoError(t, err)
+		require.Equal(t, thresholds, parsed)
+	})
+
+	t.Run("export strict thresholds", func(t *testing.T) {
+		thresholds := StrictThresholds()
+
+		jsonData, err := thresholds.ToJSON()
+		require.NoError(t, err)
+
+		// Verify structure
+		var parsed ValidationThresholds
+		err = json.Unmarshal(jsonData, &parsed)
+		require.NoError(t, err)
+		require.Equal(t, 0.05, parsed.TargetFPR)
+		require.Equal(t, 0.90, parsed.TargetTPR)
+	})
+}
+
+func TestValidationMetricsJSONExport(t *testing.T) {
+	t.Run("export metrics with all fields", func(t *testing.T) {
+		metrics := &ValidationMetrics{
+			TotalTestCases:      130,
+			TruePositivesCount:  47,
+			TrueNegativesCount:  29,
+			FalsePositivesCount: 9,
+			FalseNegativesCount: 45,
+			FalsePositiveRate:   0.2368,
+			TruePositiveRate:    0.5109,
+			Precision:           0.8393,
+			F1Score:             0.6351,
+			ProtocolsCovered:    16,
+			TargetFPR:           0.10,
+			TargetTPR:           0.80,
+			PassFPR:             false,
+			PassTPR:             false,
+			MetricsPassed:       1,
+		}
+
+		jsonData, err := metrics.ToJSON()
+		require.NoError(t, err)
+		require.NotEmpty(t, jsonData)
+
+		// Verify it's valid JSON
+		var parsed ValidationMetrics
+		err = json.Unmarshal(jsonData, &parsed)
+		require.NoError(t, err)
+
+		// Check key fields
+		require.Equal(t, metrics.TotalTestCases, parsed.TotalTestCases)
+		require.Equal(t, metrics.FalsePositiveRate, parsed.FalsePositiveRate)
+		require.Equal(t, metrics.TruePositiveRate, parsed.TruePositiveRate)
+		require.Equal(t, metrics.PassFPR, parsed.PassFPR)
+		require.Equal(t, metrics.MetricsPassed, parsed.MetricsPassed)
+	})
+
+	t.Run("export empty metrics", func(t *testing.T) {
+		metrics := &ValidationMetrics{}
+
+		jsonData, err := metrics.ToJSON()
+		require.NoError(t, err)
+		require.NotEmpty(t, jsonData)
+
+		// Should still be valid JSON
+		var parsed ValidationMetrics
+		err = json.Unmarshal(jsonData, &parsed)
+		require.NoError(t, err)
+	})
+}
+
+func TestValidationRunnerWithCustomThresholds(t *testing.T) {
+	t.Run("use default thresholds", func(t *testing.T) {
+		rules := []StaticRule{
+			{
+				ID:              "test.http.apache",
+				Protocol:        "http",
+				Product:         "Apache",
+				Vendor:          "Apache",
+				Match:           "apache",
+				PatternStrength: 0.90,
+			},
+		}
+
+		resolver := NewRuleBasedResolver(rules)
+		runner, err := NewValidationRunner(resolver, "testdata/validation_dataset.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+
+		// Verify default thresholds are used
+		require.Equal(t, DefaultThresholds(), runner.thresholds)
+	})
+
+	t.Run("use strict thresholds", func(t *testing.T) {
+		rules := []StaticRule{
+			{
+				ID:              "test.http.apache",
+				Protocol:        "http",
+				Product:         "Apache",
+				Vendor:          "Apache",
+				Match:           "apache",
+				PatternStrength: 0.90,
+			},
+		}
+
+		resolver := NewRuleBasedResolver(rules)
+		runner, err := NewValidationRunnerWithThresholds(resolver, "testdata/validation_dataset.yaml", StrictThresholds())
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+
+		// Verify strict thresholds are used
+		require.Equal(t, StrictThresholds(), runner.thresholds)
+	})
+
+	t.Run("metrics use custom thresholds", func(t *testing.T) {
+		rules, err := LoadRulesFromFile("data/fingerprint_db.yaml")
+		require.NoError(t, err)
+
+		resolver := NewRuleBasedResolver(rules)
+
+		// Use strict thresholds
+		runner, err := NewValidationRunnerWithThresholds(resolver, "testdata/validation_dataset.yaml", StrictThresholds())
+		require.NoError(t, err)
+
+		metrics, _, err := runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// Verify metrics use strict thresholds
+		require.Equal(t, 0.05, metrics.TargetFPR, "Should use strict FPR threshold")
+		require.Equal(t, 0.90, metrics.TargetTPR, "Should use strict TPR threshold")
+		require.Equal(t, 0.92, metrics.TargetPrecision, "Should use strict Precision threshold")
+	})
+
+	t.Run("env variables override defaults", func(t *testing.T) {
+		// Set custom thresholds via env
+		os.Setenv("PENTORA_VALIDATION_TARGET_FPR", "0.05")
+		os.Setenv("PENTORA_VALIDATION_TARGET_TPR", "0.90")
+		defer func() {
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_FPR")
+			os.Unsetenv("PENTORA_VALIDATION_TARGET_TPR")
+		}()
+
+		rules := []StaticRule{
+			{
+				ID:              "test.http.apache",
+				Protocol:        "http",
+				Product:         "Apache",
+				Vendor:          "Apache",
+				Match:           "apache",
+				PatternStrength: 0.90,
+			},
+		}
+
+		resolver := NewRuleBasedResolver(rules)
+		thresholds := LoadThresholdsFromEnv()
+		runner, err := NewValidationRunnerWithThresholds(resolver, "testdata/validation_dataset.yaml", thresholds)
+		require.NoError(t, err)
+
+		// Verify env thresholds are used
+		require.Equal(t, 0.05, runner.thresholds.TargetFPR)
+		require.Equal(t, 0.90, runner.thresholds.TargetTPR)
+	})
+}


### PR DESCRIPTION
## Summary

Implements **Issue #178**: Machine-readable validation metrics export and flexible threshold configuration for the fingerprint validation framework.

## Key Features

### 1. JSON Export API
- `ValidationMetrics.ToJSON()` - Machine-readable metrics export
- `ValidationThresholds.ToJSON()` - Threshold serialization
- Enables CI/CD pipeline integration
- Supports programmatic metrics tracking

### 2. Configurable Thresholds
- **DefaultThresholds()** - Production-ready defaults (FPR <10%, TPR >80%)
- **StrictThresholds()** - High-quality requirements (FPR <5%, TPR >90%)
- **RelaxedThresholds()** - Development/experimental use (FPR <15%, TPR >70%)
- Fine-tune validation criteria per use case

### 3. Environment Variable Support
- `LoadThresholdsFromEnv()` - Load custom thresholds from env vars
- Supports `PENTORA_VALIDATION_TARGET_*` variables
- Invalid values silently fall back to defaults
- Per-environment threshold customization

### 4. Flexible ValidationRunner
- `NewValidationRunner()` - Uses default thresholds
- `NewValidationRunnerWithThresholds()` - Accepts custom thresholds
- Backward compatible with existing tests
- Thresholds propagate to metrics calculation

## Implementation Details

**New Files:**
- [validation_thresholds.go](pkg/fingerprint/validation_thresholds.go): Core threshold types, constructors, env loading
- [validation_thresholds_test.go](pkg/fingerprint/validation_thresholds_test.go): Comprehensive test coverage (14 test cases)

**Modified Files:**
- [validation.go](pkg/fingerprint/validation.go): ValidationRunner refactored to accept thresholds
- [validation_runner_test.go](pkg/fingerprint/validation_runner_test.go): Fixed test to use DefaultThresholds()

**Helper Functions:**
- `loadFloatEnv()` - Load 0.0-1.0 range floats from env
- `loadPositiveFloatEnv()` - Load positive floats from env
- `loadPositiveIntEnv()` - Load positive ints from env
- Reduces cyclomatic complexity (gocyclo passes)

## Testing

- ✅ All new tests pass (14/14)
- ✅ Existing validation tests fixed and pass
- ✅ Backward compatible with DefaultThresholds()
- ✅ Environment variable override tested
- ✅ `make test` passes
- ✅ `make validate` passes

**Test Coverage:**
- Default/strict/relaxed threshold constructors
- Environment variable loading (valid, invalid, missing)
- JSON serialization (metrics, thresholds)
- Custom threshold propagation to metrics
- ValidationRunner backward compatibility

## Use Cases

### 1. CI/CD Integration
```bash
# Export metrics as JSON for automated analysis
metrics, _, _ := runner.Run(ctx)
jsonData, _ := metrics.ToJSON()
# Parse with jq, store in database, etc.
```

### 2. Strict Quality Mode
```go
// Require higher quality (>92% precision, <5% FPR)
runner := NewValidationRunnerWithThresholds(resolver, datasetPath, StrictThresholds())
metrics, _, _ := runner.Run(ctx)
```

### 3. Development/Experimental Mode
```go
// Allow experimental protocols (>70% TPR, <15% FPR)
runner := NewValidationRunnerWithThresholds(resolver, datasetPath, RelaxedThresholds())
```

### 4. Per-Environment Customization
```bash
# Different thresholds for dev/staging/prod
export PENTORA_VALIDATION_TARGET_FPR=0.05
export PENTORA_VALIDATION_TARGET_TPR=0.90
runner := NewValidationRunnerWithThresholds(resolver, datasetPath, LoadThresholdsFromEnv())
```

## Breaking Changes

None. Fully backward compatible:
- Existing code using `NewValidationRunner()` continues to work
- Default thresholds match previous hardcoded values
- All existing tests pass without modification (except one test that directly instantiated ValidationRunner)

## Related

- Resolves #178
- Follow-up to PR #176 (Phase 6: Validation & Benchmarking Framework)
- Enables future CI/CD threshold enforcement
- Prepares for Issue #177 (CI Integration)

## Acceptance Criteria

- [x] ValidationMetrics.ToJSON() exports valid JSON
- [x] All struct fields included in JSON output
- [x] Environment variables override default thresholds
- [x] Thresholds documented (via code comments)
- [x] Tests verify threshold customization works
- [x] Backward compatible with existing code
- [x] `make test && make validate` passes