### PR TITLE
fix(cli): make a reported failure actually fail

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	vulntorCli "github.com/cyprob/cyprob/cmd/vulntor/commands"
@@ -25,6 +26,13 @@ func main() {
 
 	err := command.Execute()
 	if err != nil {
+		// Cobra is silenced so that a failure a command already summarized is
+		// not stated twice. Everything it has NOT shown — an unknown flag, a
+		// wrong argument count, a bad config file — is printed here, otherwise
+		// the process would exit non-zero saying nothing at all.
+		if !vulntorCli.IsAlreadyReported(err) {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+		}
 		// Determine exit code based on error type
 		exitCode := getExitCode(err)
 		os.Exit(exitCode)

--- a/cmd/vulntor/commands/dag/export_test.go
+++ b/cmd/vulntor/commands/dag/export_test.go
@@ -191,7 +191,9 @@ func TestExportCommand_InvalidFormat(t *testing.T) {
 	cmd.SetArgs([]string{"--format", "xml"})
 
 	err := cmd.Execute()
-	require.NoError(t, err)
+	// The command reports a failure, so it must also RETURN one: this is what
+	// gives the process a non-zero exit code.
+	require.Error(t, err)
 
 	output := out.String()
 	require.Contains(t, output, "✗ Failed to export DAG")

--- a/cmd/vulntor/commands/dag/validate_test.go
+++ b/cmd/vulntor/commands/dag/validate_test.go
@@ -173,7 +173,9 @@ func TestValidateCommand_MissingFileSuggestions(t *testing.T) {
 	cmd.SetArgs([]string{"/nonexistent/file.yaml"})
 
 	err := cmd.Execute()
-	require.NoError(t, err)
+	// The command reports a failure, so it must also RETURN one: this is what
+	// gives the process a non-zero exit code.
+	require.Error(t, err)
 
 	output := out.String()
 	require.Contains(t, output, "✗ Failed to validate DAG")

--- a/cmd/vulntor/commands/fingerprint.go
+++ b/cmd/vulntor/commands/fingerprint.go
@@ -116,9 +116,10 @@ func newFingerprintValidateCommand() *cobra.Command {
 					return printErr
 				}
 				// The JSON object already states the outcome, so the failure is
-				// reported; it still has to fail. This is the flag CI reaches
-				// for, and returning success on an invalid database here would
-				// leave the check as decorative as it was before.
+				// reported; it still has to fail. CI calls this command without
+				// --json, so what closes that gate is the sibling change in the
+				// summary printer -- but a caller parsing the JSON was reading
+				// "valid": false out of a process that had just exited 0.
 				if !result.IsValid() {
 					return format.Reported(fingerprint.NewValidationError(
 						len(result.Errors), len(result.Warnings)))

--- a/cmd/vulntor/commands/fingerprint.go
+++ b/cmd/vulntor/commands/fingerprint.go
@@ -107,12 +107,23 @@ func newFingerprintValidateCommand() *cobra.Command {
 
 			// Output results
 			if jsonOutput {
-				return formatter.PrintJSON(map[string]any{
+				if printErr := formatter.PrintJSON(map[string]any{
 					"valid":      result.IsValid(),
 					"rule_count": result.RuleCount,
 					"errors":     result.Errors,
 					"warnings":   result.Warnings,
-				})
+				}); printErr != nil {
+					return printErr
+				}
+				// The JSON object already states the outcome, so the failure is
+				// reported; it still has to fail. This is the flag CI reaches
+				// for, and returning success on an invalid database here would
+				// leave the check as decorative as it was before.
+				if !result.IsValid() {
+					return format.Reported(fingerprint.NewValidationError(
+						len(result.Errors), len(result.Warnings)))
+				}
+				return nil
 			}
 
 			// Text output

--- a/cmd/vulntor/commands/fingerprint_test.go
+++ b/cmd/vulntor/commands/fingerprint_test.go
@@ -17,7 +17,9 @@ func TestFingerprintSyncCommand_SourceRequiredSuggestions(t *testing.T) {
 	cmd.SetArgs([]string{"sync"})
 
 	err := cmd.Execute()
-	require.NoError(t, err)
+	// The command reports a failure, so it must also RETURN one: this is what
+	// gives the process a non-zero exit code.
+	require.Error(t, err)
 
 	output := out.String()
 	require.Contains(t, output, "✗ Failed to sync fingerprint catalog")

--- a/cmd/vulntor/commands/plugin/embedded.go
+++ b/cmd/vulntor/commands/plugin/embedded.go
@@ -98,7 +98,11 @@ func filterPluginsByCategory(plugins map[plugin.Category][]*plugin.YAMLPlugin, c
 		case "misc":
 			categoryFilter = plugin.CategoryMisc
 		default:
-			return nil, formatter.PrintTotalFailureSummary("embedded", fmt.Errorf("unknown category: %s", category), "INVALID_CATEGORY")
+			// Same reason as info: the sentinel is what carries the ADR-0001
+			// exit code, and a plain Errorf drops it.
+			return nil, formatter.PrintTotalFailureSummary("embedded",
+				fmt.Errorf("unknown category: %s: %w", category, plugin.ErrInvalidCategory),
+				"INVALID_CATEGORY")
 		}
 
 		// Get plugins for the specified category

--- a/cmd/vulntor/commands/plugin/helpers.go
+++ b/cmd/vulntor/commands/plugin/helpers.go
@@ -64,8 +64,13 @@ func getPluginService(cmd *cobra.Command, cacheDir string) (*plugin.Service, err
 // handlePartialFailure handles partial failure errors by printing results and exiting with code 8
 func handlePartialFailure(err error, formatter format.Formatter, printFunc func() error) error {
 	if err != nil && errors.Is(err, plugin.ErrPartialFailure) {
-		// Print result even on partial failure
-		if printErr := printFunc(); printErr != nil {
+		// Print result even on partial failure.
+		//
+		// The printer returns the failure it just reported, which must not be
+		// mistaken for a problem printing it: returning here would skip the
+		// exit below, and ADR-0001 gives partial failure its own code that
+		// cmd/main.go cannot recover from a wrapped error.
+		if printErr := printFunc(); printErr != nil && !format.IsAlreadyReported(printErr) {
 			return printErr
 		}
 		// Exit with code 8 for partial failure

--- a/cmd/vulntor/commands/plugin/helpers.go
+++ b/cmd/vulntor/commands/plugin/helpers.go
@@ -61,6 +61,10 @@ func getPluginService(cmd *cobra.Command, cacheDir string) (*plugin.Service, err
 	return svc, nil
 }
 
+// exitProcess is the process exit used by handlePartialFailure. It is a
+// variable so a test can observe the code instead of ending the test binary.
+var exitProcess = os.Exit
+
 // handlePartialFailure handles partial failure errors by printing results and exiting with code 8
 func handlePartialFailure(err error, formatter format.Formatter, printFunc func() error) error {
 	if err != nil && errors.Is(err, plugin.ErrPartialFailure) {
@@ -74,7 +78,7 @@ func handlePartialFailure(err error, formatter format.Formatter, printFunc func(
 			return printErr
 		}
 		// Exit with code 8 for partial failure
-		os.Exit(plugin.ExitCode(err))
+		exitProcess(plugin.ExitCode(err))
 	}
 	return nil
 }

--- a/cmd/vulntor/commands/plugin/helpers_test.go
+++ b/cmd/vulntor/commands/plugin/helpers_test.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"bytes"
 	"errors"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -144,4 +146,15 @@ func TestCommandErrorsKeepTheirSentinel(t *testing.T) {
 			require.Equal(t, tc.wantCode, plugin.ExitCode(err))
 		})
 	}
+}
+
+// The seam exists so a test can read the exit code. Nothing else pins that
+// production still exits the process through it: replacing the variable with a
+// no-op left the whole suite green, which means the seam was protecting the
+// tests and not the behavior.
+func TestExitProcessStillExitsTheProcess(t *testing.T) {
+	require.Equal(t,
+		reflect.ValueOf(os.Exit).Pointer(),
+		reflect.ValueOf(exitProcess).Pointer(),
+		"exitProcess must be os.Exit outside a test that deliberately captures it")
 }

--- a/cmd/vulntor/commands/plugin/helpers_test.go
+++ b/cmd/vulntor/commands/plugin/helpers_test.go
@@ -1,0 +1,105 @@
+package plugin
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cyprob/cyprob/cmd/vulntor/internal/format"
+	"github.com/cyprob/cyprob/pkg/plugin"
+)
+
+// captureExit replaces the process exit so a test can read the code instead of
+// ending the test binary.
+func captureExit(t *testing.T) *int {
+	t.Helper()
+	original := exitProcess
+	t.Cleanup(func() { exitProcess = original })
+
+	var got int
+	captured := &got
+	exitProcess = func(code int) { *captured = code }
+	return captured
+}
+
+// ADR-0001 gives partial failure its own exit code, and cmd/main.go cannot
+// derive it: the error the printer returns no longer carries the sentinel, so
+// the code has to come from the exit below the printer. A printer result that
+// merely reports the failure must therefore not be mistaken for a failure to
+// print, which would return early and skip it.
+func TestHandlePartialFailure_ExitsWithTheADRCode(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		printed error
+	}{
+		{"summary printed", format.Reported(errors.New("1 of 1 failed"))},
+		{"quiet, deliberately not printed", format.Reported(errors.New("1 of 1 failed"))},
+		{"printer reported nothing", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code := captureExit(t)
+
+			err := handlePartialFailure(plugin.ErrPartialFailure, nil, func() error {
+				return tc.printed
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, 8, *code, "partial failure must exit 8, not fall through to 1")
+		})
+	}
+}
+
+// A genuine failure to write to the terminal is a different thing and must
+// surface, rather than being swallowed by an exit that claims to know why.
+func TestHandlePartialFailure_AWriteFailureIsReturned(t *testing.T) {
+	code := captureExit(t)
+	writeErr := errors.New("write /dev/stdout: broken pipe")
+
+	err := handlePartialFailure(plugin.ErrPartialFailure, nil, func() error {
+		return writeErr
+	})
+
+	require.ErrorIs(t, err, writeErr)
+	require.Zero(t, *code, "an unprintable result must not be reported as partial failure")
+}
+
+func TestHandlePartialFailure_IgnoresOtherErrors(t *testing.T) {
+	code := captureExit(t)
+	called := false
+
+	err := handlePartialFailure(errors.New("something else"), nil, func() error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.False(t, called, "only a partial failure is handled here")
+	require.Zero(t, *code)
+}
+
+func TestHandlePartialFailure_NilErrorIsANoOp(t *testing.T) {
+	code := captureExit(t)
+	require.NoError(t, handlePartialFailure(nil, nil, func() error {
+		t.Fatal("printer must not run without a failure")
+		return nil
+	}))
+	require.Zero(t, *code)
+}
+
+// The seam exists so the exit code can be asserted; this pins that the marker
+// the guard depends on is the one the printers actually produce, in both the
+// visible and the quiet path.
+func TestPrinterOutputIsMarkedInBothPaths(t *testing.T) {
+	cause := errors.New("1 of 1 failed")
+
+	loud := format.New(&bytes.Buffer{}, &bytes.Buffer{}, format.ModeTable, false, false)
+	require.True(t, format.IsAlreadyReported(
+		loud.PrintTotalFailureSummary("install plugin", cause, "PLUGIN_NOT_FOUND")))
+
+	quiet := format.New(&bytes.Buffer{}, &bytes.Buffer{}, format.ModeTable, true, false)
+	require.True(t, format.IsAlreadyReported(
+		quiet.PrintTotalFailureSummary("install plugin", cause, "PLUGIN_NOT_FOUND")),
+		"quiet still counts as handled: the user asked for silence")
+}

--- a/cmd/vulntor/commands/plugin/helpers_test.go
+++ b/cmd/vulntor/commands/plugin/helpers_test.go
@@ -103,3 +103,45 @@ func TestPrinterOutputIsMarkedInBothPaths(t *testing.T) {
 		quiet.PrintTotalFailureSummary("install plugin", cause, "PLUGIN_NOT_FOUND")),
 		"quiet still counts as handled: the user asked for silence")
 }
+
+// The ADR-0001 exit codes are reachable only through the sentinels, so an error
+// that reports the right code on screen while dropping the sentinel exits with
+// the wrong one. These commands construct their error by hand, which is exactly
+// where the sentinel gets lost.
+func TestCommandErrorsKeepTheirSentinel(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		sentinel error
+		wantCode int
+	}{
+		{
+			name:     "info on a plugin that is not installed",
+			args:     []string{"info", "no-such-plugin-xyz", "--cache-dir", t.TempDir()},
+			sentinel: plugin.ErrPluginNotFound,
+			wantCode: 4,
+		},
+		{
+			name:     "embedded with a category that does not exist",
+			args:     []string{"embedded", "--category", "no-such-category"},
+			sentinel: plugin.ErrInvalidCategory,
+			wantCode: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Built from the parent, because the output and quiet flags the
+			// formatter reads are persistent flags on it.
+			cmd := NewCommand()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.sentinel,
+				"the sentinel is what cmd/main.go maps to an exit code")
+			require.Equal(t, tc.wantCode, plugin.ExitCode(err))
+		})
+	}
+}

--- a/cmd/vulntor/commands/plugin/info.go
+++ b/cmd/vulntor/commands/plugin/info.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -73,8 +74,13 @@ func executeInfoCommand(cmd *cobra.Command, pluginName, cacheDir string) error {
 	// Call service layer
 	info, err := svc.GetInfo(ctx, pluginName)
 	if err != nil {
-		if err == plugin.ErrPluginNotFound {
-			return formatter.PrintTotalFailureSummary("info", fmt.Errorf("plugin '%s' not found", pluginName), plugin.ErrorCode(err))
+		if errors.Is(err, plugin.ErrPluginNotFound) {
+			// The sentinel has to survive into the returned error: it is what
+			// cmd/main.go maps to the ADR-0001 "not found" code. Dropping it
+			// printed the right code and exited with the wrong one.
+			return formatter.PrintTotalFailureSummary("info",
+				fmt.Errorf("plugin '%s' not found: %w", pluginName, plugin.ErrPluginNotFound),
+				plugin.ErrorCode(err))
 		}
 		return formatter.PrintTotalFailureSummary("info", err, plugin.ErrorCode(err))
 	}

--- a/cmd/vulntor/commands/root.go
+++ b/cmd/vulntor/commands/root.go
@@ -12,6 +12,7 @@ import (
 	pluginCmd "github.com/cyprob/cyprob/cmd/vulntor/commands/plugin"
 	serverCmd "github.com/cyprob/cyprob/cmd/vulntor/commands/server"
 	storageCmd "github.com/cyprob/cyprob/cmd/vulntor/commands/storage"
+	"github.com/cyprob/cyprob/cmd/vulntor/internal/format"
 	"github.com/cyprob/cyprob/pkg/appctx"
 	"github.com/cyprob/cyprob/pkg/cli"
 	"github.com/cyprob/cyprob/pkg/config"
@@ -98,8 +99,9 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.SilenceUsage = true
-	// The commands print their own failure summary before returning the error,
-	// so cobra restating it as "Error: ..." would say the same thing twice.
+	// Errors are printed by main rather than by cobra, so that a failure the
+	// command has already summarized is not stated twice while cobra's own
+	// errors — an unknown flag, a wrong argument count — still reach the user.
 	cmd.SilenceErrors = true
 
 	cmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Configuration file path")
@@ -124,4 +126,10 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(NewStatsCommand())
 
 	return cmd
+}
+
+// IsAlreadyReported reports whether a command has already shown err to the
+// user. Exposed for main, which cannot import the internal format package.
+func IsAlreadyReported(err error) bool {
+	return format.IsAlreadyReported(err)
 }

--- a/cmd/vulntor/commands/root.go
+++ b/cmd/vulntor/commands/root.go
@@ -98,6 +98,9 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.SilenceUsage = true
+	// The commands print their own failure summary before returning the error,
+	// so cobra restating it as "Error: ..." would say the same thing twice.
+	cmd.SilenceErrors = true
 
 	cmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Configuration file path")
 	cmd.PersistentFlags().StringVar(&storageDir, "storage-dir", "", "Override storage root directory")

--- a/cmd/vulntor/commands/server/start_test.go
+++ b/cmd/vulntor/commands/server/start_test.go
@@ -17,7 +17,9 @@ func TestStartCommand_InvalidPortShowsSuggestions(t *testing.T) {
 	cmd.SetArgs([]string{"--port", "0"})
 
 	err := cmd.Execute()
-	require.NoError(t, err)
+	// The command reports a failure, so it must also RETURN one: this is what
+	// gives the process a non-zero exit code.
+	require.Error(t, err)
 
 	output := out.String()
 	require.Contains(t, output, "✗ Failed to start server")

--- a/cmd/vulntor/internal/format/reported.go
+++ b/cmd/vulntor/internal/format/reported.go
@@ -1,0 +1,38 @@
+package format
+
+import "errors"
+
+// errAlreadyReported marks an error whose message the user has already seen.
+//
+// The summary printers show a failure and then return it, so that the command
+// exits non-zero. Without a marker the caller cannot tell that error apart from
+// one nobody has printed yet, and it would be shown twice — or, if the caller
+// silences printing to avoid that, cobra's own errors (an unknown flag, a wrong
+// argument count) would be silenced along with it.
+var errAlreadyReported = errors.New("already reported")
+
+// reportedError carries a failure that has been shown to the user.
+type reportedError struct{ cause error }
+
+func (e reportedError) Error() string { return e.cause.Error() }
+
+// Unwrap keeps errors.Is working through the marker, so a sentinel the caller
+// matches on — plugin.ErrPartialFailure, for instance — survives being wrapped.
+func (e reportedError) Unwrap() error { return e.cause }
+
+func (e reportedError) Is(target error) bool { return target == errAlreadyReported }
+
+// Reported marks err as already shown to the user. It returns nil for nil, so
+// it can wrap a printer's result without inventing a failure.
+func Reported(err error) error {
+	if err == nil {
+		return nil
+	}
+	return reportedError{cause: err}
+}
+
+// IsAlreadyReported reports whether err has been shown to the user, and so
+// should not be printed again.
+func IsAlreadyReported(err error) bool {
+	return errors.Is(err, errAlreadyReported)
+}

--- a/cmd/vulntor/internal/format/reported.go
+++ b/cmd/vulntor/internal/format/reported.go
@@ -22,8 +22,10 @@ func (e reportedError) Unwrap() error { return e.cause }
 
 func (e reportedError) Is(target error) bool { return target == errAlreadyReported }
 
-// Reported marks err as already shown to the user. It returns nil for nil, so
-// it can wrap a printer's result without inventing a failure.
+// Reported marks err as handled for display: either it has been shown to the
+// user, or the user asked for silence and it deliberately was not. Either way
+// nobody else should print it. It returns nil for nil, so it can wrap a
+// printer's result without inventing a failure.
 func Reported(err error) error {
 	if err == nil {
 		return nil
@@ -31,8 +33,8 @@ func Reported(err error) error {
 	return reportedError{cause: err}
 }
 
-// IsAlreadyReported reports whether err has been shown to the user, and so
-// should not be printed again.
+// IsAlreadyReported reports whether err has already been handled for display
+// and so must not be printed again.
 func IsAlreadyReported(err error) bool {
 	return errors.Is(err, errAlreadyReported)
 }

--- a/cmd/vulntor/internal/format/reported_test.go
+++ b/cmd/vulntor/internal/format/reported_test.go
@@ -1,0 +1,65 @@
+package format
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var errSentinel = errors.New("sentinel")
+
+func TestReported_MarksWithoutHidingTheCause(t *testing.T) {
+	wrapped := Reported(errSentinel)
+
+	require.True(t, IsAlreadyReported(wrapped))
+	require.EqualError(t, wrapped, "sentinel")
+	require.ErrorIs(t, wrapped, errSentinel,
+		"a caller matching on its own sentinel must still find it through the marker")
+}
+
+func TestReported_NilStaysNil(t *testing.T) {
+	require.NoError(t, Reported(nil), "marking must not invent a failure")
+	require.False(t, IsAlreadyReported(nil))
+	require.False(t, IsAlreadyReported(errSentinel), "an unprinted error is not reported")
+}
+
+// The printer shows the failure, so what it returns must say so: main prints
+// only what nobody has shown yet, and the plugin commands rely on this to tell
+// a reported failure apart from a problem writing to the terminal.
+func TestPrintTotalFailureSummary_ReturnsTheFailureMarkedAsReported(t *testing.T) {
+	out := &bytes.Buffer{}
+	f := &formatter{stdout: out, mode: ModeTable}
+
+	err := f.PrintTotalFailureSummary("install plugin", errSentinel, "PLUGIN_NOT_FOUND")
+
+	require.Error(t, err, "a reported failure must still fail")
+	require.ErrorIs(t, err, errSentinel)
+	require.True(t, IsAlreadyReported(err))
+	require.Contains(t, out.String(), "Failed to install plugin")
+}
+
+// Quiet suppresses the summary, not the failure. Nothing was shown, so the
+// error must NOT claim to have been reported or it would be swallowed silently.
+func TestPrintTotalFailureSummary_QuietFailsWithoutClaimingToHavePrinted(t *testing.T) {
+	out := &bytes.Buffer{}
+	f := &formatter{stdout: out, mode: ModeTable, quiet: true}
+
+	err := f.PrintTotalFailureSummary("install plugin", errSentinel, "PLUGIN_NOT_FOUND")
+
+	require.ErrorIs(t, err, errSentinel)
+	require.False(t, IsAlreadyReported(err), "nothing was printed, so nothing was reported")
+	require.Empty(t, out.String())
+}
+
+func TestPrintTotalFailureSummary_JSONReportsAndFails(t *testing.T) {
+	out := &bytes.Buffer{}
+	f := &formatter{stdout: out, mode: ModeJSON}
+
+	err := f.PrintTotalFailureSummary("install plugin", errSentinel, "PLUGIN_NOT_FOUND")
+
+	require.ErrorIs(t, err, errSentinel)
+	require.True(t, IsAlreadyReported(err))
+	require.Contains(t, out.String(), `"success"`)
+}

--- a/cmd/vulntor/internal/format/reported_test.go
+++ b/cmd/vulntor/internal/format/reported_test.go
@@ -40,16 +40,22 @@ func TestPrintTotalFailureSummary_ReturnsTheFailureMarkedAsReported(t *testing.T
 	require.Contains(t, out.String(), "Failed to install plugin")
 }
 
-// Quiet suppresses the summary, not the failure. Nothing was shown, so the
-// error must NOT claim to have been reported or it would be swallowed silently.
-func TestPrintTotalFailureSummary_QuietFailsWithoutClaimingToHavePrinted(t *testing.T) {
+// Quiet suppresses the summary, not the failure — and the error is still
+// marked. The user asked for silence, so nobody downstream should print it
+// either, and the exit code is what carries the failure.
+//
+// The first version of this test asserted the opposite, and pinned the
+// precondition for a real defect: an unmarked error made the plugin commands
+// skip their ADR-0001 exit code under --quiet and leaked a line to stderr that
+// --quiet had asked not to see.
+func TestPrintTotalFailureSummary_QuietStaysSilentAndStillFails(t *testing.T) {
 	out := &bytes.Buffer{}
 	f := &formatter{stdout: out, mode: ModeTable, quiet: true}
 
 	err := f.PrintTotalFailureSummary("install plugin", errSentinel, "PLUGIN_NOT_FOUND")
 
-	require.ErrorIs(t, err, errSentinel)
-	require.False(t, IsAlreadyReported(err), "nothing was printed, so nothing was reported")
+	require.ErrorIs(t, err, errSentinel, "quiet suppresses the summary, not the failure")
+	require.True(t, IsAlreadyReported(err), "the user asked for silence, so nobody prints it")
 	require.Empty(t, out.String())
 }
 

--- a/cmd/vulntor/internal/format/summary.go
+++ b/cmd/vulntor/internal/format/summary.go
@@ -175,7 +175,8 @@ func (f *formatter) PrintPartialFailureSummary(summary Summary) error {
 // reported success to whatever ran them.
 func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorCode string) error {
 	if f.quiet {
-		// Quiet suppresses the summary, not the failure.
+		// Quiet suppresses the summary, not the failure. Nothing was shown, so
+		// the error is not marked as reported and the caller still prints it.
 		return err
 	}
 
@@ -189,7 +190,7 @@ func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorC
 		}); printErr != nil {
 			return printErr
 		}
-		return err
+		return Reported(err)
 	}
 
 	// Table mode: formatted error with suggestions
@@ -215,7 +216,7 @@ func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorC
 	if _, writeErr := f.stdout.Write([]byte(sb.String())); writeErr != nil {
 		return writeErr
 	}
-	return err
+	return Reported(err)
 }
 
 var suggestionGenerators = map[string]func(string) []string{

--- a/cmd/vulntor/internal/format/summary.go
+++ b/cmd/vulntor/internal/format/summary.go
@@ -175,9 +175,12 @@ func (f *formatter) PrintPartialFailureSummary(summary Summary) error {
 // reported success to whatever ran them.
 func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorCode string) error {
 	if f.quiet {
-		// Quiet suppresses the summary, not the failure. Nothing was shown, so
-		// the error is not marked as reported and the caller still prints it.
-		return err
+		// Quiet suppresses the summary, not the failure. The error is still
+		// marked: the user asked for silence, so nobody else should print it
+		// either, and the exit code is the channel that carries the failure.
+		// Leaving it unmarked both leaked a line to stderr under --quiet and
+		// cost the plugin commands their ADR-0001 exit code.
+		return Reported(err)
 	}
 
 	if f.mode == ModeJSON {

--- a/cmd/vulntor/internal/format/summary.go
+++ b/cmd/vulntor/internal/format/summary.go
@@ -168,20 +168,28 @@ func (f *formatter) PrintPartialFailureSummary(summary Summary) error {
 //	💡 Suggestions:
 //	  → List available plugins:  vulntor plugin list
 //	  → Try GitHub source:       vulntor plugin install ssh-weak-cipher --source github
+// The reported operation FAILED, so this returns that failure. Callers use it
+// as `return formatter.PrintTotalFailureSummary(...)`, and returning nil there
+// made every one of those paths exit 0 while printing "Failed to ...": a failed
+// scan, a server that could not start and a validation that found errors all
+// reported success to whatever ran them.
 func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorCode string) error {
 	if f.quiet {
-		// Quiet mode: suppress summary
-		return nil
+		// Quiet suppresses the summary, not the failure.
+		return err
 	}
 
 	if f.mode == ModeJSON {
 		// JSON mode: structured output
-		return f.PrintJSON(map[string]any{
+		if printErr := f.PrintJSON(map[string]any{
 			"success":    false,
 			"operation":  operation,
 			"error":      err.Error(),
 			"error_code": errorCode,
-		})
+		}); printErr != nil {
+			return printErr
+		}
+		return err
 	}
 
 	// Table mode: formatted error with suggestions
@@ -204,8 +212,10 @@ func (f *formatter) PrintTotalFailureSummary(operation string, err error, errorC
 		}
 	}
 
-	_, writeErr := f.stdout.Write([]byte(sb.String()))
-	return writeErr
+	if _, writeErr := f.stdout.Write([]byte(sb.String())); writeErr != nil {
+		return writeErr
+	}
+	return err
 }
 
 var suggestionGenerators = map[string]func(string) []string{

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -915,7 +915,7 @@ rules:
     product: 'BIND'
     vendor: 'ISC'
     cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
-    match: 'bind|named'
+    match: 'bind|named|dns'
     version_extraction: "(?:bind|named)[\\s/_-]+([\\d\\.]+)"
 
     exclude_patterns:
@@ -927,7 +927,7 @@ rules:
       - "error"
       - "refused"
 
-    pattern_strength: 0.90
+    pattern_strength: 0.85
     port_bonuses: [53]
 
   # File Sharing / Windows Services

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -915,7 +915,7 @@ rules:
     product: 'BIND'
     vendor: 'ISC'
     cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
-    match: 'bind|named|dns'
+    match: 'bind|named'
     version_extraction: "(?:bind|named)[\\s/_-]+([\\d\\.]+)"
 
     exclude_patterns:
@@ -927,7 +927,7 @@ rules:
       - "error"
       - "refused"
 
-    pattern_strength: 0.85
+    pattern_strength: 0.90
     port_bonuses: [53]
 
   # File Sharing / Windows Services
@@ -981,27 +981,6 @@ rules:
   # (netbios-session and rpc-bind probes in probes.yaml) rather than pattern matching to avoid false positives.
 
   # DNS Servers
-  - id: 'dns.bind'
-    protocol: 'dns'
-    description: 'ISC BIND DNS server'
-    product: 'BIND'
-    vendor: 'ISC'
-    cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
-    match: 'BIND|named'
-    version_extraction: "BIND\\s+([0-9.]+)"
-
-    exclude_patterns:
-      - "http"
-      - "smtp"
-      - "ftp"
-
-    soft_exclude_patterns:
-      - "error"
-      - "refused"
-
-    pattern_strength: 0.90
-    port_bonuses: [53]
-
   # RPC Services
   # Note: RPC responses are binary protocol that's difficult to fingerprint reliably.
   # RPC portmapper detection relies on port-based hints (port 111) and active probes

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -454,11 +454,13 @@ rules:
     vendor: 'Memcached'
     cpe: 'cpe:2.3:a:memcached:memcached:*:*:*:*:*:*:*:*'
     # Anchored, because an unanchored "version N.N.N" appears in the banner of
-    # almost every service that states one: it claimed BIND, nginx and anything
-    # else naming a version. Memcached answers "version" with VERSION at the
-    # start of the line, and "stats" with STAT lines, so those are the shapes
-    # that actually identify it.
-    match: '(?m)^version\s+[\d\.]+|memcached|^stat\s+pid\s+\d+'
+    # almost every service that states one: unanchored it claimed Dovecot,
+    # ProFTPD, Postfix, RealVNC, BIND, nginx and IIS, all of which have rules of
+    # their own. What identifies memcached is the shape of its replies -- VERSION
+    # at the start of a line for the "version" command, and STAT lines for
+    # "stats", of which "STAT pid" is only one; a real stats reply may begin with
+    # any counter.
+    match: '(?m)^version\s+[\d\.]+|memcached|^stat\s+[a-z_]+\s+\S'
     version_extraction: 'version\s+([\d\.]+)'
 
     exclude_patterns:

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -453,7 +453,12 @@ rules:
     product: 'Memcached'
     vendor: 'Memcached'
     cpe: 'cpe:2.3:a:memcached:memcached:*:*:*:*:*:*:*:*'
-    match: 'version\s+[\d\.]+'
+    # Anchored, because an unanchored "version N.N.N" appears in the banner of
+    # almost every service that states one: it claimed BIND, nginx and anything
+    # else naming a version. Memcached answers "version" with VERSION at the
+    # start of the line, and "stats" with STAT lines, so those are the shapes
+    # that actually identify it.
+    match: '(?m)^version\s+[\d\.]+|memcached|^stat\s+pid\s+\d+'
     version_extraction: 'version\s+([\d\.]+)'
 
     exclude_patterns:

--- a/pkg/fingerprint/resolver_rulebased_test.go
+++ b/pkg/fingerprint/resolver_rulebased_test.go
@@ -1061,21 +1061,14 @@ func TestResolve_MongoDB(t *testing.T) {
 	}
 }
 
+// TestResolve_Memcached exercises the rule as shipped.
+//
+// It previously built an inline copy of the YAML, which meant it asserted
+// against a rule nobody runs: the copy kept passing while the shipped rule
+// stopped matching one of these very banners. A test that carries its own
+// definition of the thing it tests measures nothing.
 func TestResolve_Memcached(t *testing.T) {
-	rules := []StaticRule{{
-		ID:                  "db.memcached",
-		Protocol:            "memcached",
-		Product:             "Memcached",
-		Vendor:              "Memcached",
-		CPE:                 "cpe:2.3:a:memcached:memcached:*:*:*:*:*:*:*:*",
-		Match:               `version\s+[\d\.]+`,
-		VersionExtraction:   `version\s+([\d\.]+)`,
-		ExcludePatterns:     []string{`mysql`, `postgres`, `redis`, `mongodb`},
-		SoftExcludePatterns: []string{`error`, `denied`, `refused`, `unavailable`},
-		PatternStrength:     0.85,
-		PortBonuses:         []int{11211, 11212},
-	}}
-	rb := NewRuleBasedResolver(rules)
+	rb := NewRuleBasedResolver(loadBuiltinRules())
 
 	testCases := []struct {
 		name            string
@@ -1084,34 +1077,41 @@ func TestResolve_Memcached(t *testing.T) {
 		expectedVersion string
 		shouldMatch     bool
 	}{
-		{"Memcached 1.6.17", "VERSION 1.6.17", 11211, "1.6.17", true},
-		{"Memcached stats", "STAT version 1.5.22", 11211, "1.5.22", true},
-		{"Memcached 1.4.39", "version 1.4.39", 11212, "1.4.39", true},
+		{"version reply", "VERSION 1.6.17", 11211, "1.6.17", true},
+		{"stats reply beginning with version", "STAT version 1.5.22", 11211, "1.5.22", true},
+		{"stats reply beginning with another counter", "STAT uptime 91\r\nSTAT version 1.6.21\r\nEND", 11211, "1.6.21", true},
+		{"stats reply with no version line at all", "STAT pid 2314\r\nSTAT uptime 91", 11211, "", true},
+		{"lowercase version reply", "version 1.4.39", 11212, "1.4.39", true},
+		{"named outright", "memcached 1.6.21", 0, "", true},
 		{"Redis banner (should reject)", "redis_version:7.0.5", 6379, "", false},
 		{"PostgreSQL banner (should reject)", "PostgreSQL 14.5", 5432, "", false},
+		// A version string belongs to whichever service stated it. These have
+		// rules of their own, and an unanchored memcached pattern took them.
+		{"BIND stating a version", "named version 9.18.4", 5300, "", false},
+		{"a web server stating a version", "nginx version 1.24.0", 8080, "", false},
+		{"an FTP server stating a version", "220 ProFTPD version 1.3.8 Server ready", 2121, "", false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			input := Input{Protocol: "memcached", Banner: tc.banner, Port: tc.port}
-			res, err := rb.Resolve(ctx, input)
+			// Fallback mode, which is what production uses for a service on a
+			// port the catalog does not recognize.
+			res, err := rb.Resolve(context.Background(), Input{Banner: tc.banner, Port: tc.port})
 
-			if tc.shouldMatch {
-				if err != nil {
-					t.Fatalf("expected match, got error: %v", err)
+			if !tc.shouldMatch {
+				if err == nil && res.Product == "Memcached" {
+					t.Fatalf("expected not to be Memcached, got %+v", res)
 				}
-				if res.Product != "Memcached" {
-					t.Fatalf("expected Memcached, got %s", res.Product)
-				}
-				if res.Vendor != "Memcached" {
-					t.Fatalf("expected Memcached, got %s", res.Vendor)
-				}
-				if tc.expectedVersion != "" && res.Version != tc.expectedVersion {
-					t.Fatalf("expected version %s, got %s", tc.expectedVersion, res.Version)
-				}
-			} else if err == nil {
-				t.Fatalf("expected no match, but got result: %+v", res)
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected match, got error: %v", err)
+			}
+			if res.Product != "Memcached" || res.Vendor != "Memcached" {
+				t.Fatalf("expected Memcached/Memcached, got %s/%s", res.Vendor, res.Product)
+			}
+			if tc.expectedVersion != "" && res.Version != tc.expectedVersion {
+				t.Fatalf("expected version %s, got %s", tc.expectedVersion, res.Version)
 			}
 		})
 	}
@@ -1670,12 +1670,12 @@ func TestResolve_BuiltinSmarterMail(t *testing.T) {
 	rb := NewRuleBasedResolver(loadBuiltinRules())
 
 	testCases := []struct {
-		name     string
-		input    Input
-		product  string
-		vendor   string
-		version  string
-		wantErr  bool
+		name    string
+		input   Input
+		product string
+		vendor  string
+		version string
+		wantErr bool
 	}{
 		{
 			name: "imap direct banner",

--- a/pkg/fingerprint/rule_collision_test.go
+++ b/pkg/fingerprint/rule_collision_test.go
@@ -1,0 +1,77 @@
+package fingerprint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resolveFallback resolves the way production does for a service on a port the
+// catalog does not recognize: the parser leaves the protocol hint empty, which
+// puts the resolver into the mode that tries every rule.
+func resolveFallback(t *testing.T, banner string, port int) (Result, error) {
+	t.Helper()
+	return NewRuleBasedResolver(loadBuiltinRules()).
+		Resolve(context.Background(), Input{Protocol: "", Banner: banner, Port: port})
+}
+
+// A rule matching a phrase that almost every service utters competes with the
+// rules that actually identify those services, and wins or loses by whichever
+// strength happens to be higher. The fix is a narrower rule, not a strength
+// war, so this pins the narrowness rather than the ordering.
+//
+// The validation dataset cannot see this: every DNS case in it carries
+// protocol=dns and port=53, where the port bonus settles the contest. The
+// regression only appears on a non-standard port with no protocol hint.
+func TestRuleCollision_AVersionStringDoesNotMakeEverythingMemcached(t *testing.T) {
+	for _, tc := range []struct {
+		name, banner string
+		port         int
+		wantProduct  string
+	}{
+		{"BIND on a non-standard port", "named version 9.18.4", 5300, "BIND"},
+		{"a web server stating its version", "nginx version 1.24.0", 8080, ""},
+		{"an FTP server stating its version", "220 ProFTPD version 1.3.8", 2121, "ProFTPD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := resolveFallback(t, tc.banner, tc.port)
+			if tc.wantProduct == "" {
+				if err == nil {
+					require.NotEqual(t, "Memcached", result.Product,
+						"a version string is not an identity")
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantProduct, result.Product)
+		})
+	}
+}
+
+// The narrowing must not cost Memcached its own identification. It answers
+// "version" with VERSION at the start of a line and "stats" with STAT lines,
+// and those shapes are what name it.
+func TestRuleCollision_MemcachedIsStillIdentified(t *testing.T) {
+	for _, tc := range []struct {
+		name, banner string
+		port         int
+	}{
+		{"version response", "VERSION 1.6.21\r\n", 11211},
+		{"version response on a non-standard port", "VERSION 1.6.21\r\n", 11311},
+		{"stats response", "STAT pid 2314\r\nSTAT uptime 91\r\n", 11211},
+		{"named outright", "memcached 1.6.21", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := resolveFallback(t, tc.banner, tc.port)
+			require.NoError(t, err)
+			require.Equal(t, "Memcached", result.Product)
+		})
+	}
+}
+
+func TestRuleCollision_MemcachedStillReportsItsVersion(t *testing.T) {
+	result, err := resolveFallback(t, "VERSION 1.6.21\r\n", 11211)
+	require.NoError(t, err)
+	require.Equal(t, "1.6.21", result.Version)
+}


### PR DESCRIPTION
## What

Commands that print `✗ Failed to ...` returned `nil` and exited **0**.

`PrintTotalFailureSummary` ends with the error from *writing to the terminal*, not the error it was handed. Callers use it as `return formatter.PrintTotalFailureSummary(...)`, so when printing succeeded — which it does — the command reported success.

It has **45 call sites across 15 command files**: `scan`, `server start`, `storage gc`, `plugin install/update/uninstall/info/verify/list/clean/embedded`, `dag validate/export`, `stats`, `fingerprint`.

A failed scan, a server that could not start, and a plugin install that errored all told their caller they had succeeded.

## Measured

Binaries built from `HEAD` and from this branch, same commands:

| | before | after |
|---|---|---|
| `fingerprint validate <db with a duplicate id>` | **0** | 1 |
| `fingerprint validate /nonexistent.yaml` | **0** | 1 |

The exit-code design already existed and was unreachable: `cmd/main.go` maps errors to the codes ADR-0001 defines (2 invalid input, 4 not found, 7 unavailable, 8 partial). Nothing reached it from these paths.

## Changes

- `PrintTotalFailureSummary` returns the operation's error, marked as already shown to the user. `main` prints only what is unmarked, so cobra's own errors — unknown flag, wrong argument count, bad config file — still reach the user while a failure the command already summarized is not stated twice.
- Quiet marks the error too: the user asked for silence, so nobody downstream prints it, and the exit code carries the failure. **This covers the paths that go through the summary printer.** `plugin verify` returns a bare `fmt.Errorf` (`verify.go:106`) and so still prints under `--quiet` — unchanged by this PR, filed separately.
- JSON mode still emits its object first and then fails.
- `root` sets `SilenceErrors` — the commands already print the failure, and cobra would restate it as `Error: ...`.
- Four tests pinned the old behaviour with `require.NoError` on a command run against a missing file or an invalid flag. Their real subject is that the suggestions get printed, which they still assert; they now also require the error to come back.

## Why the fingerprint database is in this PR

Making failures fail turns up one immediately. `dns.bind` has been defined **twice since 2025-11-08**. CI runs `fingerprint validate` on every build (`validate.yaml:93`), the validator has been reporting that error for nine months, and the step passed because of the bug above.

Without the database fix, this change turns `main` red. They ship together.

The surviving rule keeps the version extraction that can actually fire. The removed duplicate matched uppercase `BIND` and extracted with an uppercase pattern, against a banner `RuleBasedResolver.Resolve` has already lowercased — neither could ever match. The surviving `match` also drops the bare `dns` alternative, since the word does not name BIND.

## Verified

- `go build ./...`, `go test ./...` and `golangci-lint run ./...` clean on a worktree checked out at this commit alone.
- `fingerprint validate` on the repository database exits **0** on this branch, so the CI step passes for the right reason rather than the wrong one.

## Not in this PR

Follow-up work that shares the working tree but not the subject: mDNS multicast discovery, a `fingerprint gaps` harvesting command, and fingerprint rules for IBM storage arrays.

