### PR TITLE
tests: increase coverage (evaluation, reporting, fingerprint)

### DIFF
--- a/pkg/engine/proto/proto_smoke_test.go
+++ b/pkg/engine/proto/proto_smoke_test.go
@@ -1,0 +1,10 @@
+package proto
+
+import "testing"
+
+// Smoke test to ensure generated proto types are present and package compiles under tests.
+func TestModuleAPISmoke(t *testing.T) {
+	// Instantiate zero-values of a few generated types to ensure linkage.
+	var _ ModuleMessage
+	var _ HostControlSignal_SignalType
+}

--- a/pkg/fingerprint/catalogsync/service_test.go
+++ b/pkg/fingerprint/catalogsync/service_test.go
@@ -1,0 +1,62 @@
+package catalogsync
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileSource_Load(t *testing.T) {
+	_, err := FileSource{Path: ""}.Load(context.Background())
+	if err == nil {
+		t.Fatalf("expected error for empty path")
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(p, []byte("rules: []\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	b, err := FileSource{Path: p}.Load(context.Background())
+	if err != nil || len(b) == 0 {
+		t.Fatalf("expected bytes, err=%v", err)
+	}
+}
+
+func TestFileStore_Save(t *testing.T) {
+	err := FileStore{Path: ""}.Save(context.Background(), []byte("x"))
+	if err == nil {
+		t.Fatalf("expected error for empty path")
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "out", "c.yaml")
+	if err := (FileStore{Path: p}).Save(context.Background(), []byte("rules: []\n")); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("expected file saved: %v", err)
+	}
+}
+
+func TestHTTPSource_Load(t *testing.T) {
+	if _, err := (HTTPSource{URL: ""}).Load(context.Background()); err == nil {
+		t.Fatalf("expected error for empty url")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("rules: []\n"))
+	}))
+	defer ts.Close()
+	if b, err := (HTTPSource{URL: ts.URL}).Load(context.Background()); err != nil || len(b) == 0 {
+		t.Fatalf("expected ok, err=%v", err)
+	}
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts2.Close()
+	if _, err := (HTTPSource{URL: ts2.URL}).Load(context.Background()); err == nil {
+		t.Fatalf("expected status error")
+	}
+}

--- a/pkg/modules/reporting/asset_profile_builder_more_test.go
+++ b/pkg/modules/reporting/asset_profile_builder_more_test.go
@@ -1,0 +1,68 @@
+package reporting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pentora-ai/pentora/pkg/engine"
+	"github.com/pentora-ai/pentora/pkg/modules/parse"
+)
+
+// NOTE: Vulnerability aggregation is handled, but not asserted here due to
+// evolving profile structure. Focus other behaviors for now.
+
+func TestAssetProfileBuilderHandlesEmptyInputs(t *testing.T) {
+	m := newAssetProfileBuilderModule()
+	if err := m.Init(assetProfileBuilderModuleTypeName, map[string]interface{}{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	outCh := make(chan engine.ModuleOutput, 1)
+	if err := m.Execute(context.Background(), map[string]interface{}{}, outCh); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	select {
+	case out := <-outCh:
+		if _, ok := out.Data.([]engine.AssetProfile); !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for output")
+	}
+}
+
+func TestAssetProfileBuilderMergesParsedDetails(t *testing.T) {
+	m := newAssetProfileBuilderModule()
+	if err := m.Init(assetProfileBuilderModuleTypeName, map[string]interface{}{}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	target := "203.0.113.42"
+	port := 80
+	inputs := map[string]interface{}{
+		"config.targets": []string{target},
+		"service.http.details": []interface{}{
+			parse.HTTPParsedInfo{Target: target, Port: port, ServerProduct: "nginx", ServerVersion: "1.21.6"},
+		},
+		"service.ssh.details": []interface{}{
+			parse.SSHParsedInfo{Target: target, Port: 22, Software: "OpenSSH", SoftwareVersion: "9.3"},
+		},
+	}
+	outCh := make(chan engine.ModuleOutput, 1)
+	if err := m.Execute(context.Background(), inputs, outCh); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	select {
+	case out := <-outCh:
+		profiles := out.Data.([]engine.AssetProfile)
+		if len(profiles) == 0 {
+			t.Fatalf("no profiles")
+		}
+		ap := profiles[0]
+		// Expect to see both HTTP and SSH services reflected in the profile maps
+		if _, ok := ap.OpenPorts[target]; !ok {
+			t.Fatalf("expected open ports for %s", target)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/pkg/modules/reporting/asset_profile_builder_test.go
+++ b/pkg/modules/reporting/asset_profile_builder_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pentora-ai/pentora/pkg/engine"
 	"github.com/pentora-ai/pentora/pkg/modules/discovery"
+	"github.com/pentora-ai/pentora/pkg/modules/evaluation"
 	"github.com/pentora-ai/pentora/pkg/modules/parse"
 	"github.com/pentora-ai/pentora/pkg/modules/scan"
 )
@@ -61,6 +62,425 @@ func TestAssetProfileBuilderUsesFingerprintForNonDefaultPort(t *testing.T) {
 		}
 		if service.Version != "8.9p1" {
 			t.Fatalf("expected version 8.9p1, got %s", service.Version)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilderModuleFactory_ReturnsModule(t *testing.T) {
+	t.Parallel()
+
+	mod := AssetProfileBuilderModuleFactory()
+	if mod == nil {
+		t.Fatal("factory returned nil module")
+	}
+
+	meta := mod.Metadata()
+	if meta.Name != assetProfileBuilderModuleTypeName {
+		t.Fatalf("expected module name %q, got %q", assetProfileBuilderModuleTypeName, meta.Name)
+	}
+}
+
+func TestAssetProfileBuilderModuleFactory_InitExecuteProducesAssetProfilesKey(t *testing.T) {
+	t.Parallel()
+
+	mod := AssetProfileBuilderModuleFactory()
+	if err := mod.Init("factory-instance", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	if mod.Metadata().ID != "factory-instance" {
+		t.Fatalf("expected meta.ID set to %q, got %q", "factory-instance", mod.Metadata().ID)
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	if err := mod.Execute(context.Background(), map[string]interface{}{}, outCh); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		if out.DataKey != "asset.profiles" {
+			t.Fatalf("unexpected data key: %s", out.DataKey)
+		}
+		if _, ok := out.Data.([]engine.AssetProfile); !ok {
+			t.Fatalf("expected data type []engine.AssetProfile, got %T", out.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilderMapsVulnerabilitiesToPort(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init(assetProfileBuilderModuleTypeName, map[string]interface{}{}); err != nil {
+		t.Fatalf("init module failed: %v", err)
+	}
+
+	target := "192.0.2.30"
+	port := 8080
+
+	vuln := evaluation.VulnerabilityResult{
+		Target:      target,
+		Port:        port,
+		Plugin:      "test-plugin",
+		Message:     "remote code execution",
+		Severity:    "medium",
+		CVE:         []string{"CVE-2025-1234"},
+		Remediation: "update package",
+		Reference:   "http://example.com/vuln",
+	}
+
+	inputs := map[string]interface{}{
+		"config.targets": []string{target},
+		"discovery.open_tcp_ports": []interface{}{
+			discovery.TCPPortDiscoveryResult{Target: target, OpenPorts: []int{port}},
+		},
+		"evaluation.vulnerabilities": []interface{}{vuln},
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	if err := module.Execute(context.Background(), inputs, outCh); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) == 0 {
+			t.Fatalf("no asset profiles returned")
+		}
+		profile := profiles[0]
+		ports := profile.OpenPorts[target]
+		if len(ports) == 0 {
+			t.Fatalf("expected open port entry")
+		}
+		if profile.TotalVulnerabilities != 1 {
+			t.Fatalf("expected TotalVulnerabilities 1, got %d", profile.TotalVulnerabilities)
+		}
+		vulns := ports[0].Vulnerabilities
+		if len(vulns) != 1 {
+			t.Fatalf("expected 1 vulnerability on port, got %d", len(vulns))
+		}
+		if vulns[0].Summary != vuln.Message {
+			t.Fatalf("expected vulnerability summary %q, got %q", vuln.Message, vulns[0].Summary)
+		}
+		if vulns[0].SourceModule != vuln.Plugin {
+			t.Fatalf("expected vulnerability source %q, got %q", vuln.Plugin, vulns[0].SourceModule)
+		}
+		if vulns[0].ID != "CVE-2025-1234" {
+			t.Fatalf("expected vulnerability ID %q, got %q", "CVE-2025-1234", vulns[0].ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilder_Execute_EmptyInputs(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init("test-empty", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	err := module.Execute(context.Background(), map[string]interface{}{}, outCh)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) != 0 {
+			t.Fatalf("expected 0 profiles, got %d", len(profiles))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilder_Execute_InitialTargetsOnly(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init("test-initial", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	targets := []string{"192.0.2.1", "192.0.2.2"}
+	inputs := map[string]interface{}{
+		"config.targets": targets,
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	err := module.Execute(context.Background(), inputs, outCh)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) != len(targets) {
+			t.Fatalf("expected %d profiles, got %d", len(targets), len(profiles))
+		}
+		for _, p := range profiles {
+			if p.IsAlive {
+				t.Errorf("expected IsAlive=false for %s", p.Target)
+			}
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilder_Execute_LiveHostsAndOpenPorts(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init("test-live", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	target := "192.0.2.5"
+	port := 443
+	inputs := map[string]interface{}{
+		"config.targets": []string{target},
+		"discovery.live_hosts": []interface{}{
+			discovery.ICMPPingDiscoveryResult{LiveHosts: []string{target}},
+		},
+		"discovery.open_tcp_ports": []interface{}{
+			discovery.TCPPortDiscoveryResult{Target: target, OpenPorts: []int{port}},
+		},
+		"service.banner.tcp": []interface{}{
+			scan.BannerGrabResult{IP: target, Port: port, Banner: "HTTPS Service", IsTLS: true},
+		},
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	err := module.Execute(context.Background(), inputs, outCh)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) != 1 {
+			t.Fatalf("expected 1 profile, got %d", len(profiles))
+		}
+		profile := profiles[0]
+		if !profile.IsAlive {
+			t.Errorf("expected IsAlive=true for %s", profile.Target)
+		}
+		ports := profile.OpenPorts[target]
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 open port, got %d", len(ports))
+		}
+		if ports[0].PortNumber != port {
+			t.Errorf("expected port %d, got %d", port, ports[0].PortNumber)
+		}
+		if ports[0].Service.RawBanner != "HTTPS Service" {
+			t.Errorf("expected banner 'HTTPS Service', got %q", ports[0].Service.RawBanner)
+		}
+		if !ports[0].Service.IsTLS {
+			t.Errorf("expected IsTLS=true")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilder_Execute_HTTPAndSSHDetails(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init("test-details", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	target := "192.0.2.10"
+	httpPort := 80
+	sshPort := 22
+
+	inputs := map[string]interface{}{
+		"config.targets": []string{target},
+		"discovery.open_tcp_ports": []interface{}{
+			discovery.TCPPortDiscoveryResult{Target: target, OpenPorts: []int{httpPort, sshPort}},
+		},
+		"service.http.details": []interface{}{
+			parse.HTTPParsedInfo{
+				Target:        target,
+				Port:          httpPort,
+				ServerProduct: "nginx",
+				ServerVersion: "1.21.0",
+				StatusCode:    200,
+				HTTPVersion:   "1.1",
+				HTMLTitle:     "Welcome",
+				ContentType:   "text/html",
+				Headers:       map[string]string{"Server": "nginx"},
+			},
+		},
+		"service.ssh.details": []interface{}{
+			parse.SSHParsedInfo{
+				Target:          target,
+				Port:            sshPort,
+				ProtocolName:    "ssh",
+				Software:        "OpenSSH",
+				SoftwareVersion: "8.9p1",
+				SSHVersion:      "2.0",
+				VersionInfo:     "OpenSSH_8.9p1 Debian-3",
+			},
+		},
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	err := module.Execute(context.Background(), inputs, outCh)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) == 0 {
+			t.Fatalf("no asset profiles returned")
+		}
+		profile := profiles[0]
+		ports := profile.OpenPorts[target]
+		if len(ports) != 2 {
+			t.Fatalf("expected 2 open ports, got %d", len(ports))
+		}
+		var httpFound, sshFound bool
+		for _, p := range ports {
+			if p.PortNumber == httpPort {
+				httpFound = true
+				if p.Service.Name != "http" {
+					t.Errorf("expected service name http, got %s", p.Service.Name)
+				}
+				if p.Service.Product != "nginx" {
+					t.Errorf("expected product nginx, got %s", p.Service.Product)
+				}
+				if p.Service.Version != "1.21.0" {
+					t.Errorf("expected version 1.21.0, got %s", p.Service.Version)
+				}
+				if p.Service.ParsedAttributes["http_status_code"] != 200 {
+					t.Errorf("expected status code 200, got %v", p.Service.ParsedAttributes["http_status_code"])
+				}
+			}
+			if p.PortNumber == sshPort {
+				sshFound = true
+				if p.Service.Name != "ssh" {
+					t.Errorf("expected service name ssh, got %s", p.Service.Name)
+				}
+				if p.Service.Product != "OpenSSH" {
+					t.Errorf("expected product OpenSSH, got %s", p.Service.Product)
+				}
+				if p.Service.Version != "8.9p1" {
+					t.Errorf("expected version 8.9p1, got %s", p.Service.Version)
+				}
+				if p.Service.ParsedAttributes["ssh_protocol_version"] != "2.0" {
+					t.Errorf("expected ssh_protocol_version 2.0, got %v", p.Service.ParsedAttributes["ssh_protocol_version"])
+				}
+			}
+		}
+		if !httpFound {
+			t.Error("HTTP port not found in profile")
+		}
+		if !sshFound {
+			t.Error("SSH port not found in profile")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no output emitted")
+	}
+}
+
+func TestAssetProfileBuilder_Execute_FingerprintOverridesBanner(t *testing.T) {
+	module := newAssetProfileBuilderModule()
+	if err := module.Init("test-fp", map[string]interface{}{}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	target := "192.0.2.20"
+	port := 8081
+
+	inputs := map[string]interface{}{
+		"config.targets": []string{target},
+		"discovery.open_tcp_ports": []interface{}{
+			discovery.TCPPortDiscoveryResult{Target: target, OpenPorts: []int{port}},
+		},
+		"service.banner.tcp": []interface{}{
+			scan.BannerGrabResult{IP: target, Port: port, Banner: "SomeBanner"},
+		},
+		"service.fingerprint.details": []interface{}{
+			parse.FingerprintParsedInfo{
+				Target:      target,
+				Port:        port,
+				Protocol:    "customproto",
+				Product:     "CustomProduct",
+				Version:     "2.3.4",
+				Confidence:  0.99,
+				CPE:         "cpe:/a:custom:product:2.3.4",
+				Vendor:      "CustomVendor",
+				Description: "Custom service",
+				SourceProbe: "fp-probe",
+			},
+		},
+	}
+
+	outCh := make(chan engine.ModuleOutput, 1)
+	err := module.Execute(context.Background(), inputs, outCh)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	select {
+	case out := <-outCh:
+		profiles, ok := out.Data.([]engine.AssetProfile)
+		if !ok {
+			t.Fatalf("expected []engine.AssetProfile, got %T", out.Data)
+		}
+		if len(profiles) == 0 {
+			t.Fatalf("no asset profiles returned")
+		}
+		profile := profiles[0]
+		ports := profile.OpenPorts[target]
+		if len(ports) == 0 {
+			t.Fatalf("expected open port entry")
+		}
+		service := ports[0].Service
+		if service.Name != "customproto" {
+			t.Errorf("expected service name customproto, got %s", service.Name)
+		}
+		if service.Product != "CustomProduct" {
+			t.Errorf("expected product CustomProduct, got %s", service.Product)
+		}
+		if service.Version != "2.3.4" {
+			t.Errorf("expected version 2.3.4, got %s", service.Version)
+		}
+		if service.ParsedAttributes["cpe"] != "cpe:/a:custom:product:2.3.4" {
+			t.Errorf("expected cpe attribute, got %v", service.ParsedAttributes["cpe"])
+		}
+		if service.ParsedAttributes["vendor"] != "CustomVendor" {
+			t.Errorf("expected vendor attribute, got %v", service.ParsedAttributes["vendor"])
+		}
+		if service.ParsedAttributes["fingerprint_primary_description"] != "Custom service" {
+			t.Errorf("expected fingerprint_primary_description, got %v", service.ParsedAttributes["fingerprint_primary_description"])
+		}
+		if service.ParsedAttributes["fingerprint_primary_probe"] != "fp-probe" {
+			t.Errorf("expected fingerprint_primary_probe, got %v", service.ParsedAttributes["fingerprint_primary_probe"])
+		}
+		if service.ParsedAttributes["fingerprint_confidence"] != 0.99 {
+			t.Errorf("expected fingerprint_confidence 0.99, got %v", service.ParsedAttributes["fingerprint_confidence"])
 		}
 	case <-time.After(time.Second):
 		t.Fatal("no output emitted")


### PR DESCRIPTION
This PR raises test coverage across several non-CLI packages.

Highlights
- fingerprint: add parse and validation metrics unit tests (list/wrapper YAML, TP/FP/FN/TN metrics).
- engine/proto: add smoke test to pin generated types.
- fingerprint/catalogsync: add FileSource/FileStore/HTTPSource tests (success + error paths).
- reporting: add asset profile builder tests for empty inputs and parsed HTTP/SSH detail merge.
- evaluation: keep stable tests (TLS weak cipher); removed TLS cert tests for now (will return once test context aligns with plugin triggers).

Why
- Improves confidence without touching production code.
- Focus on fast, deterministic unit tests.

Notes
- TLS expired/self-signed plugin tests will return in a follow-up once we align test context with embedded plugin match rules.
- No CLI changes.

Validation
- go test ./... -covermode=atomic
- Module-level runs for evaluation and reporting pass locally.
