### PR TITLE
feat(fingerprint): report the banners no rule recognizes

### DIFF
--- a/cmd/vulntor/commands/fingerprint.go
+++ b/cmd/vulntor/commands/fingerprint.go
@@ -27,6 +27,7 @@ func NewFingerprintCommand() *cobra.Command {
 
 	cmd.AddCommand(newFingerprintSyncCommand())
 	cmd.AddCommand(newFingerprintValidateCommand())
+	cmd.AddCommand(newFingerprintGapsCommand())
 
 	return cmd
 }

--- a/cmd/vulntor/commands/fingerprint_gaps.go
+++ b/cmd/vulntor/commands/fingerprint_gaps.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cyprob/cyprob/pkg/fingerprint"
+)
+
+// scanCorpusHost is the subset of a scan result this command reads. It is
+// deliberately partial: the file format carries far more than the banners, and
+// depending on the rest would break this tool every time the report grows.
+type scanCorpusHost struct {
+	Target        string `json:"target"`
+	OpenPortsByIP map[string][]struct {
+		PortNumber int    `json:"port_number"`
+		Protocol   string `json:"protocol"`
+		Service    struct {
+			Name      string `json:"name"`
+			RawBanner string `json:"raw_banner"`
+		} `json:"service"`
+	} `json:"open_ports_by_ip"`
+}
+
+func newFingerprintGapsCommand() *cobra.Command {
+	var (
+		showStubs bool
+		minCount  int
+		asJSON    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gaps <scan.json> [scan.json...]",
+		Short: "Report banners in a scan corpus that no fingerprint rule recognizes",
+		Long: strings.TrimSpace(`
+Reads scan results already on disk and reports which service banners no rule in
+the fingerprint database recognizes, grouped by the line a rule would anchor on
+and ranked by how often it was seen.
+
+This reads local files and prints a report. It sends nothing anywhere.
+
+The point is to write rules against what an estate actually contains rather than
+against what it is assumed to contain. A device usually names itself in its
+banner; the report says which of those names we are currently ignoring, and how
+much each one is worth.
+
+  cyprob scan 10.0.0.0/24 -o json > estate.json
+  cyprob fingerprint gaps estate.json --stub
+`),
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			observations, err := loadScanCorpus(args)
+			if err != nil {
+				return err
+			}
+			report := fingerprint.AnalyzeGaps(observations)
+
+			if asJSON {
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(report)
+			}
+			printGapReport(cmd, report, minCount, showStubs)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&showStubs, "stub", false, "Print a starting rule for each gap")
+	cmd.Flags().IntVar(&minCount, "min-count", 1, "Hide gaps seen fewer times than this")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the report as JSON")
+	return cmd
+}
+
+func loadScanCorpus(paths []string) ([]fingerprint.Observation, error) {
+	observations := make([]fingerprint.Observation, 0, 64)
+	for _, path := range paths {
+		raw, err := os.ReadFile(path) //nolint:gosec // operator-supplied path, read-only
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var hosts []scanCorpusHost
+		if err := json.Unmarshal(raw, &hosts); err != nil {
+			// A single-host scan is emitted as an object rather than an array.
+			var single scanCorpusHost
+			if objErr := json.Unmarshal(raw, &single); objErr != nil {
+				return nil, fmt.Errorf("parse %s: %w", path, err)
+			}
+			hosts = []scanCorpusHost{single}
+		}
+
+		for _, host := range hosts {
+			for ip, ports := range host.OpenPortsByIP {
+				target := ip
+				if target == "" {
+					target = host.Target
+				}
+				for _, port := range ports {
+					if strings.TrimSpace(port.Service.RawBanner) == "" {
+						continue
+					}
+					// The service name is what the rules key on; the transport
+					// is only a fallback, and it puts the resolver into the mode
+					// that tries every rule.
+					protocol := strings.TrimSpace(port.Service.Name)
+					if protocol == "" {
+						protocol = strings.TrimSpace(port.Protocol)
+					}
+					observations = append(observations, fingerprint.Observation{
+						Target:   target,
+						Port:     port.PortNumber,
+						Protocol: protocol,
+						Banner:   port.Service.RawBanner,
+					})
+				}
+			}
+		}
+	}
+	return observations, nil
+}
+
+func printGapReport(cmd *cobra.Command, report fingerprint.GapReport, minCount int, showStubs bool) {
+	out := cmd.OutOrStdout()
+
+	if report.Observations == 0 {
+		fmt.Fprintln(out, "No banners in this corpus. Nothing to report.")
+		return
+	}
+
+	share := float64(report.Unmatched) / float64(report.Observations) * 100
+	fmt.Fprintf(out, "%d services with a banner, %d unrecognized (%.0f%%)\n\n",
+		report.Observations, report.Unmatched, share)
+
+	if report.Unmatched == 0 {
+		fmt.Fprintln(out, "Every banner in this corpus is already recognized.")
+		return
+	}
+
+	shown := 0
+	for _, gap := range report.Gaps {
+		if gap.Count < minCount {
+			continue
+		}
+		shown++
+		fmt.Fprintf(out, "%4dx  [%s]  %s\n", gap.Count, gap.Kind, gap.Signature)
+		fmt.Fprintf(out, "       seen at: %s\n", strings.Join(gap.Samples, ", "))
+		if showStubs {
+			for _, line := range strings.Split(gap.RuleStub(), "\n") {
+				fmt.Fprintf(out, "       %s\n", line)
+			}
+		}
+		fmt.Fprintln(out)
+	}
+
+	if shown == 0 {
+		fmt.Fprintf(out, "No gap was seen %d or more times.\n", minCount)
+		return
+	}
+	// A banner can be counted under both its Server header and its page title,
+	// so the per-signature counts deliberately do not sum to the total.
+	fmt.Fprintln(out, "A banner offering two anchors appears under both, so these counts overlap.")
+}

--- a/cmd/vulntor/commands/fingerprint_gaps.go
+++ b/cmd/vulntor/commands/fingerprint_gaps.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cyprob/cyprob/pkg/fingerprint"
+	"github.com/cyprob/cyprob/pkg/modules/parse"
 )
 
 // scanCorpusHost is the subset of a scan result this command reads. It is
@@ -60,6 +61,9 @@ much each one is worth.
 			report := fingerprint.AnalyzeGaps(observations)
 
 			if asJSON {
+				// --min-count filters the report, not just its rendering, so a
+				// machine reading the JSON sees the same set a person does.
+				report.Gaps = gapsAtLeast(report.Gaps, minCount)
 				encoder := json.NewEncoder(cmd.OutOrStdout())
 				encoder.SetIndent("", "  ")
 				return encoder.Encode(report)
@@ -102,18 +106,17 @@ func loadScanCorpus(paths []string) ([]fingerprint.Observation, error) {
 					if strings.TrimSpace(port.Service.RawBanner) == "" {
 						continue
 					}
-					// The service name is what the rules key on; the transport
-					// is only a fallback, and it puts the resolver into the mode
-					// that tries every rule.
-					protocol := strings.TrimSpace(port.Service.Name)
-					if protocol == "" {
-						protocol = strings.TrimSpace(port.Protocol)
-					}
+					// Derived the way the scan pipeline derives it, rather than
+					// from the service name alone. Taking the name at face value
+					// reported every TLS service as unrecognized: the rules are
+					// keyed on "http", the scan names the service "https", and
+					// nothing matched.
 					observations = append(observations, fingerprint.Observation{
-						Target:   target,
-						Port:     port.PortNumber,
-						Protocol: protocol,
-						Banner:   port.Service.RawBanner,
+						Target: target,
+						Port:   port.PortNumber,
+						Protocol: parse.ResolverProtocolHint(
+							port.Service.Name, port.Protocol, port.PortNumber, port.Service.RawBanner),
+						Banner: port.Service.RawBanner,
 					})
 				}
 			}
@@ -140,13 +143,16 @@ func printGapReport(cmd *cobra.Command, report fingerprint.GapReport, minCount i
 	}
 
 	shown := 0
-	for _, gap := range report.Gaps {
-		if gap.Count < minCount {
-			continue
-		}
+	for _, gap := range gapsAtLeast(report.Gaps, minCount) {
 		shown++
 		fmt.Fprintf(out, "%4dx  [%s]  %s\n", gap.Count, gap.Kind, gap.Signature)
 		fmt.Fprintf(out, "       seen at: %s\n", strings.Join(gap.Samples, ", "))
+		if len(gap.Varying) > 0 {
+			// Dropped from the signature because they differed between hosts.
+			// Usually the site's own naming, but a model number seen on a single
+			// host looks the same, so it is shown rather than lost.
+			fmt.Fprintf(out, "       varying: %s\n", strings.Join(gap.Varying, ", "))
+		}
 		if showStubs {
 			for _, line := range strings.Split(gap.RuleStub(), "\n") {
 				fmt.Fprintf(out, "       %s\n", line)
@@ -162,4 +168,18 @@ func printGapReport(cmd *cobra.Command, report fingerprint.GapReport, minCount i
 	// A banner can be counted under both its Server header and its page title,
 	// so the per-signature counts deliberately do not sum to the total.
 	fmt.Fprintln(out, "A banner offering two anchors appears under both, so these counts overlap.")
+}
+
+// gapsAtLeast drops the gaps seen fewer than minCount times.
+func gapsAtLeast(gaps []fingerprint.Gap, minCount int) []fingerprint.Gap {
+	if minCount <= 1 {
+		return gaps
+	}
+	kept := make([]fingerprint.Gap, 0, len(gaps))
+	for _, gap := range gaps {
+		if gap.Count >= minCount {
+			kept = append(kept, gap)
+		}
+	}
+	return kept
 }

--- a/cmd/vulntor/commands/fingerprint_gaps.go
+++ b/cmd/vulntor/commands/fingerprint_gaps.go
@@ -27,6 +27,9 @@ type scanCorpusHost struct {
 	} `json:"open_ports_by_ip"`
 }
 
+// varyingShownInText bounds the terminal listing only.
+const varyingShownInText = 6
+
 func newFingerprintGapsCommand() *cobra.Command {
 	var (
 		showStubs bool
@@ -150,8 +153,16 @@ func printGapReport(cmd *cobra.Command, report fingerprint.GapReport, minCount i
 		if len(gap.Varying) > 0 {
 			// Dropped from the signature because they differed between hosts.
 			// Usually the site's own naming, but a model number seen on a single
-			// host looks the same, so it is shown rather than lost.
-			fmt.Fprintf(out, "       varying: %s\n", strings.Join(gap.Varying, ", "))
+			// host looks the same, so it is shown rather than lost. The list is
+			// cut for the terminal only, and says so -- a silently cut list of
+			// model numbers reads as a complete one. --json carries them all.
+			shown := gap.Varying
+			suffix := ""
+			if len(shown) > varyingShownInText {
+				suffix = fmt.Sprintf(" (+%d more, --json for all)", len(shown)-varyingShownInText)
+				shown = shown[:varyingShownInText]
+			}
+			fmt.Fprintf(out, "       varying: %s%s\n", strings.Join(shown, ", "), suffix)
 		}
 		if showStubs {
 			for _, line := range strings.Split(gap.RuleStub(), "\n") {

--- a/pkg/fingerprint/gaps.go
+++ b/pkg/fingerprint/gaps.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/cyprob/cyprob/pkg/stringutil"
 )
 
 // Observation is one service banner as a scan recorded it.
@@ -31,6 +33,11 @@ type Gap struct {
 	// Samples are up to a few "ip:port" locations, so the finding can be
 	// confirmed against a real host rather than trusted.
 	Samples []string
+	// Varying are the tokens dropped from the signature because they differed
+	// between the hosts in this cluster. Usually that is the site's own naming,
+	// but a model number present on a single host looks the same, so they are
+	// reported rather than discarded.
+	Varying []string
 }
 
 // GapReport summarizes what a scan corpus saw and what went unrecognized.
@@ -55,6 +62,7 @@ var (
 const (
 	gapMaxSignature = 120
 	gapMaxSamples   = 3
+	gapMaxVarying   = 6
 )
 
 // AnalyzeGaps reports which observed banners no rule recognizes.
@@ -73,16 +81,19 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 	resolver := NewRuleBasedResolver(rules)
 	ctx := context.Background()
 
-	type cluster struct {
-		kind      string
-		signature string
-		protocol  string
-		count     int
-		samples   []string
-	}
-	clusters := map[string]*cluster{}
-
 	report := GapReport{}
+
+	// First pass: find what nothing recognizes, and record which hosts each
+	// token of each signature appeared on.
+	type unmatched struct {
+		location   string
+		host       string
+		protocol   string
+		signatures []gapSignature
+	}
+	found := make([]unmatched, 0, len(observations))
+	tokenHosts := map[string]map[string]bool{}
+
 	for _, obs := range observations {
 		if strings.TrimSpace(obs.Banner) == "" {
 			continue
@@ -98,29 +109,73 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		}
 		report.Unmatched++
 
-		location := fmt.Sprintf("%s:%d", obs.Target, obs.Port)
-		// A banner can offer more than one anchor — the Storwize array names
-		// itself in both its Server header and its page title — and which one a
-		// rule should use is a judgement call, so both are reported.
-		for _, sig := range gapSignatures(obs.Banner) {
-			key := sig.kind + "\x00" + strings.ToLower(sig.text)
+		// The target comes from the corpus, and a corpus can arrive from a
+		// customer, a partner or CI rather than from a local scan, so it is not
+		// trusted any more than the banner is.
+		host := stringutil.SanitizeUntrusted(obs.Target, 64)
+		signatures := gapSignatures(obs.Banner)
+		found = append(found, unmatched{
+			location:   fmt.Sprintf("%s:%d", host, obs.Port),
+			host:       host,
+			protocol:   obs.Protocol,
+			signatures: signatures,
+		})
+		for _, sig := range signatures {
+			for _, token := range signatureTokens(sig.text) {
+				key := sig.kind + "\x00" + token
+				if tokenHosts[key] == nil {
+					tokenHosts[key] = map[string]bool{}
+				}
+				tokenHosts[key][host] = true
+			}
+		}
+	}
+
+	// Second pass: group. A signature usually carries the site's own naming --
+	// a hostname, a serial, a session id -- alongside the part that names the
+	// product, and grouping on the whole string splits one device model into as
+	// many clusters as there are copies of it. Tokens seen on a single host are
+	// dropped, which is safe precisely because a token appearing once
+	// distinguishes nothing.
+	type cluster struct {
+		kind      string
+		signature string
+		protocol  string
+		count     int
+		samples   []string
+		varying   []string
+	}
+	clusters := map[string]*cluster{}
+
+	for _, item := range found {
+		// A banner can offer more than one anchor -- an IBM array names itself
+		// in both its Server header and its page title -- and which one a rule
+		// should use is a judgement the tool cannot make, so both are reported.
+		for _, sig := range item.signatures {
+			shared, dropped := sharedSignature(sig, tokenHosts)
+			key := sig.kind + "\x00" + strings.ToLower(shared)
 			existing, ok := clusters[key]
 			if !ok {
-				existing = &cluster{kind: sig.kind, signature: sig.text, protocol: obs.Protocol}
+				existing = &cluster{kind: sig.kind, signature: shared,
+					protocol: knownProtocolOrEmpty(item.protocol)}
 				clusters[key] = existing
 			}
 			existing.count++
 			if len(existing.samples) < gapMaxSamples {
-				existing.samples = append(existing.samples, location)
+				existing.samples = append(existing.samples, item.location)
+			}
+			for _, token := range dropped {
+				existing.varying = appendUniqueBounded(existing.varying, token, gapMaxVarying)
 			}
 		}
 	}
 
 	report.Gaps = make([]Gap, 0, len(clusters))
 	for _, c := range clusters {
+		sort.Strings(c.varying)
 		report.Gaps = append(report.Gaps, Gap{
 			Kind: c.kind, Signature: c.signature, Protocol: c.protocol,
-			Count: c.count, Samples: c.samples,
+			Count: c.count, Samples: c.samples, Varying: c.varying,
 		})
 	}
 	// Most frequent first; ties broken by signature so the report is stable
@@ -132,6 +187,51 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		return report.Gaps[i].Signature < report.Gaps[j].Signature
 	})
 	return report
+}
+
+// signatureTokens splits a signature into the words a rule would anchor on.
+func signatureTokens(signature string) []string {
+	return strings.Fields(strings.ToLower(signature))
+}
+
+// sharedSignature drops the tokens that appeared on only one host, and returns
+// what it dropped.
+//
+// Those are usually the site's own naming rather than the device's, and keeping
+// them splits one model across as many clusters as there are copies of it. But
+// a model number present on a single host is indistinguishable from a hostname
+// by this measure -- measured on a real corpus, "IBM FlashSystem 5000" and
+// "5300" lost exactly the number worth writing a rule for -- so what is dropped
+// is reported rather than thrown away.
+//
+// The whole signature is kept when nothing in it is shared, since a genuinely
+// unique banner has nothing to generalize.
+func sharedSignature(sig gapSignature, tokenHosts map[string]map[string]bool) (shared string, dropped []string) {
+	fields := strings.Fields(sig.text)
+	kept := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(tokenHosts[sig.kind+"\x00"+strings.ToLower(field)]) > 1 {
+			kept = append(kept, field)
+			continue
+		}
+		dropped = append(dropped, field)
+	}
+	if len(kept) == 0 {
+		return sig.text, nil
+	}
+	return strings.Join(kept, " "), dropped
+}
+
+func appendUniqueBounded(values []string, value string, limit int) []string {
+	if len(values) >= limit {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 type gapSignature struct {
@@ -167,42 +267,29 @@ func gapSignatures(banner string) []gapSignature {
 	return nil
 }
 
-// sanitizeGapText strips control characters and bounds the length.
+// sanitizeGapText makes a captured banner safe to print and bounds it.
 //
-// A banner is text a scanned host chose to send. Printing it to a terminal
-// unfiltered would let a host inject escape sequences into the operator's
-// screen, so the same treatment the probes apply is applied here.
+// A banner is text a scanned host chose to send, and it reaches the operator's
+// terminal and any rule written from the report. The shared implementation
+// removes the classes a hand-written control-character check misses -- the C1
+// block, bidirectional overrides, zero-width characters -- and bounds by runes
+// so a truncation cannot split a character.
 func sanitizeGapText(value string) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, value)
-	cleaned = strings.TrimSpace(gapWhitespace.ReplaceAllString(cleaned, " "))
-	if len(cleaned) > gapMaxSignature {
-		cleaned = strings.TrimSpace(cleaned[:gapMaxSignature]) + "…"
+	bounded := stringutil.SanitizeUntrusted(value, gapMaxSignature)
+	if bounded != stringutil.SanitizeUntrusted(value, 0) {
+		return bounded + "\u2026"
 	}
-	return cleaned
+	return bounded
 }
 
 // RuleStub renders a starting point for the rule that would close a gap.
 //
 // It is deliberately a starting point and not a finished rule. The vendor and
-// product cannot be derived from a string nothing recognizes — guessing them is
-// the failure this tool exists to avoid — and the captured signature routinely
-// contains text belonging to the site rather than to the device.
+// product cannot be derived from a string nothing recognizes -- guessing them
+// is the failure this tool exists to avoid -- and the captured signature
+// routinely contains text belonging to the site rather than to the device.
 func (g Gap) RuleStub() string {
-	anchor := regexp.QuoteMeta(strings.ToLower(g.Signature))
-	match := anchor
-	switch g.Kind {
-	case "server":
-		match = `server:\s*` + anchor
-	case "title":
-		match = `<title>[^<]*` + anchor
-	}
-
-	protocol := strings.TrimSpace(g.Protocol)
+	protocol := knownProtocolOrEmpty(g.Protocol)
 	if protocol == "" {
 		protocol = "tcp"
 	}
@@ -211,8 +298,12 @@ func (g Gap) RuleStub() string {
 		"- id: 'TODO.unique_id'",
 		"  protocol: '" + protocol + "'",
 		"  product: 'TODO'   # only what the device states about itself",
-		"  vendor: 'TODO'    # the DEVICE vendor, not the software's vendor",
-		"  match: '" + match + "'",
+		"  vendor: 'TODO'    # the DEVICE vendor, not the vendor of the software",
+		"                    # it runs: an nginx rule names F5, which is right for",
+		"                    # nginx and wrong for every appliance serving it",
+		"  cpe: 'TODO'       # required -- the loader rejects a rule without one,",
+		"                    # and a rejected rule disables the whole file",
+		"  match: " + yamlSingleQuoted(g.matchExpression()),
 		"  pattern_strength: 0.90",
 	}
 	if g.Kind == "title" {
@@ -224,4 +315,53 @@ func (g Gap) RuleStub() string {
 			"  # normally carries the site's own hostname, which is not the device.")
 	}
 	return strings.Join(lines, "\n")
+}
+
+// matchExpression builds a pattern that matches the banner the signature came
+// from.
+//
+// The signature has had its whitespace collapsed, so anchoring it literally
+// would produce a rule that does not match its own banner: real banners wrap a
+// title across lines and indent it. Whitespace in the signature therefore
+// becomes a whitespace pattern rather than a literal space.
+func (g Gap) matchExpression() string {
+	parts := strings.Fields(strings.ToLower(g.Signature))
+	for i, part := range parts {
+		parts[i] = regexp.QuoteMeta(part)
+	}
+	anchor := strings.Join(parts, `\s+`)
+
+	switch g.Kind {
+	case "server":
+		return `server:\s*` + anchor
+	case "title":
+		return `<title>[^<]*` + anchor
+	default:
+		return anchor
+	}
+}
+
+// yamlSingleQuoted quotes a value the way YAML requires, which means doubling
+// any apostrophe. A banner containing one would otherwise end the scalar early
+// and produce a file that does not parse.
+func yamlSingleQuoted(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+// gapKnownProtocols are the protocols a rule may declare. The value is embedded
+// in generated YAML, and a corpus is not necessarily one this machine produced,
+// so anything unrecognized is dropped rather than passed through.
+var gapKnownProtocols = map[string]bool{
+	"dns": true, "ftp": true, "http": true, "https": true, "imap": true,
+	"kafka": true, "ldap": true, "mysql": true, "pop3": true, "rabbitmq": true,
+	"rdp": true, "redis": true, "smb": true, "smtp": true, "snmp": true,
+	"ssh": true, "tcp": true, "telnet": true, "udp": true, "vnc": true,
+}
+
+func knownProtocolOrEmpty(protocol string) string {
+	normalized := strings.ToLower(strings.TrimSpace(protocol))
+	if gapKnownProtocols[normalized] {
+		return normalized
+	}
+	return ""
 }

--- a/pkg/fingerprint/gaps.go
+++ b/pkg/fingerprint/gaps.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cyprob/cyprob/pkg/stringutil"
@@ -40,6 +41,15 @@ type Gap struct {
 	Varying []string
 }
 
+// unmatchedObservation is one banner nothing recognized, with the anchors it
+// offers.
+type unmatchedObservation struct {
+	location   string
+	host       string
+	protocol   string
+	signatures []gapSignature
+}
+
 // GapReport summarizes what a scan corpus saw and what went unrecognized.
 type GapReport struct {
 	// Observations is how many services carried a banner at all.
@@ -51,6 +61,8 @@ type GapReport struct {
 }
 
 var (
+	// plainProtocolToken is what a rule's protocol may look like.
+	plainProtocolToken = regexp.MustCompile(`^[a-z0-9_-]+$`)
 	// gapServerHeader captures the value of an HTTP Server header.
 	gapServerHeader = regexp.MustCompile(`(?im)^server:[ \t]*(.+?)[ \t]*\r?$`)
 	// gapHTMLTitle captures the contents of a title element.
@@ -62,7 +74,6 @@ var (
 const (
 	gapMaxSignature = 120
 	gapMaxSamples   = 3
-	gapMaxVarying   = 6
 )
 
 // AnalyzeGaps reports which observed banners no rule recognizes.
@@ -79,19 +90,14 @@ func AnalyzeGaps(observations []Observation) GapReport {
 
 func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapReport {
 	resolver := NewRuleBasedResolver(rules)
+	known := ruleProtocols(rules)
 	ctx := context.Background()
 
 	report := GapReport{}
 
 	// First pass: find what nothing recognizes, and record which hosts each
 	// token of each signature appeared on.
-	type unmatched struct {
-		location   string
-		host       string
-		protocol   string
-		signatures []gapSignature
-	}
-	found := make([]unmatched, 0, len(observations))
+	found := make([]unmatchedObservation, 0, len(observations))
 	tokenHosts := map[string]map[string]bool{}
 
 	for _, obs := range observations {
@@ -100,8 +106,9 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		}
 		report.Observations++
 
+		protocol := resolvableProtocol(obs.Protocol, known)
 		if _, err := resolver.Resolve(ctx, Input{
-			Protocol: obs.Protocol,
+			Protocol: protocol,
 			Banner:   obs.Banner,
 			Port:     obs.Port,
 		}); err == nil {
@@ -114,10 +121,10 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		// trusted any more than the banner is.
 		host := stringutil.SanitizeUntrusted(obs.Target, 64)
 		signatures := gapSignatures(obs.Banner)
-		found = append(found, unmatched{
+		found = append(found, unmatchedObservation{
 			location:   fmt.Sprintf("%s:%d", host, obs.Port),
 			host:       host,
-			protocol:   obs.Protocol,
+			protocol:   protocol,
 			signatures: signatures,
 		})
 		for _, sig := range signatures {
@@ -131,12 +138,23 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		}
 	}
 
-	// Second pass: group. A signature usually carries the site's own naming --
-	// a hostname, a serial, a session id -- alongside the part that names the
-	// product, and grouping on the whole string splits one device model into as
-	// many clusters as there are copies of it. Tokens seen on a single host are
-	// dropped, which is safe precisely because a token appearing once
-	// distinguishes nothing.
+	// Second pass: group.
+	//
+	// A signature usually carries the site's own naming beside the part that
+	// names the product, and grouping on the whole string splits one model into
+	// as many clusters as there are copies of it.
+	//
+	// Two signatures are treated as the same device when they agree everywhere
+	// except ONE token position, and the values at that position each belong to
+	// a single host. Requiring a single position is what keeps this honest:
+	// dropping every token that happens to be unique merges unrelated devices
+	// through whatever noise they share, and a corpus of one-off appliances is
+	// mostly such tokens. Two differences mean two devices -- which is also why
+	// "IBM FlashSystem 5000" and "5300" stay apart, since they differ in the
+	// hostname AND the model.
+	//
+	// Comparison happens inside a bucket of the same kind, protocol and token
+	// count, so a telnet banner and a postgres one are never candidates.
 	type cluster struct {
 		kind      string
 		signature string
@@ -147,17 +165,24 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 	}
 	clusters := map[string]*cluster{}
 
-	for _, item := range found {
-		// A banner can offer more than one anchor -- an IBM array names itself
-		// in both its Server header and its page title -- and which one a rule
-		// should use is a judgement the tool cannot make, so both are reported.
-		for _, sig := range item.signatures {
-			shared, dropped := sharedSignature(sig, tokenHosts)
-			key := sig.kind + "\x00" + strings.ToLower(shared)
+	drops := chooseDroppedPositions(found)
+
+	for index, item := range found {
+		for sigIndex, sig := range item.signatures {
+			// A missing entry means nothing qualified. Reading the zero value as
+			// "drop position 0" silently truncated every signature that had no
+			// merge to make.
+			position, hasDrop := drops[dropKey{index, sigIndex}]
+			if !hasDrop {
+				position = -1
+			}
+			shared, dropped := applyDrop(sig, position)
+			key := sig.kind + "\x00" + item.protocol +
+				"\x00" + strings.ToLower(shared)
 			existing, ok := clusters[key]
 			if !ok {
 				existing = &cluster{kind: sig.kind, signature: shared,
-					protocol: knownProtocolOrEmpty(item.protocol)}
+					protocol: item.protocol}
 				clusters[key] = existing
 			}
 			existing.count++
@@ -165,7 +190,9 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 				existing.samples = append(existing.samples, item.location)
 			}
 			for _, token := range dropped {
-				existing.varying = appendUniqueBounded(existing.varying, token, gapMaxVarying)
+				if !containsString(existing.varying, token) {
+					existing.varying = append(existing.varying, token)
+				}
 			}
 		}
 	}
@@ -189,49 +216,123 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 	return report
 }
 
-// signatureTokens splits a signature into the words a rule would anchor on.
-func signatureTokens(signature string) []string {
-	return strings.Fields(strings.ToLower(signature))
-}
+// dropKey identifies one signature of one unmatched observation.
+type dropKey struct{ observation, signature int }
 
-// sharedSignature drops the tokens that appeared on only one host, and returns
-// what it dropped.
+// chooseDroppedPositions decides, for each signature, which token position (if
+// any) is the site's own naming rather than the device's.
 //
-// Those are usually the site's own naming rather than the device's, and keeping
-// them splits one model across as many clusters as there are copies of it. But
-// a model number present on a single host is indistinguishable from a hostname
-// by this measure -- measured on a real corpus, "IBM FlashSystem 5000" and
-// "5300" lost exactly the number worth writing a rule for -- so what is dropped
-// is reported rather than thrown away.
-//
-// The whole signature is kept when nothing in it is shared, since a genuinely
-// unique banner has nothing to generalize.
-func sharedSignature(sig gapSignature, tokenHosts map[string]map[string]bool) (shared string, dropped []string) {
-	fields := strings.Fields(sig.text)
-	kept := make([]string, 0, len(fields))
-	for _, field := range fields {
-		if len(tokenHosts[sig.kind+"\x00"+strings.ToLower(field)]) > 1 {
-			kept = append(kept, field)
+// A position qualifies when blanking it makes two or more signatures in the
+// same bucket identical, and every value seen at that position belongs to a
+// single host. When several positions qualify, the one merging the most
+// signatures wins, and the earliest position breaks a tie so the result does
+// not depend on map order.
+func chooseDroppedPositions(found []unmatchedObservation) map[dropKey]int {
+	type maskEntry struct {
+		members []dropKey
+		values  map[string]map[string]bool
+	}
+	masks := map[string]*maskEntry{}
+
+	for index, item := range found {
+		for sigIndex, sig := range item.signatures {
+			tokens := strings.Fields(sig.text)
+			bucket := sig.kind + "\x00" + item.protocol +
+				"\x00" + strconv.Itoa(len(tokens))
+			for position := range tokens {
+				blanked := append([]string{}, tokens...)
+				value := strings.ToLower(blanked[position])
+				blanked[position] = "\x00"
+				maskID := bucket + "\x00" + strconv.Itoa(position) + "\x00" +
+					strings.ToLower(strings.Join(blanked, " "))
+
+				entry, ok := masks[maskID]
+				if !ok {
+					entry = &maskEntry{values: map[string]map[string]bool{}}
+					masks[maskID] = entry
+				}
+				entry.members = append(entry.members, dropKey{index, sigIndex})
+				if entry.values[value] == nil {
+					entry.values[value] = map[string]bool{}
+				}
+				entry.values[value][item.host] = true
+			}
+		}
+	}
+
+	best := map[dropKey]int{}
+	bestSize := map[dropKey]int{}
+	maskIDs := make([]string, 0, len(masks))
+	for maskID := range masks {
+		maskIDs = append(maskIDs, maskID)
+	}
+	sort.Strings(maskIDs)
+
+	for _, maskID := range maskIDs {
+		entry := masks[maskID]
+		if len(entry.values) < 2 {
+			continue // nothing varies here, so nothing is site-specific
+		}
+		siteSpecific := true
+		for _, hosts := range entry.values {
+			if len(hosts) > 1 {
+				siteSpecific = false
+				break
+			}
+		}
+		if !siteSpecific {
 			continue
 		}
-		dropped = append(dropped, field)
+		position := maskPosition(maskID)
+		for _, member := range entry.members {
+			if size, seen := bestSize[member]; !seen || len(entry.members) > size ||
+				(len(entry.members) == size && position < best[member]) {
+				best[member] = position
+				bestSize[member] = len(entry.members)
+			}
+		}
 	}
+	return best
+}
+
+func maskPosition(maskID string) int {
+	parts := strings.Split(maskID, "\x00")
+	if len(parts) < 4 {
+		return 0
+	}
+	position, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return 0
+	}
+	return position
+}
+
+// applyDrop removes the chosen position from a signature.
+func applyDrop(sig gapSignature, position int) (shared string, dropped []string) {
+	tokens := strings.Fields(sig.text)
+	if position < 0 || position >= len(tokens) {
+		return sig.text, nil
+	}
+	dropped = append(dropped, tokens[position])
+	kept := append(append([]string{}, tokens[:position]...), tokens[position+1:]...)
 	if len(kept) == 0 {
 		return sig.text, nil
 	}
 	return strings.Join(kept, " "), dropped
 }
 
-func appendUniqueBounded(values []string, value string, limit int) []string {
-	if len(values) >= limit {
-		return values
-	}
+func containsString(values []string, value string) bool {
 	for _, existing := range values {
 		if existing == value {
-			return values
+			return true
 		}
 	}
-	return append(values, value)
+	return false
+}
+
+// signatureTokens splits a signature into the words a rule would anchor on.
+func signatureTokens(signature string) []string {
+	return strings.Fields(strings.ToLower(signature))
 }
 
 type gapSignature struct {
@@ -289,14 +390,27 @@ func sanitizeGapText(value string) string {
 // is the failure this tool exists to avoid -- and the captured signature
 // routinely contains text belonging to the site rather than to the device.
 func (g Gap) RuleStub() string {
-	protocol := knownProtocolOrEmpty(g.Protocol)
-	if protocol == "" {
+	// Gap.Protocol is already the hint the resolver was given, so declaring it
+	// puts the rule where production will look. When the hint was empty the
+	// resolver was in fallback mode, and a rule is reachable there whatever it
+	// declares -- but only there, which the stub says rather than hiding.
+	// Gap.Protocol is produced by resolvableProtocol and so is already one of
+	// the rule protocols, but RuleStub is exported and its output is pasted into
+	// a YAML file: anything that is not a plain token is refused rather than
+	// quoted, since a protocol is not free text and a corpus need not be one
+	// this machine produced.
+	protocol := g.Protocol
+	if !plainProtocolToken.MatchString(protocol) {
+		protocol = ""
+	}
+	fallbackOnly := protocol == ""
+	if fallbackOnly {
 		protocol = "tcp"
 	}
 
 	lines := []string{
 		"- id: 'TODO.unique_id'",
-		"  protocol: '" + protocol + "'",
+		"  protocol: " + yamlSingleQuoted(protocol),
 		"  product: 'TODO'   # only what the device states about itself",
 		"  vendor: 'TODO'    # the DEVICE vendor, not the vendor of the software",
 		"                    # it runs: an nginx rule names F5, which is right for",
@@ -305,6 +419,13 @@ func (g Gap) RuleStub() string {
 		"                    # and a rejected rule disables the whole file",
 		"  match: " + yamlSingleQuoted(g.matchExpression()),
 		"  pattern_strength: 0.90",
+	}
+	if fallbackOnly {
+		lines = append(lines,
+			"  # This banner was resolved with no protocol hint, so the rule is",
+			"  # reachable only in fallback mode. Name the protocol the service",
+			"  # speaks if you know it, or the rule will be skipped wherever the",
+			"  # scan does identify the service.")
 	}
 	if g.Kind == "title" {
 		// A page title is usually "<hostname> - <page> - <Product>", and the
@@ -325,17 +446,29 @@ func (g Gap) RuleStub() string {
 // title across lines and indent it. Whitespace in the signature therefore
 // becomes a whitespace pattern rather than a literal space.
 func (g Gap) matchExpression() string {
-	parts := strings.Fields(strings.ToLower(g.Signature))
+	// The ellipsis is this tool's mark that the signature was cut, not something
+	// the host sent. Anchoring it would produce a rule matching a character no
+	// banner contains.
+	signature := strings.TrimSuffix(g.Signature, "\u2026")
+
+	parts := strings.Fields(strings.ToLower(signature))
 	for i, part := range parts {
 		parts[i] = regexp.QuoteMeta(part)
 	}
-	anchor := strings.Join(parts, `\s+`)
+	// Whitespace in the signature stands for whatever separated the tokens in
+	// the banner, and that is not necessarily a space: the sanitizer turns any
+	// non-printable character into one, so a banner separated by a no-break
+	// space, a zero-width space or a stray control byte would not match a plain
+	// \\s. The class covers control, format and every Unicode space.
+	anchor := strings.Join(parts, `[\s\p{Cc}\p{Cf}\p{Z}]+`)
 
 	switch g.Kind {
 	case "server":
-		return `server:\s*` + anchor
+		return `server:[\s\p{Cc}\p{Cf}\p{Z}]*` + anchor
 	case "title":
-		return `<title>[^<]*` + anchor
+		// The title element carries attributes often enough that a literal
+		// <title> misses them.
+		return `<title[^>]*>[^<]*` + anchor
 	default:
 		return anchor
 	}
@@ -348,19 +481,33 @@ func yamlSingleQuoted(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
-// gapKnownProtocols are the protocols a rule may declare. The value is embedded
-// in generated YAML, and a corpus is not necessarily one this machine produced,
-// so anything unrecognized is dropped rather than passed through.
-var gapKnownProtocols = map[string]bool{
-	"dns": true, "ftp": true, "http": true, "https": true, "imap": true,
-	"kafka": true, "ldap": true, "mysql": true, "pop3": true, "rabbitmq": true,
-	"rdp": true, "redis": true, "smb": true, "smtp": true, "snmp": true,
-	"ssh": true, "tcp": true, "telnet": true, "udp": true, "vnc": true,
+// ruleProtocols is the set of protocols the rules actually key on, derived from
+// the rules themselves rather than kept by hand: a list maintained separately
+// drifts, and the drift is silent -- an unrecognized hint matches no rule at
+// all instead of trying every one.
+func ruleProtocols(rules []StaticRule) map[string]bool {
+	known := make(map[string]bool, len(rules))
+	for _, rule := range rules {
+		if protocol := strings.ToLower(strings.TrimSpace(rule.Protocol)); protocol != "" {
+			known[protocol] = true
+		}
+	}
+	return known
 }
 
-func knownProtocolOrEmpty(protocol string) string {
+// resolvableProtocol keeps a hint only when some rule keys on it.
+//
+// The scan pipeline hands the resolver whatever the service was named, and a
+// name no rule declares selects no rules at all -- the service then looks
+// unrecognized when it was only mis-hinted. An empty hint puts the resolver in
+// the mode that tries every rule, which is the honest answer when the name
+// means nothing to the rules.
+func resolvableProtocol(protocol string, known map[string]bool) string {
 	normalized := strings.ToLower(strings.TrimSpace(protocol))
-	if gapKnownProtocols[normalized] {
+	if normalized == "" || normalized == "tcp" || normalized == "udp" {
+		return ""
+	}
+	if known[normalized] {
 		return normalized
 	}
 	return ""

--- a/pkg/fingerprint/gaps.go
+++ b/pkg/fingerprint/gaps.go
@@ -1,0 +1,227 @@
+package fingerprint
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Observation is one service banner as a scan recorded it.
+type Observation struct {
+	Target   string
+	Port     int
+	Protocol string
+	Banner   string
+}
+
+// Gap is a group of banners that no rule in the database recognizes, keyed by
+// the distinctive line a rule would most likely anchor on.
+type Gap struct {
+	// Kind is where the signature was taken from: "server", "title" or "banner".
+	Kind string
+	// Signature is the distinctive text itself, sanitized and bounded.
+	Signature string
+	// Count is how many observations carried this signature.
+	Count int
+	// Protocol is the service the signature was observed on, which is what a
+	// rule closing this gap has to declare.
+	Protocol string
+	// Samples are up to a few "ip:port" locations, so the finding can be
+	// confirmed against a real host rather than trusted.
+	Samples []string
+}
+
+// GapReport summarizes what a scan corpus saw and what went unrecognized.
+type GapReport struct {
+	// Observations is how many services carried a banner at all.
+	Observations int
+	// Unmatched is how many of those no rule recognized.
+	Unmatched int
+	// Gaps are the clusters, most frequent first.
+	Gaps []Gap
+}
+
+var (
+	// gapServerHeader captures the value of an HTTP Server header.
+	gapServerHeader = regexp.MustCompile(`(?im)^server:[ \t]*(.+?)[ \t]*\r?$`)
+	// gapHTMLTitle captures the contents of a title element.
+	gapHTMLTitle = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+	// gapWhitespace collapses the runs that titles are usually formatted with.
+	gapWhitespace = regexp.MustCompile(`\s+`)
+)
+
+const (
+	gapMaxSignature = 120
+	gapMaxSamples   = 3
+)
+
+// AnalyzeGaps reports which observed banners no rule recognizes.
+//
+// It exists because writing fingerprint rules from intuition guesses at what an
+// estate contains. The banners a scan already captured say it outright, and the
+// only question worth answering first is which unrecognized ones are frequent.
+//
+// Nothing is sent anywhere: this reads a corpus already on disk and returns a
+// summary for a person to read.
+func AnalyzeGaps(observations []Observation) GapReport {
+	return analyzeGapsWithRules(observations, loadBuiltinRules())
+}
+
+func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapReport {
+	resolver := NewRuleBasedResolver(rules)
+	ctx := context.Background()
+
+	type cluster struct {
+		kind      string
+		signature string
+		protocol  string
+		count     int
+		samples   []string
+	}
+	clusters := map[string]*cluster{}
+
+	report := GapReport{}
+	for _, obs := range observations {
+		if strings.TrimSpace(obs.Banner) == "" {
+			continue
+		}
+		report.Observations++
+
+		if _, err := resolver.Resolve(ctx, Input{
+			Protocol: obs.Protocol,
+			Banner:   obs.Banner,
+			Port:     obs.Port,
+		}); err == nil {
+			continue
+		}
+		report.Unmatched++
+
+		location := fmt.Sprintf("%s:%d", obs.Target, obs.Port)
+		// A banner can offer more than one anchor — the Storwize array names
+		// itself in both its Server header and its page title — and which one a
+		// rule should use is a judgement call, so both are reported.
+		for _, sig := range gapSignatures(obs.Banner) {
+			key := sig.kind + "\x00" + strings.ToLower(sig.text)
+			existing, ok := clusters[key]
+			if !ok {
+				existing = &cluster{kind: sig.kind, signature: sig.text, protocol: obs.Protocol}
+				clusters[key] = existing
+			}
+			existing.count++
+			if len(existing.samples) < gapMaxSamples {
+				existing.samples = append(existing.samples, location)
+			}
+		}
+	}
+
+	report.Gaps = make([]Gap, 0, len(clusters))
+	for _, c := range clusters {
+		report.Gaps = append(report.Gaps, Gap{
+			Kind: c.kind, Signature: c.signature, Protocol: c.protocol,
+			Count: c.count, Samples: c.samples,
+		})
+	}
+	// Most frequent first; ties broken by signature so the report is stable
+	// across runs and a diff between two corpora means something.
+	sort.SliceStable(report.Gaps, func(i, j int) bool {
+		if report.Gaps[i].Count != report.Gaps[j].Count {
+			return report.Gaps[i].Count > report.Gaps[j].Count
+		}
+		return report.Gaps[i].Signature < report.Gaps[j].Signature
+	})
+	return report
+}
+
+type gapSignature struct {
+	kind string
+	text string
+}
+
+// gapSignatures picks the lines a rule would most likely anchor on.
+func gapSignatures(banner string) []gapSignature {
+	signatures := make([]gapSignature, 0, 2)
+
+	if m := gapServerHeader.FindStringSubmatch(banner); len(m) == 2 {
+		if value := sanitizeGapText(m[1]); value != "" {
+			signatures = append(signatures, gapSignature{kind: "server", text: value})
+		}
+	}
+	if m := gapHTMLTitle.FindStringSubmatch(banner); len(m) == 2 {
+		if value := sanitizeGapText(m[1]); value != "" {
+			signatures = append(signatures, gapSignature{kind: "title", text: value})
+		}
+	}
+	if len(signatures) > 0 {
+		return signatures
+	}
+
+	// Nothing structured: fall back to the first line that says anything, which
+	// is what a non-HTTP banner usually is.
+	for _, line := range strings.Split(banner, "\n") {
+		if value := sanitizeGapText(line); value != "" {
+			return []gapSignature{{kind: "banner", text: value}}
+		}
+	}
+	return nil
+}
+
+// sanitizeGapText strips control characters and bounds the length.
+//
+// A banner is text a scanned host chose to send. Printing it to a terminal
+// unfiltered would let a host inject escape sequences into the operator's
+// screen, so the same treatment the probes apply is applied here.
+func sanitizeGapText(value string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, value)
+	cleaned = strings.TrimSpace(gapWhitespace.ReplaceAllString(cleaned, " "))
+	if len(cleaned) > gapMaxSignature {
+		cleaned = strings.TrimSpace(cleaned[:gapMaxSignature]) + "…"
+	}
+	return cleaned
+}
+
+// RuleStub renders a starting point for the rule that would close a gap.
+//
+// It is deliberately a starting point and not a finished rule. The vendor and
+// product cannot be derived from a string nothing recognizes — guessing them is
+// the failure this tool exists to avoid — and the captured signature routinely
+// contains text belonging to the site rather than to the device.
+func (g Gap) RuleStub() string {
+	anchor := regexp.QuoteMeta(strings.ToLower(g.Signature))
+	match := anchor
+	switch g.Kind {
+	case "server":
+		match = `server:\s*` + anchor
+	case "title":
+		match = `<title>[^<]*` + anchor
+	}
+
+	protocol := strings.TrimSpace(g.Protocol)
+	if protocol == "" {
+		protocol = "tcp"
+	}
+
+	lines := []string{
+		"- id: 'TODO.unique_id'",
+		"  protocol: '" + protocol + "'",
+		"  product: 'TODO'   # only what the device states about itself",
+		"  vendor: 'TODO'    # the DEVICE vendor, not the software's vendor",
+		"  match: '" + match + "'",
+		"  pattern_strength: 0.90",
+	}
+	if g.Kind == "title" {
+		// A page title is usually "<hostname> - <page> - <Product>", and the
+		// hostname is the operator's own naming. Left in, the rule matches one
+		// customer's device and nobody else's.
+		lines = append(lines,
+			"  # Narrow the match to the part naming the PRODUCT: a page title",
+			"  # normally carries the site's own hostname, which is not the device.")
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/fingerprint/gaps.go
+++ b/pkg/fingerprint/gaps.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/cyprob/cyprob/pkg/stringutil"
 )
@@ -284,6 +285,9 @@ func chooseDroppedPositions(found []unmatchedObservation) map[dropKey]int {
 			continue
 		}
 		position := maskPosition(maskID)
+		if !looksLikeSiteNaming(position, entry.values) {
+			continue
+		}
 		for _, member := range entry.members {
 			if size, seen := bestSize[member]; !seen || len(entry.members) > size ||
 				(len(entry.members) == size && position < best[member]) {
@@ -293,6 +297,51 @@ func chooseDroppedPositions(found []unmatchedObservation) map[dropKey]int {
 		}
 	}
 	return best
+}
+
+// looksLikeSiteNaming decides whether a differing position is the operator's
+// own naming rather than part of the product name.
+//
+// A single differing token cannot be classified from the text alone: "NODE-A"
+// and "NODE-B" are hostnames, while "Router" and "Switch" in "Acme Router 1000"
+// name two different products, and both are one token apart. So this is
+// deliberately narrow, and narrow in the safe direction -- refusing a merge
+// splits one model across a few clusters, which is visible and recoverable,
+// while accepting a wrong one hides two products behind a single line in a
+// ranking whose whole purpose is to say what is worth writing a rule for.
+//
+// Two conditions, both drawn from the naming actually observed on real estates
+// (LS_V3700, LSV5030, LS5030FLASH, NODE-A, SITE-B):
+//
+//   - It is the FIRST token. Every observed hostname is a prefix, followed by a
+//     separator and then the product. A token in the middle of a title is part
+//     of what the device calls itself.
+//   - It is not purely alphabetic. Site naming carries digits, underscores or
+//     hyphens; a plain word is product vocabulary.
+func looksLikeSiteNaming(position int, values map[string]map[string]bool) bool {
+	if position != 0 {
+		return false
+	}
+	for value := range values {
+		if isPlainWord(value) {
+			return false
+		}
+	}
+	return true
+}
+
+// isPlainWord reports whether a token is only letters, which is what product
+// vocabulary looks like and what a hostname almost never is.
+func isPlainWord(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func maskPosition(maskID string) int {

--- a/pkg/fingerprint/gaps.go
+++ b/pkg/fingerprint/gaps.go
@@ -72,6 +72,13 @@ var (
 	gapWhitespace = regexp.MustCompile(`\s+`)
 )
 
+// gapSeparatorClass matches one character the sanitizer turns into a space.
+// \p{C} covers Cc, Cf, Co, Cs and Cn; \p{Z} the spaces; and U+FFFD is what an
+// invalid byte decodes to before it is replaced. The quantifier is applied at
+// each use, since a separator between tokens must be present while one after a
+// header colon need not be.
+const gapSeparatorClass = `[\s\p{C}\p{Z}\x{FFFD}]`
+
 const (
 	gapMaxSignature = 120
 	gapMaxSamples   = 3
@@ -91,7 +98,6 @@ func AnalyzeGaps(observations []Observation) GapReport {
 
 func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapReport {
 	resolver := NewRuleBasedResolver(rules)
-	known := ruleProtocols(rules)
 	ctx := context.Background()
 
 	report := GapReport{}
@@ -107,9 +113,8 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		}
 		report.Observations++
 
-		protocol := resolvableProtocol(obs.Protocol, known)
 		if _, err := resolver.Resolve(ctx, Input{
-			Protocol: protocol,
+			Protocol: obs.Protocol,
 			Banner:   obs.Banner,
 			Port:     obs.Port,
 		}); err == nil {
@@ -125,7 +130,7 @@ func analyzeGapsWithRules(observations []Observation, rules []StaticRule) GapRep
 		found = append(found, unmatchedObservation{
 			location:   fmt.Sprintf("%s:%d", host, obs.Port),
 			host:       host,
-			protocol:   protocol,
+			protocol:   obs.Protocol,
 			signatures: signatures,
 		})
 		for _, sig := range signatures {
@@ -505,15 +510,25 @@ func (g Gap) matchExpression() string {
 		parts[i] = regexp.QuoteMeta(part)
 	}
 	// Whitespace in the signature stands for whatever separated the tokens in
-	// the banner, and that is not necessarily a space: the sanitizer turns any
-	// non-printable character into one, so a banner separated by a no-break
-	// space, a zero-width space or a stray control byte would not match a plain
-	// \\s. The class covers control, format and every Unicode space.
-	anchor := strings.Join(parts, `[\s\p{Cc}\p{Cf}\p{Z}]+`)
+	// the banner, and that is not necessarily a space: the sanitizer replaces
+	// everything unprintable with one, so the class here has to be the
+	// complement of what the sanitizer keeps. That is wider than control and
+	// format characters -- it also covers unassigned and private-use code
+	// points, and the replacement character an invalid byte decodes to, all of
+	// which appear in binary banners and vendor strings carrying custom glyphs.
+	anchor := strings.Join(parts, gapSeparatorClass+`+`)
 
 	switch g.Kind {
 	case "server":
-		return `server:[\s\p{Cc}\p{Cf}\p{Z}]*` + anchor
+		if len(g.Varying) > 0 {
+			// A token was dropped from the front of this signature, so the
+			// header begins with text the pattern must not require to be
+			// absent. Anchoring straight onto the first surviving token
+			// produced a rule that matched none of the banners in its own
+			// cluster.
+			return `server:[^\r\n]*?` + anchor
+		}
+		return `server:` + gapSeparatorClass + `*` + anchor
 	case "title":
 		// The title element carries attributes often enough that a literal
 		// <title> misses them.
@@ -528,36 +543,4 @@ func (g Gap) matchExpression() string {
 // and produce a file that does not parse.
 func yamlSingleQuoted(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
-}
-
-// ruleProtocols is the set of protocols the rules actually key on, derived from
-// the rules themselves rather than kept by hand: a list maintained separately
-// drifts, and the drift is silent -- an unrecognized hint matches no rule at
-// all instead of trying every one.
-func ruleProtocols(rules []StaticRule) map[string]bool {
-	known := make(map[string]bool, len(rules))
-	for _, rule := range rules {
-		if protocol := strings.ToLower(strings.TrimSpace(rule.Protocol)); protocol != "" {
-			known[protocol] = true
-		}
-	}
-	return known
-}
-
-// resolvableProtocol keeps a hint only when some rule keys on it.
-//
-// The scan pipeline hands the resolver whatever the service was named, and a
-// name no rule declares selects no rules at all -- the service then looks
-// unrecognized when it was only mis-hinted. An empty hint puts the resolver in
-// the mode that tries every rule, which is the honest answer when the name
-// means nothing to the rules.
-func resolvableProtocol(protocol string, known map[string]bool) string {
-	normalized := strings.ToLower(strings.TrimSpace(protocol))
-	if normalized == "" || normalized == "tcp" || normalized == "udp" {
-		return ""
-	}
-	if known[normalized] {
-		return normalized
-	}
-	return ""
 }

--- a/pkg/fingerprint/gaps_test.go
+++ b/pkg/fingerprint/gaps_test.go
@@ -1,0 +1,148 @@
+package fingerprint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// storwizeBanner is the response an IBM Storwize V3700 actually sent, captured
+// from a live array. The array names itself twice: in the Server header and in
+// the page title.
+const storwizeBanner = "HTTP/1.1 200 OK\r\n" +
+	"Content-Type: text/html;charset=UTF-8\r\n" +
+	"Server: SVC GUI\r\n\r\n" +
+	"<html><head><title>\n        LS_V3700 - Log in - \n        IBM Storwize V3700\n    </title></head>"
+
+func gapRules() []StaticRule {
+	return []StaticRule{
+		{ID: "http.nginx", Protocol: "http", Product: "nginx", Vendor: "F5 Networks",
+			Match: `server:\s*nginx`, PatternStrength: 0.9},
+	}
+}
+
+func TestAnalyzeGaps_ReportsOnlyWhatNoRuleRecognizes(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http", Banner: storwizeBanner},
+		{Target: "10.0.0.2", Port: 80, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\n\r\n"},
+	}, gapRules())
+
+	require.Equal(t, 2, report.Observations)
+	require.Equal(t, 1, report.Unmatched, "the nginx banner is already recognized")
+
+	for _, gap := range report.Gaps {
+		require.NotContains(t, strings.ToLower(gap.Signature), "nginx",
+			"a recognized banner must not be reported as a gap")
+	}
+}
+
+// A device that names itself in two places is worth reporting under both, since
+// which one a rule should anchor on is a judgement the tool cannot make.
+func TestAnalyzeGaps_ReportsEveryAnchorABannerOffers(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http", Banner: storwizeBanner},
+	}, gapRules())
+
+	kinds := map[string]string{}
+	for _, gap := range report.Gaps {
+		kinds[gap.Kind] = gap.Signature
+	}
+	require.Equal(t, "SVC GUI", kinds["server"])
+	require.Contains(t, kinds["title"], "IBM Storwize V3700")
+	require.Equal(t, 1, report.Unmatched, "one service, however many anchors it offers")
+}
+
+func TestAnalyzeGaps_GroupsAndRanksByFrequency(t *testing.T) {
+	observations := []Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http", Banner: storwizeBanner},
+		{Target: "10.0.0.2", Port: 80, Protocol: "http", Banner: storwizeBanner},
+		{Target: "10.0.0.3", Port: 80, Protocol: "http",
+			Banner: "HTTP/1.1 401\r\nServer: cisco-IOS\r\n\r\n"},
+	}
+	report := analyzeGapsWithRules(observations, gapRules())
+
+	require.Equal(t, 3, report.Unmatched)
+	require.NotEmpty(t, report.Gaps)
+
+	// Frequency decides the order; ties fall back to the signature so two runs
+	// over the same corpus produce the same report and a diff means something.
+	counts := make([]int, 0, len(report.Gaps))
+	for _, gap := range report.Gaps {
+		counts = append(counts, gap.Count)
+	}
+	require.IsNonIncreasing(t, counts, "the most frequent gap is reported first")
+	require.Equal(t, 1, report.Gaps[len(report.Gaps)-1].Count, "the rarest comes last")
+
+	byKind := map[string]Gap{}
+	for _, gap := range report.Gaps {
+		byKind[gap.Kind+"|"+gap.Signature] = gap
+	}
+	server := byKind["server|SVC GUI"]
+	require.Equal(t, 2, server.Count, "the same array seen twice is one gap counted twice")
+	require.Equal(t, []string{"10.0.0.1:80", "10.0.0.2:80"}, server.Samples,
+		"a gap names where to go and confirm it")
+}
+
+// The banner is text a scanned host chose to send. It reaches an operator's
+// terminal, so it must not be able to carry escape sequences there.
+func TestAnalyzeGaps_SanitizesHostSuppliedText(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: evil\x1b[31mred\x07\r\n\r\n"},
+	}, gapRules())
+
+	require.Len(t, report.Gaps, 1)
+	require.NotContains(t, report.Gaps[0].Signature, "\x1b")
+	require.NotContains(t, report.Gaps[0].Signature, "\x07")
+}
+
+func TestAnalyzeGaps_BoundsWhatAHostCanClaim(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: " + strings.Repeat("A", 5000) + "\r\n\r\n"},
+	}, gapRules())
+
+	require.Len(t, report.Gaps, 1)
+	require.LessOrEqual(t, len([]rune(report.Gaps[0].Signature)), gapMaxSignature+1,
+		"a long banner is truncated rather than filling the report")
+}
+
+// Non-HTTP services carry their identity on the first line.
+func TestAnalyzeGaps_FallsBackToTheFirstLine(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 21, Protocol: "ftp", Banner: "220 SomeAppliance FTP ready\r\n"},
+	}, gapRules())
+
+	require.Len(t, report.Gaps, 1)
+	require.Equal(t, "banner", report.Gaps[0].Kind)
+	require.Equal(t, "220 SomeAppliance FTP ready", report.Gaps[0].Signature)
+}
+
+func TestAnalyzeGaps_IgnoresServicesWithoutABanner(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 445, Protocol: "smb", Banner: ""},
+		{Target: "10.0.0.2", Port: 139, Protocol: "smb", Banner: "   "},
+	}, gapRules())
+
+	require.Zero(t, report.Observations)
+	require.Empty(t, report.Gaps)
+}
+
+func TestRuleStub_AnchorsOnTheRightPartAndEscapes(t *testing.T) {
+	server := Gap{Kind: "server", Signature: "ntopng 5.7.230405 (x86_64)", Protocol: "http"}
+	stub := server.RuleStub()
+	require.Contains(t, stub, "protocol: 'http'")
+	require.Contains(t, stub, `match: 'server:\s*ntopng 5\.7\.230405 \(x86_64\)'`,
+		"regex metacharacters in a banner must be escaped, not interpreted")
+
+	title := Gap{Kind: "title", Signature: "LS_V3700 - Log in - IBM Storwize V3700", Protocol: "http"}
+	require.Contains(t, title.RuleStub(), "<title>[^<]*")
+	require.Contains(t, title.RuleStub(), "hostname",
+		"a title stub must warn that it carries the site's own naming")
+}
+
+func TestRuleStub_DefaultsProtocolWhenUnknown(t *testing.T) {
+	require.Contains(t, Gap{Kind: "banner", Signature: "x"}.RuleStub(), "protocol: 'tcp'")
+}

--- a/pkg/fingerprint/gaps_test.go
+++ b/pkg/fingerprint/gaps_test.go
@@ -417,3 +417,52 @@ func TestRuleStub_DoesNotAnchorOnTheTruncationMark(t *testing.T) {
 	require.True(t, compiled.MatchString(strings.ToLower(long)),
 		"a truncated signature must still match the banner it came from")
 }
+
+// A single differing token cannot be classified from the text alone: "NODE-A"
+// and "NODE-B" are hostnames, while "Router" and "Switch" in "Acme Router 1000"
+// name two different products, and both are one token apart. The rule is
+// therefore narrow, and narrow in the safe direction — refusing a merge splits
+// one model across a few clusters, which is visible and recoverable, while
+// accepting a wrong one hides two products behind a single line.
+func TestAnalyzeGaps_DoesNotMergeTwoProductsThatDifferByOneWord(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.4.0.1", Port: 443, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: AcmeOS\r\n\r\n<title>Acme Router 1000</title>"},
+		{Target: "10.4.0.2", Port: 443, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: AcmeOS\r\n\r\n<title>Acme Switch 1000</title>"},
+	}, gapRules())
+
+	titles := map[string]bool{}
+	for _, gap := range report.Gaps {
+		if gap.Kind == "title" {
+			titles[gap.Signature] = true
+		}
+	}
+	require.True(t, titles["Acme Router 1000"], "the router keeps its name")
+	require.True(t, titles["Acme Switch 1000"], "and so does the switch")
+	require.False(t, titles["Acme 1000"], "two products must not merge into one line")
+}
+
+func TestLooksLikeSiteNaming(t *testing.T) {
+	hosts := func(values ...string) map[string]map[string]bool {
+		out := map[string]map[string]bool{}
+		for i, v := range values {
+			out[v] = map[string]bool{fmt.Sprintf("10.0.0.%d", i): true}
+		}
+		return out
+	}
+
+	// Naming observed on real estates: digits, underscores, hyphens.
+	require.True(t, looksLikeSiteNaming(0, hosts("ls_v3700", "lsv5030")))
+	require.True(t, looksLikeSiteNaming(0, hosts("node-a", "node-b")))
+	require.True(t, looksLikeSiteNaming(0, hosts("site-a", "site-b")))
+
+	// Product vocabulary is plain words, and never dropped.
+	require.False(t, looksLikeSiteNaming(0, hosts("router", "switch")))
+	require.False(t, looksLikeSiteNaming(0, hosts("alpha", "beta")))
+
+	// Only a leading token is treated as naming; every observed hostname is a
+	// prefix, and a token inside a title is part of what the device calls itself.
+	require.False(t, looksLikeSiteNaming(1, hosts("ls_v3700", "lsv5030")))
+	require.False(t, looksLikeSiteNaming(2, hosts("5000", "5300")))
+}

--- a/pkg/fingerprint/gaps_test.go
+++ b/pkg/fingerprint/gaps_test.go
@@ -136,10 +136,10 @@ func TestRuleStub_AnchorsOnTheRightPartAndEscapes(t *testing.T) {
 	server := Gap{Kind: "server", Signature: "ntopng 5.7.230405 (x86_64)", Protocol: "http"}
 	stub := server.RuleStub()
 	require.Contains(t, stub, "protocol: 'http'")
-	require.Contains(t, stub, `ntopng[\s\p{Cc}\p{Cf}\p{Z}]+5\.7\.230405`,
+	require.Contains(t, stub, `ntopng`+gapSeparatorClass+`+5\.7\.230405`,
 		"metacharacters are escaped, and the separator is a class rather than "+
-			"a literal space: the sanitizer turns any non-printable character "+
-			"into one, and a plain backslash-s would not match what it replaced")
+			"a literal space: the sanitizer replaces every unprintable character "+
+			"with one, so the class has to be the complement of what it keeps")
 
 	title := Gap{Kind: "title", Signature: "LS_V3700 - Log in - IBM Storwize V3700", Protocol: "http"}
 	require.Contains(t, title.RuleStub(), "<title[^>]*>[^<]*",
@@ -154,24 +154,65 @@ func TestRuleStub_DefaultsProtocolWhenUnknown(t *testing.T) {
 }
 
 // A stub that does not match the banner it was generated from is a dead rule,
-// and nothing about the file it lands in would say so. The signature has had
-// its whitespace collapsed, while the banner it came from wraps its title
-// across lines and indents it, so anchoring the collapsed text literally was
-// enough to break this.
-func TestRuleStub_MatchesTheBannerItWasGeneratedFrom(t *testing.T) {
-	report := analyzeGapsWithRules([]Observation{
-		{Target: "10.0.0.1", Port: 443, Protocol: "http", Banner: storwizeBanner},
-	}, gapRules())
-	require.NotEmpty(t, report.Gaps)
+// and nothing about the file it lands in would say so.
+//
+// The first version of this test fed ONE observation, which meant no position
+// ever qualified as site naming and the merged shape -- the one where a token
+// has been dropped from the signature -- was never exercised at all. It passed
+// while the server-kind stub matched none of the banners in its own cluster.
+// Every case here therefore supplies at least two hosts, and the generated
+// pattern is required to match EVERY banner in the cluster it came from.
+func TestRuleStub_MatchesEveryBannerInItsCluster(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		banners []string
+	}{
+		{"single observation, nothing dropped", []string{
+			storwizeBanner,
+		}},
+		{"server kind, leading token differs", []string{
+			"HTTP/1.1 200 OK\r\nServer: node01 Acme Array 9000\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nServer: node02 Acme Array 9000\r\n\r\n",
+		}},
+		{"title kind, leading token differs", []string{
+			"HTTP/1.1 200 OK\r\nServer: X\r\n\r\n<title>node01 - Acme Array 9000</title>",
+			"HTTP/1.1 200 OK\r\nServer: X\r\n\r\n<title>node02 - Acme Array 9000</title>",
+		}},
+		{"banner kind, leading token differs", []string{
+			"node01 Acme FTP ready\r\n",
+			"node02 Acme FTP ready\r\n",
+		}},
+		{"title wrapped across lines, as a real one is", []string{
+			"HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n<title>\n  ls_v3700 - Log in - \n  IBM Storwize V3700\n</title>",
+			"HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n<title>\n  ls_v3701 - Log in - \n  IBM Storwize V3700\n</title>",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observations := make([]Observation, 0, len(tc.banners))
+			for i, banner := range tc.banners {
+				observations = append(observations, Observation{
+					Target: fmt.Sprintf("10.9.0.%d", i), Port: 80,
+					Protocol: "http", Banner: banner,
+				})
+			}
+			report := analyzeGapsWithRules(observations, gapRules())
+			require.NotEmpty(t, report.Gaps)
 
-	for _, gap := range report.Gaps {
-		t.Run(gap.Kind, func(t *testing.T) {
-			pattern := gap.matchExpression()
-			compiled, err := regexp.Compile(pattern)
-			require.NoError(t, err, "the generated pattern must compile")
+			for _, gap := range report.Gaps {
+				pattern := gap.matchExpression()
+				compiled, err := regexp.Compile(pattern)
+				require.NoError(t, err, "%s: the generated pattern must compile", gap.Kind)
 
-			require.True(t, compiled.MatchString(strings.ToLower(storwizeBanner)),
-				"generated %q does not match the banner it came from", pattern)
+				matched := 0
+				for _, banner := range tc.banners {
+					if compiled.MatchString(strings.ToLower(banner)) {
+						matched++
+					}
+				}
+				require.Equal(t, gap.Count, matched,
+					"%s: generated %q matched %d of the %d banners in its cluster",
+					gap.Kind, pattern, matched, gap.Count)
+			}
 		})
 	}
 }
@@ -337,37 +378,29 @@ func TestRuleStub_RefusesAProtocolThatIsNotAPlainToken(t *testing.T) {
 	require.NotContains(t, stub, "rm -rf")
 }
 
-// The scan names a service whatever it likes, and the two callers of the shared
-// derivation pass different things into it: production passes a value from the
-// probe catalog, the tool passes the recorded service name. A name no rule
-// declares selects no rules at all, so the service looks unrecognized when it
-// was only mis-hinted -- the same class of false gap as the https case, reached
-// through the argument rather than the function.
-func TestResolvableProtocol_UnknownNamesFallBackToTryingEveryRule(t *testing.T) {
-	known := ruleProtocols(loadBuiltinRules())
+// The tool must ask the resolver the same question production asks, or its
+// report is about a scanner nobody runs.
+//
+// An earlier version filtered the hint against the protocols the rules declare,
+// which made the tool MORE generous than production: a service production
+// cannot identify was resolved here in fallback mode and quietly left out of
+// the report. That is the wrong direction for a gap report, and it also made
+// the shared derivation dead code -- mutating it changed nothing. The filter is
+// gone; the derivation is the only thing deciding the hint.
+func TestAnalyzeGaps_UsesTheHintProductionWouldUse(t *testing.T) {
+	// A service name no rule keys on is a real gap: production passes the same
+	// name, matches nothing, and reports nothing about the host either.
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.3.0.1", Port: 5672, Protocol: "rabbitmq",
+			Banner: "AMQP\x00\x00\x09\x01"},
+	}, gapRules())
 
-	for _, tc := range []struct{ in, want string }{
-		{"http", "http"},
-		{"HTTP", "http"},
-		{"ssh", "ssh"},
-		// Named by a scan, keyed on by no rule.
-		{"memcached-alt", ""},
-		{"vnc-http", ""},
-		{"", ""},
-		// The transport says nothing the rules key on.
-		{"tcp", ""},
-		{"udp", ""},
-	} {
-		require.Equal(t, tc.want, resolvableProtocol(tc.in, known), "input %q", tc.in)
-	}
-}
-
-func TestRuleProtocols_ComesFromTheRulesThemselves(t *testing.T) {
-	known := ruleProtocols([]StaticRule{
-		{Protocol: "http"}, {Protocol: "HTTP"}, {Protocol: " ssh "}, {Protocol: ""},
-	})
-	require.Equal(t, map[string]bool{"http": true, "ssh": true}, known,
-		"a list kept by hand drifts from the rules; this is derived from them")
+	require.Equal(t, 1, report.Unmatched,
+		"a service production cannot resolve must be reported, not resolved by a "+
+			"more generous hint than production uses")
+	require.NotEmpty(t, report.Gaps)
+	require.Equal(t, "rabbitmq", report.Gaps[0].Protocol,
+		"and the stub must declare the protocol production hands the resolver")
 }
 
 // A banner whose tokens are separated by something the sanitizer replaced must
@@ -376,14 +409,24 @@ func TestRuleProtocols_ComesFromTheRulesThemselves(t *testing.T) {
 // it replaced.
 func TestRuleStub_MatchesBannersSeparatedByNonPrintableCharacters(t *testing.T) {
 	for _, separator := range []string{
-		"\u00a0", // no-break space
-		"\u200b", // zero-width space
-		"\ufeff", // byte order mark
-		"\u00ad", // soft hyphen
-		"\u0085", // C1 NEL
-		"\u3000", // ideographic space
-		"\x1b",   // escape
-		"\x00",   // NUL
+		"\u00a0", // no-break space (Z)
+		"\u200b", // zero-width space (Cf)
+		"\ufeff", // byte order mark (Cf)
+		"\u00ad", // soft hyphen (Cf)
+		"\u0085", // C1 NEL (Cc)
+		"\u3000", // ideographic space (Z)
+		"\x1b",   // escape (Cc)
+		"\x00",   // NUL (Cc)
+		// The sanitizer replaces everything unprintable, which is wider than
+		// control and format characters. These are the classes a class built
+		// from Cc+Cf+Z alone lets through, and they occur in binary banners and
+		// in vendor strings carrying custom glyphs.
+		"\ufffd",     // replacement character
+		"\ue000",     // private use (Co)
+		"\uf8ff",     // private use (Co)
+		"\u0378",     // unassigned (Cn)
+		"\u05ff",     // unassigned (Cn)
+		"\xff",       // an invalid byte, which decodes to U+FFFD
 	} {
 		t.Run(fmt.Sprintf("%U", []rune(separator)[0]), func(t *testing.T) {
 			banner := "HTTP/1.1 200 OK\r\nServer: Acme" + separator + "Array/1.0\r\n\r\n"

--- a/pkg/fingerprint/gaps_test.go
+++ b/pkg/fingerprint/gaps_test.go
@@ -136,12 +136,15 @@ func TestRuleStub_AnchorsOnTheRightPartAndEscapes(t *testing.T) {
 	server := Gap{Kind: "server", Signature: "ntopng 5.7.230405 (x86_64)", Protocol: "http"}
 	stub := server.RuleStub()
 	require.Contains(t, stub, "protocol: 'http'")
-	require.Contains(t, stub, `match: 'server:\s*ntopng\s+5\.7\.230405\s+\(x86_64\)'`,
-		"metacharacters are escaped, and whitespace becomes a pattern so the "+
-			"rule still matches a banner whose spacing the signature collapsed")
+	require.Contains(t, stub, `ntopng[\s\p{Cc}\p{Cf}\p{Z}]+5\.7\.230405`,
+		"metacharacters are escaped, and the separator is a class rather than "+
+			"a literal space: the sanitizer turns any non-printable character "+
+			"into one, and a plain backslash-s would not match what it replaced")
 
 	title := Gap{Kind: "title", Signature: "LS_V3700 - Log in - IBM Storwize V3700", Protocol: "http"}
-	require.Contains(t, title.RuleStub(), "<title>[^<]*")
+	require.Contains(t, title.RuleStub(), "<title[^>]*>[^<]*",
+		"a title element carries attributes often enough that a literal "+
+			"<title> misses them")
 	require.Contains(t, title.RuleStub(), "hostname",
 		"a title stub must warn that it carries the site's own naming")
 }
@@ -190,13 +193,6 @@ func TestRuleStub_QuotesApostrophesForYAML(t *testing.T) {
 
 	require.Contains(t, stub, "bob''s", "an apostrophe is doubled, not left to end the scalar")
 	require.NotContains(t, stub, "match: 'server:\\s*bob's")
-}
-
-// The protocol is embedded in generated YAML and a corpus need not be one this
-// machine produced, so an unrecognized value is dropped rather than passed on.
-func TestRuleStub_RefusesAnUnknownProtocol(t *testing.T) {
-	stub := Gap{Kind: "banner", Signature: "x", Protocol: "'; rm -rf /"}.RuleStub()
-	require.Contains(t, stub, "protocol: 'tcp'")
 }
 
 // Frequency ranking is the whole value of the report, so a signature carrying
@@ -248,11 +244,12 @@ func TestAnalyzeGaps_AUniqueBannerKeepsItsSignature(t *testing.T) {
 	require.Equal(t, "OneOfAKind/9.9", report.Gaps[0].Signature)
 }
 
-// Dropping tokens that appear on one host groups a model correctly, but a model
-// number present on a single host is indistinguishable from a hostname by that
-// measure. Measured on a real corpus, "IBM FlashSystem 5000" and "5300" lost
-// exactly the number worth writing a rule for, so what is dropped is reported.
-func TestAnalyzeGaps_ReportsWhatItDroppedFromTheSignature(t *testing.T) {
+// A token is dropped only when doing so merges signatures that agree
+// everywhere else. Two arrays differing in BOTH the hostname and the model
+// number differ in two positions, so they stay apart and keep their models --
+// which is the case an earlier corpus-wide rule got wrong, collapsing
+// "IBM FlashSystem 5000" and "5300" into one cluster with the numbers gone.
+func TestAnalyzeGaps_TwoDifferencesMeanTwoDevices(t *testing.T) {
 	const template = "HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n<title>%s - Log in - IBM FlashSystem %s</title>"
 
 	report := analyzeGapsWithRules([]Observation{
@@ -260,14 +257,163 @@ func TestAnalyzeGaps_ReportsWhatItDroppedFromTheSignature(t *testing.T) {
 		{Target: "10.0.0.2", Port: 443, Protocol: "http", Banner: fmt.Sprintf(template, "SITE-B", "5300")},
 	}, gapRules())
 
+	titles := map[string]Gap{}
+	for _, gap := range report.Gaps {
+		if gap.Kind == "title" {
+			titles[gap.Signature] = gap
+		}
+	}
+	require.Len(t, titles, 2, "different models are different devices")
+	for signature := range titles {
+		require.True(t,
+			strings.Contains(signature, "5000") || strings.Contains(signature, "5300"),
+			"the model number survives: %q", signature)
+	}
+}
+
+// The same model across several hosts differs in one position, so it merges and
+// the hostnames are reported rather than silently dropped.
+func TestAnalyzeGaps_OneDifferenceMergesAndIsReported(t *testing.T) {
+	const template = "HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n<title>%s - Log in - IBM FlashSystem 5000</title>"
+
+	observations := make([]Observation, 0, 3)
+	for i, host := range []string{"SITE-A", "SITE-B", "SITE-C"} {
+		observations = append(observations, Observation{
+			Target: fmt.Sprintf("10.0.0.%d", i), Port: 443, Protocol: "http",
+			Banner: fmt.Sprintf(template, host),
+		})
+	}
+
+	report := analyzeGapsWithRules(observations, gapRules())
+
 	var title Gap
 	for _, gap := range report.Gaps {
 		if gap.Kind == "title" {
 			title = gap
 		}
 	}
-	require.Equal(t, 2, title.Count, "the two arrays group together")
-	require.NotContains(t, title.Signature, "5000", "the differing token left the signature")
-	require.Subset(t, title.Varying, []string{"5000", "5300"},
-		"but it is reported, because it may be the model rather than a hostname")
+	require.Equal(t, 3, title.Count, "one model, one cluster")
+	require.Contains(t, title.Signature, "5000", "the model survives")
+	require.NotContains(t, title.Signature, "SITE-", "the site naming does not")
+	require.ElementsMatch(t, []string{"SITE-A", "SITE-B", "SITE-C"}, title.Varying,
+		"every dropped token is reported, none silently cut")
+}
+
+// Unrelated devices must not merge through whatever noise they share. An
+// earlier corpus-wide rule collapsed ten distinct appliances into clusters
+// like "- Management" and produced a stub anchored on the word "ready".
+func TestAnalyzeGaps_UnrelatedDevicesKeepTheirSignatures(t *testing.T) {
+	titles := []string{
+		"Vendor-A Box - Management",
+		"Vendor-B Unit - Console",
+		"Zeta 6000 Web Interface",
+		"Omega 7000 Web Interface",
+	}
+	observations := make([]Observation, 0, len(titles))
+	for i, title := range titles {
+		observations = append(observations, Observation{
+			Target: fmt.Sprintf("10.0.1.%d", i), Port: 443, Protocol: "http",
+			Banner: fmt.Sprintf("HTTP/1.1 200 OK\r\nServer: Vendor%d/1.0\r\n\r\n<title>%s</title>", i, title),
+		})
+	}
+
+	report := analyzeGapsWithRules(observations, gapRules())
+
+	seen := map[string]bool{}
+	for _, gap := range report.Gaps {
+		if gap.Kind == "title" {
+			seen[gap.Signature] = true
+		}
+	}
+	for _, title := range titles {
+		require.True(t, seen[title], "%q lost tokens to a merge that never happened", title)
+	}
+}
+
+// A protocol is not free text, and RuleStub output is pasted into YAML.
+func TestRuleStub_RefusesAProtocolThatIsNotAPlainToken(t *testing.T) {
+	stub := Gap{Kind: "banner", Signature: "x", Protocol: "'; rm -rf /"}.RuleStub()
+	require.Contains(t, stub, "protocol: 'tcp'")
+	require.NotContains(t, stub, "rm -rf")
+}
+
+// The scan names a service whatever it likes, and the two callers of the shared
+// derivation pass different things into it: production passes a value from the
+// probe catalog, the tool passes the recorded service name. A name no rule
+// declares selects no rules at all, so the service looks unrecognized when it
+// was only mis-hinted -- the same class of false gap as the https case, reached
+// through the argument rather than the function.
+func TestResolvableProtocol_UnknownNamesFallBackToTryingEveryRule(t *testing.T) {
+	known := ruleProtocols(loadBuiltinRules())
+
+	for _, tc := range []struct{ in, want string }{
+		{"http", "http"},
+		{"HTTP", "http"},
+		{"ssh", "ssh"},
+		// Named by a scan, keyed on by no rule.
+		{"memcached-alt", ""},
+		{"vnc-http", ""},
+		{"", ""},
+		// The transport says nothing the rules key on.
+		{"tcp", ""},
+		{"udp", ""},
+	} {
+		require.Equal(t, tc.want, resolvableProtocol(tc.in, known), "input %q", tc.in)
+	}
+}
+
+func TestRuleProtocols_ComesFromTheRulesThemselves(t *testing.T) {
+	known := ruleProtocols([]StaticRule{
+		{Protocol: "http"}, {Protocol: "HTTP"}, {Protocol: " ssh "}, {Protocol: ""},
+	})
+	require.Equal(t, map[string]bool{"http": true, "ssh": true}, known,
+		"a list kept by hand drifts from the rules; this is derived from them")
+}
+
+// A banner whose tokens are separated by something the sanitizer replaced must
+// still be matched by the rule generated from it. The sanitizer turns every
+// non-printable character into an ASCII space, and a plain \s cannot match what
+// it replaced.
+func TestRuleStub_MatchesBannersSeparatedByNonPrintableCharacters(t *testing.T) {
+	for _, separator := range []string{
+		"\u00a0", // no-break space
+		"\u200b", // zero-width space
+		"\ufeff", // byte order mark
+		"\u00ad", // soft hyphen
+		"\u0085", // C1 NEL
+		"\u3000", // ideographic space
+		"\x1b",   // escape
+		"\x00",   // NUL
+	} {
+		t.Run(fmt.Sprintf("%U", []rune(separator)[0]), func(t *testing.T) {
+			banner := "HTTP/1.1 200 OK\r\nServer: Acme" + separator + "Array/1.0\r\n\r\n"
+			report := analyzeGapsWithRules([]Observation{
+				{Target: "10.0.0.1", Port: 80, Protocol: "http", Banner: banner},
+			}, gapRules())
+			require.NotEmpty(t, report.Gaps)
+
+			pattern := report.Gaps[0].matchExpression()
+			compiled, err := regexp.Compile(pattern)
+			require.NoError(t, err)
+			require.True(t, compiled.MatchString(strings.ToLower(banner)),
+				"generated %q does not match the banner it came from", pattern)
+		})
+	}
+}
+
+// The ellipsis marks that this tool cut the signature; it is not something the
+// host sent, and anchoring it produces a rule no banner can match.
+func TestRuleStub_DoesNotAnchorOnTheTruncationMark(t *testing.T) {
+	long := "HTTP/1.1 200 OK\r\nServer: " + strings.Repeat("Acme Array ", 30) + "\r\n\r\n"
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http", Banner: long},
+	}, gapRules())
+	require.NotEmpty(t, report.Gaps)
+
+	pattern := report.Gaps[0].matchExpression()
+	require.NotContains(t, pattern, "\u2026")
+	compiled, err := regexp.Compile(pattern)
+	require.NoError(t, err)
+	require.True(t, compiled.MatchString(strings.ToLower(long)),
+		"a truncated signature must still match the banner it came from")
 }

--- a/pkg/fingerprint/gaps_test.go
+++ b/pkg/fingerprint/gaps_test.go
@@ -1,6 +1,8 @@
 package fingerprint
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -134,8 +136,9 @@ func TestRuleStub_AnchorsOnTheRightPartAndEscapes(t *testing.T) {
 	server := Gap{Kind: "server", Signature: "ntopng 5.7.230405 (x86_64)", Protocol: "http"}
 	stub := server.RuleStub()
 	require.Contains(t, stub, "protocol: 'http'")
-	require.Contains(t, stub, `match: 'server:\s*ntopng 5\.7\.230405 \(x86_64\)'`,
-		"regex metacharacters in a banner must be escaped, not interpreted")
+	require.Contains(t, stub, `match: 'server:\s*ntopng\s+5\.7\.230405\s+\(x86_64\)'`,
+		"metacharacters are escaped, and whitespace becomes a pattern so the "+
+			"rule still matches a banner whose spacing the signature collapsed")
 
 	title := Gap{Kind: "title", Signature: "LS_V3700 - Log in - IBM Storwize V3700", Protocol: "http"}
 	require.Contains(t, title.RuleStub(), "<title>[^<]*")
@@ -145,4 +148,126 @@ func TestRuleStub_AnchorsOnTheRightPartAndEscapes(t *testing.T) {
 
 func TestRuleStub_DefaultsProtocolWhenUnknown(t *testing.T) {
 	require.Contains(t, Gap{Kind: "banner", Signature: "x"}.RuleStub(), "protocol: 'tcp'")
+}
+
+// A stub that does not match the banner it was generated from is a dead rule,
+// and nothing about the file it lands in would say so. The signature has had
+// its whitespace collapsed, while the banner it came from wraps its title
+// across lines and indents it, so anchoring the collapsed text literally was
+// enough to break this.
+func TestRuleStub_MatchesTheBannerItWasGeneratedFrom(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 443, Protocol: "http", Banner: storwizeBanner},
+	}, gapRules())
+	require.NotEmpty(t, report.Gaps)
+
+	for _, gap := range report.Gaps {
+		t.Run(gap.Kind, func(t *testing.T) {
+			pattern := gap.matchExpression()
+			compiled, err := regexp.Compile(pattern)
+			require.NoError(t, err, "the generated pattern must compile")
+
+			require.True(t, compiled.MatchString(strings.ToLower(storwizeBanner)),
+				"generated %q does not match the banner it came from", pattern)
+		})
+	}
+}
+
+// The loader requires a CPE and rejects the whole file without one, so a stub
+// that omits it silently disables every rule in the file it is pasted into.
+func TestRuleStub_CarriesEveryFieldTheLoaderRequires(t *testing.T) {
+	stub := Gap{Kind: "server", Signature: "SVC GUI", Protocol: "http"}.RuleStub()
+
+	for _, required := range []string{"protocol:", "product:", "vendor:", "cpe:", "match:"} {
+		require.Contains(t, stub, required)
+	}
+}
+
+// A banner containing an apostrophe would end a single-quoted YAML scalar early
+// and produce a file that does not parse.
+func TestRuleStub_QuotesApostrophesForYAML(t *testing.T) {
+	stub := Gap{Kind: "server", Signature: "Bob's Router", Protocol: "http"}.RuleStub()
+
+	require.Contains(t, stub, "bob''s", "an apostrophe is doubled, not left to end the scalar")
+	require.NotContains(t, stub, "match: 'server:\\s*bob's")
+}
+
+// The protocol is embedded in generated YAML and a corpus need not be one this
+// machine produced, so an unrecognized value is dropped rather than passed on.
+func TestRuleStub_RefusesAnUnknownProtocol(t *testing.T) {
+	stub := Gap{Kind: "banner", Signature: "x", Protocol: "'; rm -rf /"}.RuleStub()
+	require.Contains(t, stub, "protocol: 'tcp'")
+}
+
+// Frequency ranking is the whole value of the report, so a signature carrying
+// the site's own naming splits one device model into as many clusters as there
+// are copies of it and buries the thing worth writing a rule for.
+func TestAnalyzeGaps_OneModelIsOneClusterAcrossManyHosts(t *testing.T) {
+	const template = "HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n" +
+		"<html><head><title>\n    %s - Log in - \n    %s\n  </title></head>"
+
+	observations := make([]Observation, 0, 8)
+	for i, model := range []string{"IBM Storwize V3700", "IBM FlashSystem 5300"} {
+		for copy := 0; copy < 4; copy++ {
+			observations = append(observations, Observation{
+				Target:   fmt.Sprintf("10.0.%d.%d", i, copy),
+				Port:     443,
+				Protocol: "http",
+				// Each copy carries a different hostname, as a real estate does.
+				Banner: fmt.Sprintf(template, fmt.Sprintf("SITE-%s-%02d", model[4:8], copy), model),
+			})
+		}
+	}
+
+	report := analyzeGapsWithRules(observations, gapRules())
+
+	titles := map[string]int{}
+	for _, gap := range report.Gaps {
+		if gap.Kind == "title" {
+			titles[gap.Signature] = gap.Count
+		}
+	}
+	require.Len(t, titles, 2, "two models, two clusters — not one per host")
+
+	for signature, count := range titles {
+		require.Equal(t, 4, count, "every copy of a model lands in its cluster")
+		require.NotContains(t, signature, "SITE-",
+			"the site's own naming must not survive into the signature")
+	}
+}
+
+// A banner with nothing in common with any other keeps its whole signature:
+// dropping every token would leave nothing to write a rule from.
+func TestAnalyzeGaps_AUniqueBannerKeepsItsSignature(t *testing.T) {
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 80, Protocol: "http",
+			Banner: "HTTP/1.1 200 OK\r\nServer: OneOfAKind/9.9\r\n\r\n"},
+	}, gapRules())
+
+	require.Len(t, report.Gaps, 1)
+	require.Equal(t, "OneOfAKind/9.9", report.Gaps[0].Signature)
+}
+
+// Dropping tokens that appear on one host groups a model correctly, but a model
+// number present on a single host is indistinguishable from a hostname by that
+// measure. Measured on a real corpus, "IBM FlashSystem 5000" and "5300" lost
+// exactly the number worth writing a rule for, so what is dropped is reported.
+func TestAnalyzeGaps_ReportsWhatItDroppedFromTheSignature(t *testing.T) {
+	const template = "HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n<title>%s - Log in - IBM FlashSystem %s</title>"
+
+	report := analyzeGapsWithRules([]Observation{
+		{Target: "10.0.0.1", Port: 443, Protocol: "http", Banner: fmt.Sprintf(template, "SITE-A", "5000")},
+		{Target: "10.0.0.2", Port: 443, Protocol: "http", Banner: fmt.Sprintf(template, "SITE-B", "5300")},
+	}, gapRules())
+
+	var title Gap
+	for _, gap := range report.Gaps {
+		if gap.Kind == "title" {
+			title = gap
+		}
+	}
+	require.Equal(t, 2, title.Count, "the two arrays group together")
+	require.NotContains(t, title.Signature, "5000", "the differing token left the signature")
+	require.Subset(t, title.Varying, []string{"5000", "5300"},
+		"but it is reported, because it may be the model rather than a hostname")
 }

--- a/pkg/modules/parse/fingerprint_parser.go
+++ b/pkg/modules/parse/fingerprint_parser.go
@@ -241,20 +241,9 @@ func (m *FingerprintParserModule) processBannerCandidates(ctx context.Context, b
 			Str("response_preview", response[:min(len(response), 50)]).
 			Msg("Processing banner candidate")
 
-		protocolHint := strings.ToLower(candidate.Protocol)
-		if protocolHint == "" || protocolHint == "tcp" || protocolHint == "udp" {
-			protocolHint = strings.ToLower(banner.Protocol)
-		}
-		if protocolHint == "" || protocolHint == "tcp" || protocolHint == "udp" {
-			detectedHint := fingerprintProtocolHint(banner.Port, response)
-			if detectedHint != "" {
-				protocolHint = detectedHint
-			} else {
-				// Phase 1: If no hint found, leave as generic to trigger fallback in resolver
-				// This enables detection on non-standard ports (e.g., MySQL on 3210, HTTP on 2096)
-				protocolHint = "" // Empty triggers fallback mode
-			}
-		}
+		// An empty result triggers the resolver's fallback mode, which is what
+		// finds a service on a non-standard port (MySQL on 3210, HTTP on 2096).
+		protocolHint := protocolHintFor(candidate.Protocol, banner.Protocol, banner.Port, response)
 		resolverProtocolHint := normalizeResolverProtocol(protocolHint, response, candidate.ProbeID)
 
 		result, err := resolver.Resolve(ctx, fingerprint.Input{
@@ -603,4 +592,44 @@ func fingerprintParserModuleFactory() engine.Module {
 
 func init() {
 	engine.RegisterModuleFactory(fingerprintParserModuleName, fingerprintParserModuleFactory)
+}
+
+// protocolHintFor derives the protocol hint from what the scan recorded, before
+// the resolver-specific normalization. This is the single copy of that chain:
+// the scan pipeline and ResolverProtocolHint both go through it, so a report
+// about what the rules would match cannot drift from what they do match.
+func protocolHintFor(serviceName, transport string, port int, banner string) string {
+	hint := strings.ToLower(strings.TrimSpace(serviceName))
+	if isGenericTransportHint(hint) {
+		hint = strings.ToLower(strings.TrimSpace(transport))
+	}
+	if isGenericTransportHint(hint) {
+		// An empty result here is meaningful: it puts the resolver into the
+		// mode that tries every rule.
+		hint = fingerprintProtocolHint(port, banner)
+	}
+	return hint
+}
+
+// isGenericTransportHint reports whether a hint names the transport rather than
+// the protocol, which is to say it names nothing the rules key on.
+func isGenericTransportHint(hint string) bool {
+	return hint == "" || hint == "tcp" || hint == "udp"
+}
+
+// ResolverProtocolHint returns the protocol hint the fingerprint resolver is
+// given for a banner, as the scan pipeline would derive it.
+//
+// It exists so that anything reasoning about what the rules would match -- the
+// gap report, for instance -- asks the same question production asks. The
+// mismatch it prevents is silent: a hint of "https" matches no rule, because
+// the rules are keyed on "http", and the service then looks unrecognized rather
+// than mis-hinted.
+//
+// One deliberate difference: without a probe id, an ambiguous response needs two
+// HTTP header markers to be treated as HTTP rather than one. That is the
+// conservative direction, and a real HTTP response carries several.
+func ResolverProtocolHint(serviceName, transport string, port int, banner string) string {
+	return normalizeResolverProtocol(
+		protocolHintFor(serviceName, transport, port, banner), banner, "")
 }

--- a/pkg/modules/parse/resolver_protocol_hint_test.go
+++ b/pkg/modules/parse/resolver_protocol_hint_test.go
@@ -1,0 +1,80 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ResolverProtocolHint exists so that anything reasoning about what the rules
+// would match asks the same question the scan pipeline asks. It had no test,
+// which meant the drift it was created to prevent was not actually prevented:
+// replacing its body with a constant changed no behavior anyone could observe.
+func TestResolverProtocolHint(t *testing.T) {
+	const httpResponse = "HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\nContent-Type: text/html\r\n\r\n"
+
+	for _, tc := range []struct {
+		name                       string
+		serviceName, transport     string
+		port                       int
+		banner                     string
+		want                       string
+	}{
+		{
+			name:        "https becomes http when the response is HTTP",
+			serviceName: "https", transport: "tcp", port: 443, banner: httpResponse,
+			want: "http",
+		},
+		{
+			name:        "https stays https when the response is not HTTP",
+			serviceName: "https", transport: "tcp", port: 443, banner: "\x16\x03\x01\x00\xa5\x01",
+			want: "https",
+		},
+		{
+			name:        "a named service is kept",
+			serviceName: "ssh", transport: "tcp", port: 22, banner: "SSH-2.0-OpenSSH_9.6p1\r\n",
+			want: "ssh",
+		},
+		{
+			name:        "the transport says nothing, so the banner decides",
+			serviceName: "", transport: "tcp", port: 8080, banner: httpResponse,
+			want: "http",
+		},
+		{
+			name:        "udp is a transport, not a protocol",
+			serviceName: "udp", transport: "udp", port: 161, banner: "irrelevant",
+			want: "snmp",
+		},
+		{
+			name:        "nothing recognizable leaves an empty hint, which tries every rule",
+			serviceName: "", transport: "tcp", port: 65000, banner: "\x00\x01\x02\x03",
+			want: "",
+		},
+		{
+			name:        "a service name no rule keys on is passed through unchanged",
+			serviceName: "rabbitmq", transport: "tcp", port: 5672, banner: "AMQP\x00\x00\x09\x01",
+			want: "rabbitmq",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want,
+				ResolverProtocolHint(tc.serviceName, tc.transport, tc.port, tc.banner))
+		})
+	}
+}
+
+// The exported wrapper and the chain the pipeline runs must agree, or the
+// report describes a scanner nobody runs. Asserting it here rather than
+// trusting that both call the same helper is the point: they took different
+// arguments once already.
+func TestResolverProtocolHint_AgreesWithThePipelineChain(t *testing.T) {
+	const banner = "HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\nContent-Type: text/html\r\n\r\n"
+
+	for _, serviceName := range []string{"https", "http", "", "tcp", "rabbitmq"} {
+		pipeline := normalizeResolverProtocol(
+			protocolHintFor(serviceName, "tcp", 443, banner), banner, "")
+
+		require.Equal(t, pipeline, ResolverProtocolHint(serviceName, "tcp", 443, banner),
+			"service %q", serviceName)
+	}
+}

--- a/pkg/modules/scan/mndp_probe.go
+++ b/pkg/modules/scan/mndp_probe.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/stringutil"
 )
 
 const (
@@ -305,20 +306,14 @@ func parseMNDPAnnouncement(packet []byte) MNDPNeighborInfo {
 	return info
 }
 
-// sanitizeMNDPText strips control characters so a hostile or corrupt
-// announcement cannot inject terminal escapes into a report, and bounds what a
-// device can claim.
+// sanitizeMNDPText makes an announcement field safe to report.
+//
+// The announcement is whatever the device chose to broadcast. The shared
+// implementation removes what a control-character check misses -- C1,
+// bidirectional overrides, zero-width characters -- and bounds by runes, so a
+// device cannot have its name cut into invalid UTF-8.
 func sanitizeMNDPText(value []byte) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return -1
-		}
-		return r
-	}, strings.TrimSpace(string(value)))
-	if len(cleaned) > 128 {
-		cleaned = cleaned[:128]
-	}
-	return cleaned
+	return stringutil.SanitizeUntrusted(string(value), 128)
 }
 
 func init() {

--- a/pkg/modules/scan/mndp_probe_test.go
+++ b/pkg/modules/scan/mndp_probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,8 +97,14 @@ func TestParseMNDPAnnouncement_TruncatedInputIsRejectedWithoutPanicking(t *testi
 
 // A hostile or corrupt announcement must not carry escapes into a report.
 func TestSanitizeMNDPText(t *testing.T) {
-	require.Equal(t, "AB[31mC", sanitizeMNDPText([]byte("AB\x1b[31mC")))
-	require.Len(t, sanitizeMNDPText(make([]byte, 400)), 0, "control bytes are stripped entirely")
+	// The unsafe character becomes a space rather than vanishing: deleting it
+	// would let its neighbors join into a token the device never sent.
+	require.Equal(t, "AB [31mC", sanitizeMNDPText([]byte("AB\x1b[31mC")))
+	require.Len(t, sanitizeMNDPText(make([]byte, 400)), 0, "control bytes leave nothing behind")
+	require.Equal(t, "ab cd", sanitizeMNDPText([]byte("ab\u200bcd")),
+		"a zero-width character separates rather than joining")
+	require.Equal(t, 128, len([]rune(sanitizeMNDPText([]byte(strings.Repeat("配", 400))))),
+		"the bound counts runes, so a name cannot be cut into invalid UTF-8")
 }
 
 // The request reaches the whole segment, so devices nobody asked to scan will

--- a/pkg/modules/scan/ssdp_probe.go
+++ b/pkg/modules/scan/ssdp_probe.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cyprob/cyprob/pkg/engine"
 	"github.com/cyprob/cyprob/pkg/modules/discovery"
+	"github.com/cyprob/cyprob/pkg/stringutil"
 )
 
 const (
@@ -446,19 +447,14 @@ func ssdpLocationBelongsToTarget(location, target string) bool {
 	return strings.EqualFold(strings.Trim(host, "[]"), target)
 }
 
-// sanitizeSSDPValue strips control characters so a hostile reply cannot inject
-// terminal escapes into a report, and bounds the length a device can claim.
+// sanitizeSSDPValue makes a value a device stated about itself safe to report.
+//
+// A device description is attacker-controlled text. The shared implementation
+// removes what a control-character check misses -- C1, bidirectional overrides,
+// zero-width characters -- and bounds by runes rather than bytes, so a long
+// value cannot be cut into invalid UTF-8.
 func sanitizeSSDPValue(value string) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return -1
-		}
-		return r
-	}, strings.TrimSpace(value))
-	if len(cleaned) > 256 {
-		cleaned = cleaned[:256]
-	}
-	return cleaned
+	return stringutil.SanitizeUntrusted(value, 256)
 }
 
 func init() {

--- a/pkg/modules/scan/ssdp_probe_test.go
+++ b/pkg/modules/scan/ssdp_probe_test.go
@@ -59,10 +59,16 @@ func TestApplySSDPDescription_FirstValueWins(t *testing.T) {
 }
 
 func TestSanitizeSSDPValue(t *testing.T) {
-	require.Equal(t, "AB[31mC", sanitizeSSDPValue("AB\x1b[31mC"),
+	// The unsafe character becomes a space rather than vanishing: deleting it
+	// would let its neighbors join into a token the device never sent.
+	require.Equal(t, "AB [31mC", sanitizeSSDPValue("AB\x1b[31mC"),
 		"a hostile reply must not carry escapes into a report")
+	require.Equal(t, "ngi nx", sanitizeSSDPValue("ngi\u200bnx"),
+		"a zero-width character separates rather than joining")
 	require.Len(t, sanitizeSSDPValue(strings.Repeat("x", 500)), 256,
 		"a device does not get to claim an unbounded name")
+	require.Equal(t, 256, len([]rune(sanitizeSSDPValue(strings.Repeat("配", 500)))),
+		"the bound counts runes, so a name cannot be cut into invalid UTF-8")
 }
 
 // A device must not be able to point the scanner at a host of its choosing.

--- a/pkg/stringutil/sanitize.go
+++ b/pkg/stringutil/sanitize.go
@@ -1,0 +1,50 @@
+package stringutil
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// SanitizeUntrusted makes text a scanned host chose to send safe to put in a
+// report or on an operator's terminal, and bounds how much of it a host can
+// claim.
+//
+// Anything not printable becomes a space rather than disappearing, so two
+// tokens separated only by a stripped character do not run together into a
+// third thing that was never sent. Runs of whitespace then collapse to one.
+//
+// unicode.IsPrint is an allowlist, which is what makes this safe to reason
+// about: it excludes C0, DEL, the C1 block (U+0080-U+009F, whose members are
+// single-byte equivalents of escape sequences that several terminals still
+// act on), and the whole Cf category -- which is where the bidirectional
+// overrides live (U+202E and friends, able to reverse how a line reads) along
+// with the zero-width characters (U+200B, U+FEFF, the soft hyphen). A denylist
+// of the control characters someone thought of at the time misses all three of
+// those groups.
+//
+// The limit counts runes, not bytes: cutting a multi-byte character in half
+// produces invalid UTF-8, which then travels wherever the report goes.
+//
+// Order matters and is deliberate: unsafe characters are removed BEFORE the
+// text is cut, so a truncation can never leave the front half of an escape
+// sequence behind.
+func SanitizeUntrusted(value string, maxRunes int) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == utf8.RuneError || !unicode.IsPrint(r) {
+			return ' '
+		}
+		return r
+	}, value)
+
+	cleaned = strings.TrimSpace(strings.Join(strings.Fields(cleaned), " "))
+	if maxRunes <= 0 {
+		return cleaned
+	}
+
+	runes := []rune(cleaned)
+	if len(runes) <= maxRunes {
+		return cleaned
+	}
+	return strings.TrimSpace(string(runes[:maxRunes]))
+}

--- a/pkg/stringutil/sanitize_test.go
+++ b/pkg/stringutil/sanitize_test.go
@@ -1,0 +1,80 @@
+package stringutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Each of these classes reaches a terminal or a report when only the obvious
+// control characters are removed, which is what a hand-written denylist does.
+// They are written as escapes on purpose: several are invisible in an editor,
+// which is the whole reason they are worth removing.
+func TestSanitizeUntrusted_RemovesEveryNonPrintableClass(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		unsafe rune
+	}{
+		{"C0 escape", '\x1b'},
+		{"DEL", '\x7f'},
+		{"C1 CSI, a single-byte escape introducer", '\u009b'},
+		{"C1 OSC", '\u009d'},
+		{"C1 NEL", '\u0085'},
+		{"bidi override, reverses how a line reads", '\u202e'},
+		{"zero-width space", '\u200b'},
+		{"zero-width joiner", '\u200d'},
+		{"byte order mark", '\ufeff'},
+		{"soft hyphen", '\u00ad'},
+		{"line separator", '\u2028'},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeUntrusted("AB"+string(tc.unsafe)+"C", 0)
+
+			// What has to go is the character itself. Anything it introduced is
+			// ordinary text once the introducer is gone -- an escape sequence
+			// without its ESC is just the letters that followed it.
+			require.NotContains(t, got, string(tc.unsafe),
+				"%U reached the output", tc.unsafe)
+			require.Equal(t, "AB C", got, "and it leaves a separator behind")
+			require.True(t, utf8.ValidString(got))
+		})
+	}
+}
+
+// A removed character must not let its neighbors join into a token nobody
+// sent: "ngi<zero-width>nx" is not the word nginx, and a rule written from it
+// would never match.
+func TestSanitizeUntrusted_DoesNotFuseTokensAcrossARemovedCharacter(t *testing.T) {
+	require.Equal(t, "ngi nx", SanitizeUntrusted("ngi\u200bnx", 0))
+}
+
+// Cutting by bytes splits a multi-byte character and produces invalid UTF-8,
+// which then travels wherever the report goes.
+func TestSanitizeUntrusted_BoundsByRunesAndStaysValidUTF8(t *testing.T) {
+	got := SanitizeUntrusted(strings.Repeat("配", 200), 120)
+
+	require.True(t, utf8.ValidString(got), "truncation must not split a character")
+	require.Equal(t, 120, utf8.RuneCountInString(got), "the limit counts runes, not bytes")
+	require.Less(t, len(got), 200*3, "and it did truncate")
+}
+
+// Unsafe characters go before the cut, so a truncation cannot leave the front
+// half of an escape sequence behind.
+func TestSanitizeUntrusted_StripsBeforeTruncating(t *testing.T) {
+	got := SanitizeUntrusted("\x1b[31m"+strings.Repeat("A", 200), 10)
+
+	require.NotContains(t, got, "\x1b")
+	require.LessOrEqual(t, utf8.RuneCountInString(got), 10)
+}
+
+func TestSanitizeUntrusted_CollapsesWhitespaceAndTrims(t *testing.T) {
+	require.Equal(t, "a b c", SanitizeUntrusted("  a\t\tb\n\n c  ", 0))
+	require.Empty(t, SanitizeUntrusted(strings.Repeat("\x00", 40), 0))
+}
+
+func TestSanitizeUntrusted_ZeroLimitDoesNotTruncate(t *testing.T) {
+	long := strings.Repeat("A", 500)
+	require.Equal(t, long, SanitizeUntrusted(long, 0))
+}


### PR DESCRIPTION
## Why

Fingerprint rules have been written from intuition about what an estate contains. The banners a scan already captured say it outright — and most of them are currently ignored.

Measured on the lab corpus, **148 real banners: 96 unrecognized (65%)**. Among them four IBM storage models sitting in plain text in their own management pages, an SSH implementation on nine hosts, and `Microsoft-HTTPAPI/2.0` on eight — none matched by any rule.

The report is evidence for which rules are worth writing, not a guess at them.

## What

```bash
cyprob scan 10.0.0.0/24 -o json > estate.json
cyprob fingerprint gaps estate.json --stub
```

Reads scan results already on disk, runs each captured banner through the existing rule database **the way the scan pipeline does**, and reports what nothing recognized — grouped by the line a rule would anchor on, ranked by frequency, naming a host where it can be confirmed.

```
148 services with a banner, 96 unrecognized (65%)

  16x  [server]  SVC GUI
       seen at: 10.20.30.14:80, 10.20.30.10:443, 10.20.30.15:8443

   9x  [banner]  SSH-2.0-mpSSH_0.2.1
       seen at: 10.20.30.49:22, 10.20.30.56:22, 10.20.30.45:22

   6x  [title]  - Log in - IBM FlashSystem
       seen at: 10.20.30.2:8443, 10.20.30.2:443, 10.20.30.2:80
       varying: 5000, 5300, LS5030FLASH, LS_FS5300, Storage
```

**It reads local files and prints a report.** It opens no network connection and sends nothing anywhere.

Flags: `--stub` prints a starting rule, `--min-count` hides rare signatures, `--json` emits the report for a machine.

## Design notes worth reviewing

**A banner offering two anchors is reported under both.** An IBM array names itself in its `Server` header *and* its page title; which one a rule should use is a judgement the tool cannot make. Per-signature counts therefore overlap, and the report says so rather than quietly double-counting.

**`--stub` leaves vendor and product as `TODO`.** They cannot be derived from a string nothing recognizes, and guessing them is exactly the failure this exists to avoid. The stub carries the reminder that a device's vendor is not its software's vendor — the same confusion that has an nginx rule labelling devices `F5 Networks`.

**A title stub warns about the site's own hostname.** The captured signature above is `LS_V3700 - Log in - IBM Storwize V3700`; `LS_V3700` is the operator's naming. Left in, the rule matches one customer's device and nobody else's.

**Signatures are sanitized and bounded.** A banner is text a scanned host chose to send and it reaches an operator's terminal, so control characters are stripped — same treatment the probes already apply. Pinned by a test.

## Verified

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` clean on a worktree checked out at this commit alone.
- Run end-to-end against a live IBM Storwize V3700: the tool surfaces both anchors from real scanner output.
- 10 tests, including the sanitization and truncation bounds, the frequency ranking, and that an already-recognized banner is never reported as a gap.

## Scope

Independent of #228. This adds a read-only reporting command and changes no existing behaviour.

The rules this report argues for are not in this PR.

