### PR TITLE
feat(engine): include probe evidence in JSON output

### DIFF
--- a/pkg/engine/asset.go
+++ b/pkg/engine/asset.go
@@ -5,6 +5,35 @@ import (
 	"time"
 )
 
+// ProbeObservation captures the result of an active probe execution.
+// This struct is used in banner grabbing to record individual probe attempts
+// and their responses, including TLS metadata when applicable.
+type ProbeObservation struct {
+	ProbeID     string          `json:"probe_id" yaml:"probe_id"`
+	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
+	Protocol    string          `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+	IsTLS       bool            `json:"is_tls,omitempty" yaml:"is_tls,omitempty"`
+	Duration    time.Duration   `json:"duration_ns,omitempty" yaml:"duration_ns,omitempty"`
+	Response    string          `json:"response,omitempty" yaml:"response,omitempty"`
+	Error       string          `json:"error,omitempty" yaml:"error,omitempty"`
+	TLS         *TLSObservation `json:"tls,omitempty" yaml:"tls,omitempty"` // Phase 1.7
+}
+
+// TLSObservation captures TLS handshake metadata including certificate validity.
+// Phase 1.7: Added certificate expiry and self-signed detection for security assessment.
+type TLSObservation struct {
+	Version        string    `json:"version,omitempty" yaml:"version,omitempty"`
+	CipherSuite    string    `json:"cipher_suite,omitempty" yaml:"cipher_suite,omitempty"`
+	ServerName     string    `json:"server_name,omitempty" yaml:"server_name,omitempty"`
+	PeerCommonName string    `json:"peer_common_name,omitempty" yaml:"peer_common_name,omitempty"`
+	PeerDNSNames   []string  `json:"peer_dns_names,omitempty" yaml:"peer_dns_names,omitempty"`
+	Issuer         string    `json:"issuer,omitempty" yaml:"issuer,omitempty"`         // Phase 1.7: Certificate issuer DN
+	NotBefore      time.Time `json:"not_before,omitempty" yaml:"not_before,omitempty"` // Phase 1.7: Certificate validity start
+	NotAfter       time.Time `json:"not_after,omitempty" yaml:"not_after,omitempty"`   // Phase 1.7: Certificate validity end
+	IsExpired      bool      `json:"is_expired" yaml:"is_expired"`                     // Phase 1.7: True if cert expired
+	IsSelfSigned   bool      `json:"is_self_signed" yaml:"is_self_signed"`             // Phase 1.7: True if Subject == Issuer
+}
+
 // FindingSeverity defines the severity of a finding.
 type FindingSeverity string
 
@@ -37,6 +66,7 @@ type ServiceDetails struct {
 	RawBanner        string                 `json:"raw_banner,omitempty" yaml:"raw_banner,omitempty"` // Raw banner captured
 	IsTLS            bool                   `json:"is_tls,omitempty" yaml:"is_tls,omitempty"`
 	ParsedAttributes map[string]interface{} `json:"parsed_attributes,omitempty" yaml:"parsed_attributes,omitempty"` // HTTP headers, SSH specific details, etc.
+	Evidence         []ProbeObservation     `json:"evidence,omitempty" yaml:"evidence,omitempty"`                   // Active probe results from Phase 1.5 (Probe Fallback)
 }
 
 // PortProfile details information about a specific open port on a target.

--- a/pkg/modules/parse/fingerprint_parser.go
+++ b/pkg/modules/parse/fingerprint_parser.go
@@ -38,7 +38,7 @@ type FingerprintParsedInfo struct {
 	SourceProbe string  `json:"source_probe,omitempty"`
 
 	// Phase 1.7: TLS metadata (certificate validity and security indicators)
-	TLS *scan.TLSObservation `json:"tls,omitempty"`
+	TLS *engine.TLSObservation `json:"tls,omitempty"`
 }
 
 // FingerprintParserModule consumes banner results and produces fingerprint matches.
@@ -200,7 +200,7 @@ type bannerCandidate struct {
 	Response string
 	Protocol string
 	ProbeID  string
-	TLS      *scan.TLSObservation // Phase 1.7: TLS metadata from probe
+	TLS      *engine.TLSObservation // Phase 1.7: TLS metadata from probe
 }
 
 func gatherBannerCandidates(banner scan.BannerGrabResult) []bannerCandidate {

--- a/pkg/modules/parse/fingerprint_parser_test.go
+++ b/pkg/modules/parse/fingerprint_parser_test.go
@@ -63,7 +63,7 @@ func TestFingerprintParserModule_Execute_FullCoverage(t *testing.T) {
 		Port:     22,
 		Protocol: "tcp",
 		Banner:   "SSH-2.0-OpenSSH_8.9",
-		Evidence: []scan.ProbeObservation{
+		Evidence: []engine.ProbeObservation{
 			{Response: "HTTP/1.1 200 OK\r\nServer: nginx", Protocol: "http", ProbeID: "probe1"},
 			{Response: "error-banner", Protocol: "http", ProbeID: "probe2"},
 			{Response: "unknown-banner", Protocol: "ftp", ProbeID: "probe3"},
@@ -170,7 +170,7 @@ func TestFingerprintParserModule_gatherBannerCandidates(t *testing.T) {
 	banner := scan.BannerGrabResult{
 		Banner:   "HTTP/1.1 200 OK",
 		Protocol: "tcp",
-		Evidence: []scan.ProbeObservation{
+		Evidence: []engine.ProbeObservation{
 			{Response: "SSH-2.0-OpenSSH_8.9", Protocol: "", ProbeID: "probe1"},
 			{Response: "   ", Protocol: "http", ProbeID: "probe2"}, // boş response skip
 		},

--- a/pkg/modules/reporting/asset_profile_builder.go
+++ b/pkg/modules/reporting/asset_profile_builder.go
@@ -262,6 +262,7 @@ func (m *AssetProfileBuilderModule) Execute(ctx context.Context, inputs map[stri
 						if banner.IP == targetIP && banner.Port == portNum {
 							portProfile.Service.RawBanner = banner.Banner
 							portProfile.Service.IsTLS = banner.IsTLS
+							portProfile.Service.Evidence = banner.Evidence // Issue #199: Include probe evidence in JSON output
 							break
 						}
 					}


### PR DESCRIPTION
## Summary

Fixes #199 - JSON output now includes active probe evidence from Phase 1.5 (Probe Fallback System), showing users which probes were executed on each port.

## Problem

Active probe results (http-get, https-get, redis-ping, ftp-feat) were not appearing in JSON output even though:
- BannerGrabResult had Evidence field with proper JSON tags
- Phase 1.5 was collecting probe observations correctly

**Root Cause**:
1. `ProbeObservation` and `TLSObservation` types were in `scan` package
2. `ServiceDetails` (in `engine` package) couldn't import them → circular dependency
3. `asset_profile_builder.go` wasn't copying the Evidence field during transformation

## Solution

**Type Relocation**:
- Moved `ProbeObservation` and `TLSObservation` from scan to engine package
- This is pragmatic: `engine/asset.go` already contains output-related structs (ServiceDetails, PortProfile, VulnerabilityFinding)
- No circular dependency: scan already imports engine

**Changes**:
1. [pkg/engine/asset.go](pkg/engine/asset.go#L11-L35): Add ProbeObservation and TLSObservation types
2. [pkg/engine/asset.go](pkg/engine/asset.go#L69): Add Evidence field to ServiceDetails
3. [pkg/modules/scan/banner_grab.go](pkg/modules/scan/banner_grab.go): Update to use `engine.ProbeObservation` (7 occurrences)
4. [pkg/modules/parse/fingerprint_parser.go](pkg/modules/parse/fingerprint_parser.go): Update to use `engine.TLSObservation` (2 occurrences)
5. [pkg/modules/reporting/asset_profile_builder.go](pkg/modules/reporting/asset_profile_builder.go#L265): Copy Evidence field during transformation
6. [pkg/modules/parse/fingerprint_parser_test.go](pkg/modules/parse/fingerprint_parser_test.go): Fix test references (2 occurrences)

## Test Results

**Real scan verification**:
```bash
go run ./cmd scan 127.0.0.1 --ports 8765 --output json
```

Output now includes evidence field with 5 probe observations:
```json
{
  "service": {
    "raw_banner": "...",
    "evidence": [
      {
        "probe_id": "tcp-passive",
        "protocol": "tcp",
        "duration_ns": 1001061750,
        "error": "read tcp 127.0.0.1:51542->127.0.0.1:8765: i/o timeout"
      },
      {
        "probe_id": "http-get",
        "protocol": "http",
        "duration_ns": 561208,
        "response": "<!DOCTYPE HTML..."
      },
      {
        "probe_id": "https-get",
        "protocol": "https",
        "is_tls": true,
        "duration_ns": 680167,
        "error": "tls: first record does not look like a TLS handshake"
      },
      {
        "probe_id": "redis-ping",
        "protocol": "redis",
        "duration_ns": 1001584333,
        "response": "..."
      },
      {
        "probe_id": "ftp-feat",
        "protocol": "ftp",
        "duration_ns": 1001647500,
        "response": "..."
      }
    ]
  }
}
```

**Validation**:
- ✅ All unit tests pass (`make test`)
- ✅ Linting and formatting pass (`make validate`)
- ✅ No regressions

## Impact

**User Benefits**:
- **Transparency**: Users can see which probes were executed on each port
- **Debugging**: Understand why a service was or wasn't detected
- **Probe performance**: See execution times (duration_ns) for each probe
- **Error visibility**: See which probes failed and why

**Example Use Cases**:
- "Why wasn't HTTP detected on port 2096?" → Check evidence, see if http-get probe was tried
- "How long do probes take?" → Check duration_ns for performance analysis
- "Did TLS handshake succeed?" → Check is_tls and tls metadata in evidence

## Related

- Closes #199
- Related to Phase 1.5: Probe Fallback System
- Related to Phase 1.7: TLS Metadata Collection