### PR TITLE
chore(fmt): apply gofumpt formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,21 @@ make test      # Run unit tests - MUST PASS
 make validate  # Lint + format + spell + shell checks - MUST PASS
 ```
 
+### Formatter installation (gofumpt)
+
+The project uses `gofumpt` (stricter `gofmt`) via `make fmt`:
+
+```bash
+# Install gofumpt if it's not already in your PATH
+go install mvdan.cc/gofumpt@latest
+
+# Ensure GOPATH/bin is on your PATH
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+# Run formatting locally
+make fmt
+```
+
 **Integration tests** (optional, recommended before PR):
 ```bash
 make test-integration  # Run with -tags=integration
@@ -221,4 +236,3 @@ Interfaces in `pkg/api` and `pkg/server` are evolving. Treat them as experimenta
 - If a review task was interrupted in the CLI, re-initiate with `/review` and wait for it to complete.
 
 Thanks for contributing and keeping Pentora healthy and reliable!
-

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ test-all: test-unit test-integration
 fmt:
 	@echo "🔧 Running gci (import organization)..."
 	@gci write --skip-generated -s standard -s default -s "prefix(github.com/pentora-ai/pentora)" $(SRCS)
-	@echo "🔧 Running gofmt (code formatting)..."
-	@gofmt -s -l -w $(SRCS)
+	@echo "🔧 Running gofumpt (code formatting)..."
+	@gofumpt -l -w -extra $(SRCS)
 	@echo "✅ Code formatted"	
 
 #? dist: Create the "dist" directory

--- a/cmd/pentora/internal/format/summary.go
+++ b/cmd/pentora/internal/format/summary.go
@@ -431,7 +431,7 @@ func init() {
 }
 
 // GetSuggestions returns actionable hints based on error code and operation.
-func GetSuggestions(errorCode string, operation string) []string {
+func GetSuggestions(errorCode, operation string) []string {
 	if generator, ok := suggestionGenerators[errorCode]; ok {
 		return generator(operation)
 	}

--- a/pkg/engine/proto/module_api.pb.go
+++ b/pkg/engine/proto/module_api.pb.go
@@ -9,11 +9,12 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -752,21 +753,24 @@ func file_pkg_engine_proto_module_api_proto_rawDescGZIP() []byte {
 	return file_pkg_engine_proto_module_api_proto_rawDescData
 }
 
-var file_pkg_engine_proto_module_api_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_pkg_engine_proto_module_api_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-var file_pkg_engine_proto_module_api_proto_goTypes = []any{
-	(HostControlSignal_SignalType)(0), // 0: engine.HostControlSignal.SignalType
-	(*ModuleMessage)(nil),             // 1: engine.ModuleMessage
-	(*HostMessage)(nil),               // 2: engine.HostMessage
-	(*ModuleRegistration)(nil),        // 3: engine.ModuleRegistration
-	(*RegistrationAck)(nil),           // 4: engine.RegistrationAck
-	(*ExecuteNewTask)(nil),            // 5: engine.ExecuteNewTask
-	(*TaskOutputResult)(nil),          // 6: engine.TaskOutputResult
-	(*ModuleHeartbeat)(nil),           // 7: engine.ModuleHeartbeat
-	(*HostControlSignal)(nil),         // 8: engine.HostControlSignal
-	nil,                               // 9: engine.ExecuteNewTask.InputsEntry
-	nil,                               // 10: engine.ExecuteNewTask.ModuleConfigEntry
-}
+var (
+	file_pkg_engine_proto_module_api_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+	file_pkg_engine_proto_module_api_proto_msgTypes  = make([]protoimpl.MessageInfo, 10)
+	file_pkg_engine_proto_module_api_proto_goTypes   = []any{
+		(HostControlSignal_SignalType)(0), // 0: engine.HostControlSignal.SignalType
+		(*ModuleMessage)(nil),             // 1: engine.ModuleMessage
+		(*HostMessage)(nil),               // 2: engine.HostMessage
+		(*ModuleRegistration)(nil),        // 3: engine.ModuleRegistration
+		(*RegistrationAck)(nil),           // 4: engine.RegistrationAck
+		(*ExecuteNewTask)(nil),            // 5: engine.ExecuteNewTask
+		(*TaskOutputResult)(nil),          // 6: engine.TaskOutputResult
+		(*ModuleHeartbeat)(nil),           // 7: engine.ModuleHeartbeat
+		(*HostControlSignal)(nil),         // 8: engine.HostControlSignal
+		nil,                               // 9: engine.ExecuteNewTask.InputsEntry
+		nil,                               // 10: engine.ExecuteNewTask.ModuleConfigEntry
+	}
+)
+
 var file_pkg_engine_proto_module_api_proto_depIdxs = []int32{
 	3,  // 0: engine.ModuleMessage.registration:type_name -> engine.ModuleRegistration
 	6,  // 1: engine.ModuleMessage.output_result:type_name -> engine.TaskOutputResult

--- a/pkg/engine/proto/module_api_grpc.pb.go
+++ b/pkg/engine/proto/module_api_grpc.pb.go
@@ -10,6 +10,7 @@ package proto
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/engine/registry.go
+++ b/pkg/engine/registry.go
@@ -25,7 +25,7 @@ func RegisterModuleFactory(name string, factory ModuleFactory) {
 
 // GetModuleInstance creates a new instance of a module given its registered name
 // and initializes it with the provided configuration.
-func GetModuleInstance(instanceID string, name string, config map[string]interface{}) (Module, error) {
+func GetModuleInstance(instanceID, name string, config map[string]interface{}) (Module, error) {
 	factory, ok := moduleRegistry[name]
 	if !ok {
 		return nil, fmt.Errorf("no module factory registered for name: %s", name)

--- a/pkg/fingerprint/resolver_helpers.go
+++ b/pkg/fingerprint/resolver_helpers.go
@@ -41,7 +41,7 @@ func softExcludePenalty(banner string, soft []*regexp.Regexp, perMatchPenalty fl
 
 // calculateConfidence computes a confidence score based on pattern strength,
 // soft-exclude penalties, and optional port bonuses.
-func calculateConfidence(base float64, softPenalty float64, portBonus float64) float64 {
+func calculateConfidence(base, softPenalty, portBonus float64) float64 {
 	conf := base - softPenalty + portBonus
 	if conf < 0 {
 		conf = 0

--- a/pkg/fingerprint/telemetry.go
+++ b/pkg/fingerprint/telemetry.go
@@ -71,7 +71,7 @@ func (w *TelemetryWriter) Write(event DetectionEvent) error {
 }
 
 // WriteSuccess writes a successful detection event.
-func (w *TelemetryWriter) WriteSuccess(target string, port int, protocol string, result Result, resolverName string, ruleID string) error {
+func (w *TelemetryWriter) WriteSuccess(target string, port int, protocol string, result Result, resolverName, ruleID string) error {
 	event := DetectionEvent{
 		Timestamp:    time.Now(),
 		Target:       target,
@@ -89,7 +89,7 @@ func (w *TelemetryWriter) WriteSuccess(target string, port int, protocol string,
 }
 
 // WriteNoMatch writes a no-match event when no rule matched the banner.
-func (w *TelemetryWriter) WriteNoMatch(target string, port int, protocol string, resolverName string) error {
+func (w *TelemetryWriter) WriteNoMatch(target string, port int, protocol, resolverName string) error {
 	event := DetectionEvent{
 		Timestamp:    time.Now(),
 		Target:       target,
@@ -103,7 +103,7 @@ func (w *TelemetryWriter) WriteNoMatch(target string, port int, protocol string,
 }
 
 // WriteRejected writes a rejection event when anti-patterns triggered.
-func (w *TelemetryWriter) WriteRejected(target string, port int, protocol string, reason string, resolverName string, ruleID string) error {
+func (w *TelemetryWriter) WriteRejected(target string, port int, protocol, reason, resolverName, ruleID string) error {
 	event := DetectionEvent{
 		Timestamp:       time.Now(),
 		Target:          target,

--- a/pkg/modules/parse/ssh_parser.go
+++ b/pkg/modules/parse/ssh_parser.go
@@ -260,7 +260,7 @@ func init() {
 // extractSSHSoftwareAndVersion attempts to get a more granular software and version.
 // Example: "OpenSSH_8.9p1" -> "OpenSSH", "8.9p1"
 // Example: "dropbear_2020.78" -> "dropbear", "2020.78"
-func extractSSHSoftwareAndVersion(versionInfo string) (software string, swVersion string) {
+func extractSSHSoftwareAndVersion(versionInfo string) (software, swVersion string) {
 	if versionInfo == "" {
 		return "", ""
 	}

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -65,7 +65,7 @@ type CacheEntry struct {
 // Returns the cache entry for the plugin.
 // If rawData is provided, it will be written as-is to preserve checksums.
 // If rawData is nil, the plugin will be marshaled to YAML.
-func (c *CacheManager) Add(ctx context.Context, plugin *YAMLPlugin, checksum string, downloadURL string, rawData ...[]byte) (*CacheEntry, error) {
+func (c *CacheManager) Add(ctx context.Context, plugin *YAMLPlugin, checksum, downloadURL string, rawData ...[]byte) (*CacheEntry, error) {
 	// Check context cancellation
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (c *CacheManager) GetEntry(ctx context.Context, id, version string) (*Cache
 }
 
 // Remove removes a plugin from the cache.
-func (c *CacheManager) Remove(ctx context.Context, id string, version string) error {
+func (c *CacheManager) Remove(ctx context.Context, id, version string) error {
 	// Check context cancellation
 	if err := ctx.Err(); err != nil {
 		return err

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -294,7 +294,7 @@ func (m *ManifestManager) GetRegistryURL() (string, error) {
 }
 
 // NewManifestEntryFromPlugin creates a ManifestEntry from a YAMLPlugin.
-func NewManifestEntryFromPlugin(plugin *YAMLPlugin, checksum string, downloadURL string) *ManifestEntry {
+func NewManifestEntryFromPlugin(plugin *YAMLPlugin, checksum, downloadURL string) *ManifestEntry {
 	return &ManifestEntry{
 		Name:        plugin.Name,
 		Version:     plugin.Version,

--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -32,7 +32,7 @@ type CacheInterface interface {
 	GetEntry(ctx context.Context, name, version string) (*CacheEntry, error)
 	Size(ctx context.Context) (int64, error)
 	Prune(ctx context.Context, olderThan time.Duration) (int, error)
-	Remove(ctx context.Context, id string, version string) error
+	Remove(ctx context.Context, id, version string) error
 }
 
 // ManifestInterface defines the manifest operations needed by Service

--- a/pkg/plugin/service_test.go
+++ b/pkg/plugin/service_test.go
@@ -221,7 +221,7 @@ type mockCacheManager struct {
 	getEntryFunc func(ctx context.Context, name, version string) (*CacheEntry, error)
 	sizeFunc     func(ctx context.Context) (int64, error)
 	pruneFunc    func(ctx context.Context, olderThan time.Duration) (int, error)
-	removeFunc   func(ctx context.Context, id string, version string) error
+	removeFunc   func(ctx context.Context, id, version string) error
 	putFunc      func(ctx context.Context, entry CacheEntry) error
 	listFunc     func(ctx context.Context) ([]CacheEntry, error)
 	deleteFunc   func(ctx context.Context, name, version string) error
@@ -248,7 +248,7 @@ func (m *mockCacheManager) Prune(ctx context.Context, olderThan time.Duration) (
 	return 0, nil
 }
 
-func (m *mockCacheManager) Remove(ctx context.Context, id string, version string) error {
+func (m *mockCacheManager) Remove(ctx context.Context, id, version string) error {
 	if m.removeFunc != nil {
 		return m.removeFunc(ctx, id, version)
 	}

--- a/pkg/plugin/verify.go
+++ b/pkg/plugin/verify.go
@@ -28,7 +28,7 @@ func NewVerifier() *Verifier {
 
 // VerifyFile verifies a plugin file against its expected checksum.
 // Returns true if the checksum matches, false otherwise.
-func (v *Verifier) VerifyFile(filePath string, expectedChecksum string) (bool, error) {
+func (v *Verifier) VerifyFile(filePath, expectedChecksum string) (bool, error) {
 	if filePath == "" {
 		return false, fmt.Errorf("file path cannot be empty")
 	}
@@ -146,7 +146,7 @@ func (v *Verifier) normalizeChecksum(checksum string) string {
 // Examples:
 //   - "sha256:abc123" -> ("sha256", "abc123", nil)
 //   - "abc123" -> ("sha256", "abc123", nil) // default algorithm
-func ParseChecksum(checksum string) (algorithm string, hexValue string, err error) {
+func ParseChecksum(checksum string) (algorithm, hexValue string, err error) {
 	if checksum == "" {
 		return "", "", fmt.Errorf("checksum cannot be empty")
 	}
@@ -166,6 +166,6 @@ func ParseChecksum(checksum string) (algorithm string, hexValue string, err erro
 
 // FormatChecksum formats a checksum with algorithm prefix.
 // Example: FormatChecksum("sha256", "abc123") -> "sha256:abc123"
-func FormatChecksum(algorithm string, hexValue string) string {
+func FormatChecksum(algorithm, hexValue string) string {
 	return fmt.Sprintf("%s:%s", algorithm, hexValue)
 }


### PR DESCRIPTION
chore(fmt): apply gofumpt formatting

This PR applies gofumpt formatting across the repository to align with .golangci.yaml.

- Ran make fmt (gci + gofumpt -extra)
- Committed only formatting changes
- No functional changes

Rationale:
- Enforces consistent project style
- Avoids noisy diffs on future PRs
- Matches lint configuration (gofumpt)
