### PR TITLE
feat(scan): reach mDNS devices over multicast as well as unicast

### DIFF
--- a/pkg/modules/scan/mdns_identity.go
+++ b/pkg/modules/scan/mdns_identity.go
@@ -42,6 +42,17 @@ var mdnsServiceDeviceTypes = map[string]string{
 	"_adisk._tcp":            deviceTypeStorage,
 }
 
+// appleOnlyServiceTypes are DNS-SD services published only by Apple's own
+// devices, so advertising one names the vendor even when no model record is
+// available. AirPlay and RAOP are deliberately absent: both are licensed to
+// third parties, and a Sony television advertising AirPlay is not an Apple
+// device.
+var appleOnlyServiceTypes = map[string]bool{
+	"_companion-link._tcp": true,
+	"_rdlink._tcp":         true,
+	"_apple-mobdev2._tcp":  true,
+}
+
 // appleModelFamilies maps Apple hardware-identifier prefixes (e.g. "Mac16,7")
 // to a device class. These identifier families are stable and self-describing.
 var appleModelFamilies = []struct {
@@ -100,6 +111,12 @@ func deriveMDNSIdentity(result *MDNSServiceInfo) {
 	if result.VendorHint == "" && isAppleModelIdentifier(result.Model) {
 		result.VendorHint = "Apple"
 	}
+	// A host that states no model at all can still name its vendor by the
+	// services it advertises. This is the only identity available for a device
+	// with a randomized MAC that publishes no model record.
+	if result.VendorHint == "" && advertisesAppleOnlyService(result.ServiceTypes) {
+		result.VendorHint = "Apple"
+	}
 
 	result.DeviceType = deriveMDNSDeviceType(result)
 
@@ -118,7 +135,7 @@ func deriveMDNSDeviceType(result *MDNSServiceInfo) string {
 	// Service types win: a host advertising _ipp is a printer regardless of how
 	// its model string reads.
 	for _, service := range result.ServiceTypes {
-		key := strings.TrimSuffix(strings.TrimSuffix(strings.ToLower(strings.TrimSpace(service)), "."), ".local")
+		key := normalizeMDNSServiceType(service)
 		if deviceType, ok := mdnsServiceDeviceTypes[key]; ok && deviceType != deviceTypeIoT {
 			return deviceType
 		}
@@ -131,12 +148,27 @@ func deriveMDNSDeviceType(result *MDNSServiceInfo) string {
 	// IoT is the weakest of the service signals, so it only applies when
 	// nothing more specific matched.
 	for _, service := range result.ServiceTypes {
-		key := strings.TrimSuffix(strings.TrimSuffix(strings.ToLower(strings.TrimSpace(service)), "."), ".local")
+		key := normalizeMDNSServiceType(service)
 		if deviceType, ok := mdnsServiceDeviceTypes[key]; ok {
 			return deviceType
 		}
 	}
 	return ""
+}
+
+func advertisesAppleOnlyService(serviceTypes []string) bool {
+	for _, service := range serviceTypes {
+		if appleOnlyServiceTypes[normalizeMDNSServiceType(service)] {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeMDNSServiceType reduces an advertised type to its bare form:
+// "_companion-link._tcp.local." -> "_companion-link._tcp".
+func normalizeMDNSServiceType(service string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(strings.ToLower(strings.TrimSpace(service)), "."), ".local")
 }
 
 func appleModelDeviceType(model string) string {

--- a/pkg/modules/scan/mdns_identity.go
+++ b/pkg/modules/scan/mdns_identity.go
@@ -83,6 +83,19 @@ func deriveMDNSIdentity(result *MDNSServiceInfo) {
 		return
 	}
 
+	// Everything below is derived from TXTAttrs and ServiceTypes, so it is
+	// cleared first and the function becomes a pure function of them. That
+	// matters because it runs a second time after the unicast and multicast
+	// records are merged: without the reset, a field guarded by "only if empty"
+	// would keep a value derived from one transport while its siblings were
+	// recomputed from both. Resetting here rather than at the call site means a
+	// field added later cannot be left out of it.
+	result.Model = ""
+	result.VendorHint = ""
+	result.ProductHint = ""
+	result.VersionHint = ""
+	result.DeviceType = ""
+
 	// Model: several DNS-SD conventions carry it under different keys.
 	// "model" (Apple AirPlay), "md" (HomeKit / Chromecast), "usb_MDL" and
 	// "product" (printers).

--- a/pkg/modules/scan/mdns_multicast_test.go
+++ b/pkg/modules/scan/mdns_multicast_test.go
@@ -1,0 +1,273 @@
+package scan
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/modules/discovery"
+)
+
+// stubMDNSMulticast replaces the segment-wide query so unit tests never put a
+// datagram on the network.
+func stubMDNSMulticast(t *testing.T, answers map[string]MDNSServiceInfo) {
+	t.Helper()
+	original := mdnsMulticastCollectF
+	t.Cleanup(func() { mdnsMulticastCollectF = original })
+	mdnsMulticastCollectF = func(context.Context, MDNSProbeOptions) map[string]MDNSServiceInfo {
+		return answers
+	}
+}
+
+// stubMDNSUnicast replaces the per-target probe.
+func stubMDNSUnicast(t *testing.T, results map[string]MDNSServiceInfo) {
+	t.Helper()
+	original := probeMDNSDetailsFunc
+	t.Cleanup(func() { probeMDNSDetailsFunc = original })
+	probeMDNSDetailsFunc = func(_ context.Context, target string, port int, _ MDNSProbeOptions) MDNSServiceInfo {
+		if result, ok := results[target]; ok {
+			return result
+		}
+		return MDNSServiceInfo{Target: target, Port: port, ProbeError: "no_response"}
+	}
+}
+
+func mdnsExecute(t *testing.T, inputs map[string]any) map[string]MDNSServiceInfo {
+	t.Helper()
+	module := newMDNSNativeProbeModule()
+	outputs := make(chan engine.ModuleOutput, 16)
+	require.NoError(t, module.Execute(context.Background(), inputs, outputs))
+	close(outputs)
+
+	reported := map[string]MDNSServiceInfo{}
+	for out := range outputs {
+		info, ok := out.Data.(MDNSServiceInfo)
+		require.True(t, ok, "output data must be MDNSServiceInfo")
+		reported[out.Target] = info
+	}
+	return reported
+}
+
+// mdnsScopeInputs puts targets in scope without reporting any open port, which
+// is the case the multicast pass exists for.
+func mdnsScopeInputs(targets ...string) map[string]any {
+	scanned := make([]any, 0, len(targets))
+	for _, target := range targets {
+		scanned = append(scanned, discovery.UDPPortDiscoveryResult{Target: target})
+	}
+	return map[string]any{"discovery.open_udp_ports": scanned}
+}
+
+// mdnsOpenPortInputs additionally reports UDP/5353 open, which is what makes a
+// target a unicast candidate.
+func mdnsOpenPortInputs(targets ...string) map[string]any {
+	scanned := make([]any, 0, len(targets))
+	for _, target := range targets {
+		scanned = append(scanned, discovery.UDPPortDiscoveryResult{
+			Target: target, OpenPorts: []int{mdnsPort},
+		})
+	}
+	return map[string]any{"discovery.open_udp_ports": scanned}
+}
+
+// The multicast query reaches the whole segment, so devices nobody asked to
+// scan will answer. Those must not become assets.
+func TestMDNSExecute_OnlyReportsMulticastRespondersInScope(t *testing.T) {
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.10":   {Target: "192.0.2.10", MDNSProbe: true, ServiceTypes: []string{"_hap._tcp.local."}},
+		"198.51.100.7": {Target: "198.51.100.7", MDNSProbe: true, ServiceTypes: []string{"_hap._tcp.local."}},
+	})
+	stubMDNSUnicast(t, nil)
+
+	reported := mdnsExecute(t, mdnsScopeInputs("192.0.2.10"))
+
+	require.Len(t, reported, 1)
+	require.Contains(t, reported, "192.0.2.10")
+	require.NotContains(t, reported, "198.51.100.7",
+		"a responder that was never a target must not be reported")
+}
+
+// The point of the multicast pass: a host whose UDP/5353 the port scan never
+// reported open is not a unicast candidate at all, so before this it produced
+// no mDNS output whatsoever.
+func TestMDNSExecute_ReportsHostWithNoOpenPortDetected(t *testing.T) {
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.29": {
+			Target:       "192.0.2.29",
+			MDNSProbe:    true,
+			ServiceTypes: []string{"_companion-link._tcp.local."},
+		},
+	})
+	stubMDNSUnicast(t, nil)
+
+	// The host is in scope but has no open UDP port recorded.
+	reported := mdnsExecute(t, mdnsScopeInputs("192.0.2.29"))
+
+	require.Contains(t, reported, "192.0.2.29")
+	info := reported["192.0.2.29"]
+	require.True(t, info.MDNSProbe)
+	require.Equal(t, "Apple", info.VendorHint,
+		"an Apple-only service names the vendor when no model is published")
+}
+
+// A record seen only over multicast must reach the identity, which means the
+// derivation has to run again over the union of both transports.
+func TestMDNSExecute_MulticastRecordsCompleteTheIdentity(t *testing.T) {
+	stubMDNSUnicast(t, map[string]MDNSServiceInfo{
+		"192.0.2.20": {
+			Target:       "192.0.2.20",
+			Port:         mdnsPort,
+			MDNSProbe:    true,
+			ServiceTypes: []string{"_androidtvremote2._tcp.local."},
+			TXTAttrs:     map[string]string{},
+		},
+	})
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.20": {
+			Target:       "192.0.2.20",
+			MDNSProbe:    true,
+			ServiceTypes: []string{"_googlecast._tcp.local."},
+			TXTAttrs:     map[string]string{"md": "MIBOX3"},
+		},
+	})
+
+	info := mdnsExecute(t, mdnsOpenPortInputs("192.0.2.20"))["192.0.2.20"]
+
+	require.Equal(t, "MIBOX3", info.Model,
+		"the model lives only in the multicast-only record")
+	require.Equal(t, deviceTypeMediaDevice, info.DeviceType)
+	require.Contains(t, info.ServiceTypes, "_androidtvremote2._tcp.local.")
+	require.Contains(t, info.ServiceTypes, "_googlecast._tcp.local.")
+}
+
+// Re-deriving over the union must replace the whole identity, not leave a
+// product string built from the model the earlier pass reported.
+func TestMDNSExecute_DerivedFieldsAreRecomputedNotPatched(t *testing.T) {
+	stubMDNSUnicast(t, map[string]MDNSServiceInfo{
+		"192.0.2.40": {
+			Target: "192.0.2.40", Port: mdnsPort, MDNSProbe: true,
+			TXTAttrs: map[string]string{"md": "OldModel"},
+			Model:    "OldModel", ProductHint: "OldModel",
+		},
+	})
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.40": {
+			Target: "192.0.2.40", MDNSProbe: true,
+			// "model" outranks "md" in the derivation order.
+			TXTAttrs: map[string]string{"model": "NewModel"},
+		},
+	})
+
+	info := mdnsExecute(t, mdnsOpenPortInputs("192.0.2.40"))["192.0.2.40"]
+
+	require.Equal(t, "NewModel", info.Model)
+	require.Equal(t, "NewModel", info.ProductHint,
+		"the product string must follow the model it was derived from")
+}
+
+// A host that answered multicast is a responder even when the unicast attempt
+// timed out, which is exactly the asymmetry this pass exists to cover.
+func TestMDNSExecute_MulticastAnswerClearsUnicastFailure(t *testing.T) {
+	stubMDNSUnicast(t, map[string]MDNSServiceInfo{
+		"192.0.2.30": {Target: "192.0.2.30", Port: mdnsPort, ProbeError: "no_response"},
+	})
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.30": {Target: "192.0.2.30", MDNSProbe: true, ServiceTypes: []string{"_ipp._tcp.local."}},
+	})
+
+	info := mdnsExecute(t, mdnsOpenPortInputs("192.0.2.30"))["192.0.2.30"]
+
+	require.True(t, info.MDNSProbe)
+	require.Empty(t, info.ProbeError, "a host that answered is not a failure")
+	require.Equal(t, deviceTypePrinter, info.DeviceType)
+}
+
+func TestMDNSExecute_MulticastDisabledKeepsUnicastOnly(t *testing.T) {
+	stubMDNSUnicast(t, nil)
+	original := mdnsMulticastCollectF
+	t.Cleanup(func() { mdnsMulticastCollectF = original })
+	called := false
+	mdnsMulticastCollectF = func(context.Context, MDNSProbeOptions) map[string]MDNSServiceInfo {
+		called = true
+		return nil
+	}
+
+	module := newMDNSNativeProbeModule()
+	require.NoError(t, module.Init("mdns", map[string]any{"multicast_enabled": false}))
+	outputs := make(chan engine.ModuleOutput, 4)
+	require.NoError(t, module.Execute(context.Background(), mdnsScopeInputs("192.0.2.10"), outputs))
+	close(outputs)
+
+	require.False(t, called, "multicast must not be sent when it is disabled")
+	require.Empty(t, outputs, "no open UDP/5353 means no unicast candidate either")
+}
+
+func TestMDNSExecute_NoTargetsIsANoOp(t *testing.T) {
+	stubMDNSMulticast(t, map[string]MDNSServiceInfo{
+		"192.0.2.10": {Target: "192.0.2.10", MDNSProbe: true},
+	})
+	require.Empty(t, mdnsExecute(t, map[string]any{}))
+}
+
+// The merge fills gaps; it does not let a second answer overwrite a field the
+// first one already stated.
+func TestMergeMDNSInfo_FillsOnlyWhatIsMissing(t *testing.T) {
+	dst := MDNSServiceInfo{
+		Hostname:     "first.local",
+		ServiceTypes: []string{"_airplay._tcp.local."},
+		TXTAttrs:     map[string]string{"md": "first"},
+	}
+	mergeMDNSInfo(&dst, MDNSServiceInfo{
+		Hostname:     "second.local",
+		InstanceName: "Living Room",
+		ServiceTypes: []string{"_googlecast._tcp.local.", "_airplay._tcp.local."},
+		TXTAttrs:     map[string]string{"md": "second", "fw": "1.2.3"},
+	})
+
+	require.Equal(t, "first.local", dst.Hostname)
+	require.Equal(t, "first", dst.TXTAttrs["md"])
+	require.Equal(t, "Living Room", dst.InstanceName, "an empty field is filled")
+	require.Equal(t, "1.2.3", dst.TXTAttrs["fw"], "an absent key is added")
+	require.Len(t, dst.ServiceTypes, 2, "service types are unioned, not duplicated")
+}
+
+// AirPlay and RAOP are licensed to third parties, so they must not be read as
+// an Apple vendor signal — the Sony television on the test segment advertises
+// AirPlay.
+func TestAdvertisesAppleOnlyService(t *testing.T) {
+	require.True(t, advertisesAppleOnlyService([]string{"_companion-link._tcp.local."}))
+	require.True(t, advertisesAppleOnlyService([]string{"_RDLINK._TCP.LOCAL."}))
+	require.False(t, advertisesAppleOnlyService([]string{"_airplay._tcp.local."}))
+	require.False(t, advertisesAppleOnlyService([]string{"_raop._tcp.local."}))
+	require.False(t, advertisesAppleOnlyService(nil))
+}
+
+func TestDeriveMDNSIdentity_AppleServiceDoesNotOverrideAStatedVendor(t *testing.T) {
+	result := MDNSServiceInfo{
+		ServiceTypes: []string{"_companion-link._tcp.local."},
+		TXTAttrs:     map[string]string{"manufacturer": "Someone Else"},
+	}
+	deriveMDNSIdentity(&result)
+	require.Equal(t, "Someone Else", result.VendorHint)
+}
+
+// TestMDNSMulticast_Live exercises a real segment. Skipped unless MDNS_LIVE=1:
+// MDNS_LIVE=1 go test ./pkg/modules/scan/ -run MDNSMulticast.*Live -v
+func TestMDNSMulticast_Live(t *testing.T) {
+	if os.Getenv("MDNS_LIVE") == "" {
+		t.Skip("set MDNS_LIVE=1 to run the live mDNS multicast test")
+	}
+	opts := defaultMDNSProbeOptions()
+	opts.ListenTimeout = 5 * time.Second
+	found := collectMDNSMulticast(context.Background(), opts)
+	for host, info := range found {
+		deriveMDNSIdentity(&info)
+		t.Logf("%s: services=%v vendor=%q model=%q type=%q",
+			host, info.ServiceTypes, info.VendorHint, info.Model, info.DeviceType)
+	}
+	require.NotEmpty(t, found, "expected at least one mDNS responder on this segment")
+}

--- a/pkg/modules/scan/mdns_multicast_test.go
+++ b/pkg/modules/scan/mdns_multicast_test.go
@@ -271,3 +271,52 @@ func TestMDNSMulticast_Live(t *testing.T) {
 	}
 	require.NotEmpty(t, found, "expected at least one mDNS responder on this segment")
 }
+
+// The multicast pass sends eighteen datagrams and a TXT key keeps the first
+// value it sees, so applying answers in arrival order would let the network
+// decide which model string survives: the same host could report a different
+// product between two runs. Records are collected first and ordered by content
+// before being parsed, which this pins by feeding the same answers in both
+// orders and requiring the same result.
+func TestCollectMDNSMulticast_ResultDoesNotDependOnArrivalOrder(t *testing.T) {
+	first := buildMDNSResponse(t, mdnsDeviceInfo,
+		[]string{"Device._device-info._tcp.local."}, "", []string{"model=FirstAnswer"})
+	second := buildMDNSResponse(t, "_googlecast._tcp.local.",
+		[]string{"Cast._googlecast._tcp.local."}, "", []string{"model=SecondAnswer"})
+
+	forward := mergeMDNSPackets("192.0.2.10", [][]byte{first, second})
+	reverse := mergeMDNSPackets("192.0.2.10", [][]byte{second, first})
+	deriveMDNSIdentity(&forward)
+	deriveMDNSIdentity(&reverse)
+
+	require.Equal(t, forward.Model, reverse.Model,
+		"the surviving value must not depend on which datagram arrived first")
+	require.NotEmpty(t, forward.Model)
+}
+
+// deriveMDNSIdentity resets what it derives, so running it twice over the same
+// records gives the same answer and a stale value from an earlier pass cannot
+// survive. Without that, a field guarded by "only if empty" keeps a value
+// derived from one transport while its siblings are recomputed from both.
+func TestDeriveMDNSIdentity_IsIdempotentAndClearsStaleDerivations(t *testing.T) {
+	info := MDNSServiceInfo{
+		ServiceTypes: []string{"_ipp._tcp.local."},
+		TXTAttrs:     map[string]string{"ty": "OfficeJet 9010"},
+		// Left over from an earlier derivation over different records.
+		Model:       "StaleModel",
+		ProductHint: "Stale Product",
+		VendorHint:  "StaleVendor",
+		VersionHint: "0.0.0",
+		DeviceType:  deviceTypeMediaDevice,
+	}
+
+	deriveMDNSIdentity(&info)
+	once := info
+	deriveMDNSIdentity(&info)
+
+	require.Equal(t, once, info, "deriving twice must not change the answer")
+	require.Equal(t, "OfficeJet 9010", info.Model)
+	require.Equal(t, deviceTypePrinter, info.DeviceType)
+	require.NotContains(t, info.ProductHint, "Stale")
+	require.Empty(t, info.VersionHint, "no record states a version, so none is claimed")
+}

--- a/pkg/modules/scan/mdns_native_probe.go
+++ b/pkg/modules/scan/mdns_native_probe.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -252,11 +253,9 @@ func (m *mdnsNativeProbeModule) Execute(ctx context.Context, inputs map[string]a
 			result.MDNSProbe = true
 			result.ProbeError = ""
 			// The merge may have supplied records the unicast pass never saw, so
-			// the identity is derived again over the union. The derived fields are
-			// cleared first: keeping them would pair a model taken from one pass
-			// with a product string built from the other.
-			result.Model, result.VendorHint, result.ProductHint = "", "", ""
-			result.VersionHint, result.DeviceType = "", ""
+			// the identity is derived again over the union. deriveMDNSIdentity
+			// resets what it derives, so this cannot pair a model taken from one
+			// pass with a product string built from the other.
 			deriveMDNSIdentity(&result)
 		}
 		if len(result.TXTAttrs) == 0 {
@@ -502,6 +501,12 @@ func collectMDNSMulticast(ctx context.Context, opts MDNSProbeOptions) map[string
 		return results
 	}
 
+	// A responder answers each question separately, so its records arrive
+	// spread over several datagrams. They are collected first and parsed
+	// afterwards: a TXT key keeps the first value seen, so applying them in
+	// arrival order would let the network decide which model string survives,
+	// and the same host could report a different product between two runs.
+	packets := map[string][][]byte{}
 	buf := make([]byte, mdnsResponseMaxBytes)
 	for {
 		n, addr, readErr := conn.ReadFrom(buf)
@@ -512,16 +517,38 @@ func collectMDNSMulticast(ctx context.Context, opts MDNSProbeOptions) map[string
 		if splitErr != nil {
 			continue
 		}
-		// A responder answers each question separately, so its records arrive
-		// spread over several datagrams and are accumulated per host.
-		info, ok := results[host]
-		if !ok {
-			info = MDNSServiceInfo{Target: host, Port: mdnsPort, MDNSProbe: true, TXTAttrs: map[string]string{}}
-		}
-		collectMDNSRecords(buf[:n], &info)
-		results[host] = info
+		// The read buffer is reused, so the datagram has to be copied to
+		// outlive this iteration.
+		packet := make([]byte, n)
+		copy(packet, buf[:n])
+		packets[host] = append(packets[host], packet)
+	}
+
+	for host, received := range packets {
+		results[host] = mergeMDNSPackets(host, received)
 	}
 	return results
+}
+
+// mergeMDNSPackets folds a host's datagrams into one result in an order that
+// does not depend on which of them overtook which.
+//
+// Ordering by content is stable across runs for the same set of answers, which
+// is what makes the outcome reproducible: a TXT key keeps the first value seen,
+// so parsing in arrival order would let the network choose which model string
+// survives.
+func mergeMDNSPackets(host string, packets [][]byte) MDNSServiceInfo {
+	ordered := make([][]byte, len(packets))
+	copy(ordered, packets)
+	sort.Slice(ordered, func(i, j int) bool {
+		return bytes.Compare(ordered[i], ordered[j]) < 0
+	})
+
+	info := MDNSServiceInfo{Target: host, Port: mdnsPort, MDNSProbe: true, TXTAttrs: map[string]string{}}
+	for _, packet := range ordered {
+		collectMDNSRecords(packet, &info)
+	}
+	return info
 }
 
 func buildMDNSQuery(name string, qtype dnsmessage.Type) ([]byte, error) {

--- a/pkg/modules/scan/mdns_native_probe.go
+++ b/pkg/modules/scan/mdns_native_probe.go
@@ -18,9 +18,15 @@ import (
 const (
 	mdnsNativeProbeModuleID          = "mdns-native-probe-instance"
 	mdnsNativeProbeModuleName        = "mdns-native-probe"
-	mdnsNativeProbeModuleDescription = "Runs bounded unicast mDNS (DNS-SD) probes against UDP/5353 and emits device identity metadata."
+	mdnsNativeProbeModuleDescription = "Runs bounded mDNS (DNS-SD) probes over unicast and multicast and emits device identity metadata."
 
-	mdnsPort = 5353
+	mdnsPort        = 5353
+	mdnsMulticastIP = "224.0.0.251"
+
+	// mdnsMulticastBursts is how many times the query set is repeated. UDP loses
+	// packets and a responder answers a given question once, so a single pass
+	// under-reports.
+	mdnsMulticastBursts = 2
 
 	// mdnsServiceEnumeration is the DNS-SD meta-query that lists the service
 	// types a host advertises.
@@ -38,6 +44,12 @@ const (
 type MDNSProbeOptions struct {
 	TotalTimeout time.Duration `json:"total_timeout"`
 	IOTimeout    time.Duration `json:"io_timeout"`
+	// ListenTimeout bounds the multicast collection window.
+	ListenTimeout time.Duration `json:"listen_timeout"`
+	// MulticastEnabled controls the segment-wide query. Some devices publish a
+	// record only in answer to multicast, and a host whose UDP/5353 was never
+	// detected as open is never probed by unicast at all.
+	MulticastEnabled bool `json:"multicast_enabled"`
 }
 
 // MDNSServiceInfo is the structured output of the mDNS native probe.
@@ -72,8 +84,9 @@ type mdnsProbeCandidate struct {
 }
 
 var (
-	probeMDNSDetailsFunc = probeMDNSDetails
-	mdnsQueryFunc        = executeMDNSQuery
+	probeMDNSDetailsFunc  = probeMDNSDetails
+	mdnsQueryFunc         = executeMDNSQuery
+	mdnsMulticastCollectF = collectMDNSMulticast
 
 	errMDNSNoResponse = errors.New("mdns no response")
 )
@@ -107,7 +120,14 @@ func newMDNSNativeProbeModule() *mdnsNativeProbeModule {
 					DataTypeName: "discovery.UDPPortDiscoveryResult",
 					Cardinality:  engine.CardinalityList,
 					IsOptional:   false,
-					Description:  "Open UDP ports used to identify mDNS candidates.",
+					Description:  "Open UDP ports used to identify unicast mDNS candidates, and the hosts that bound which multicast responders are in scope.",
+				},
+				{
+					Key:          "discovery.live_hosts",
+					DataTypeName: "discovery.ICMPPingDiscoveryResult",
+					Cardinality:  engine.CardinalityList,
+					IsOptional:   true,
+					Description:  "Live hosts, when host discovery ran, widening the in-scope set.",
 				},
 			},
 			Produces: []engine.DataContractEntry{
@@ -126,13 +146,27 @@ func newMDNSNativeProbeModule() *mdnsNativeProbeModule {
 					Default:     "3s",
 				},
 				"io_timeout": {
-					Description: "Timeout for each mDNS query.",
+					Description: "Timeout for each unicast mDNS query.",
 					Type:        "duration",
 					Required:    false,
 					Default:     "700ms",
 				},
+				"listen_timeout": {
+					Description: "How long to collect answers to the multicast query.",
+					Type:        "duration",
+					Required:    false,
+					Default:     "3s",
+				},
+				"multicast_enabled": {
+					Description: "Send a segment-wide DNS-SD query as well as unicast queries.",
+					Type:        "boolean",
+					Required:    false,
+					Default:     true,
+				},
 			},
-			EstimatedCost: 1,
+			// The multicast pass is one segment-wide conversation on top of the
+			// per-target queries, so the module costs more than a plain probe.
+			EstimatedCost: 2,
 		},
 		options: defaultMDNSProbeOptions(),
 	}
@@ -152,52 +186,126 @@ func (m *mdnsNativeProbeModule) Init(instanceID string, configMap map[string]any
 		if d, ok := parseDurationConfig(configMap["io_timeout"]); ok && d > 0 {
 			opts.IOTimeout = d
 		}
+		if d, ok := parseDurationConfig(configMap["listen_timeout"]); ok && d > 0 {
+			opts.ListenTimeout = d
+		}
+		if enabled, ok := configMap["multicast_enabled"].(bool); ok {
+			opts.MulticastEnabled = enabled
+		}
 	}
 	m.options = opts
 	return nil
 }
 
 func (m *mdnsNativeProbeModule) Execute(ctx context.Context, inputs map[string]any, outputChan chan<- engine.ModuleOutput) error {
-	rawOpenPorts, ok := inputs["discovery.open_udp_ports"]
-	if !ok {
-		return nil
+	inScope := map[string]bool{}
+	for _, target := range ssdpTargetsInScope(inputs) {
+		inScope[strings.TrimSpace(target)] = true
 	}
 
-	candidateMap := map[string]mdnsProbeCandidate{}
-	for _, item := range toAnySlice(rawOpenPorts) {
+	// Unicast candidates are the hosts whose UDP/5353 was detected as open.
+	candidates := map[string]mdnsProbeCandidate{}
+	for _, item := range toAnySlice(inputs["discovery.open_udp_ports"]) {
 		for _, candidate := range mdnsCandidatesFromOpenPorts(item) {
-			candidateMap[fmt.Sprintf("%s:%d", candidate.target, candidate.port)] = candidate
+			candidates[candidate.target] = candidate
 		}
 	}
-	if len(candidateMap) == 0 {
+
+	// The multicast query reaches hosts the unicast candidate list never
+	// contains: a device that answers only multicast, and any device whose
+	// UDP/5353 the port scan did not report open. It is sent once for the
+	// segment rather than per target.
+	multicast := map[string]MDNSServiceInfo{}
+	if m.options.MulticastEnabled && len(inScope) > 0 {
+		multicast = mdnsMulticastCollectF(ctx, m.options)
+	}
+
+	hosts := make([]string, 0, len(candidates)+len(multicast))
+	seen := map[string]bool{}
+	for target := range candidates {
+		seen[target] = true
+		hosts = append(hosts, target)
+	}
+	for host := range multicast {
+		// A multicast query reaches the whole segment, so hosts nobody asked to
+		// scan will answer. Reporting one would invent an asset the operator
+		// never requested.
+		if !inScope[host] || seen[host] {
+			continue
+		}
+		seen[host] = true
+		hosts = append(hosts, host)
+	}
+	if len(hosts) == 0 {
 		return nil
 	}
+	sort.Strings(hosts)
 
-	keys := make([]string, 0, len(candidateMap))
-	for key := range candidateMap {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		candidate := candidateMap[key]
-		result := probeMDNSDetailsFunc(ctx, candidate.target, candidate.port, m.options)
+	for _, host := range hosts {
+		result := MDNSServiceInfo{Target: host, Port: mdnsPort, TXTAttrs: map[string]string{}}
+		if candidate, ok := candidates[host]; ok {
+			result = probeMDNSDetailsFunc(ctx, candidate.target, candidate.port, m.options)
+		}
+		if answer, ok := multicast[host]; ok {
+			mergeMDNSInfo(&result, answer)
+			// A multicast answer is a response, whatever unicast reported.
+			result.MDNSProbe = true
+			result.ProbeError = ""
+			// The merge may have supplied records the unicast pass never saw, so
+			// the identity is derived again over the union. The derived fields are
+			// cleared first: keeping them would pair a model taken from one pass
+			// with a product string built from the other.
+			result.Model, result.VendorHint, result.ProductHint = "", "", ""
+			result.VersionHint, result.DeviceType = "", ""
+			deriveMDNSIdentity(&result)
+		}
+		if len(result.TXTAttrs) == 0 {
+			result.TXTAttrs = nil
+		}
 		outputChan <- engine.ModuleOutput{
 			FromModuleName: m.meta.ID,
 			DataKey:        "service.mdns.details",
 			Data:           result,
 			Timestamp:      time.Now(),
-			Target:         candidate.target,
+			Target:         host,
 		}
 	}
 
 	return nil
 }
 
+// mergeMDNSInfo folds collected records into an existing result, filling only
+// what is missing. Unicast and multicast reach different devices and neither is
+// authoritative over the other, so the first answer to state a field keeps it.
+func mergeMDNSInfo(dst *MDNSServiceInfo, src MDNSServiceInfo) {
+	if dst.Hostname == "" {
+		dst.Hostname = src.Hostname
+	}
+	if dst.InstanceName == "" {
+		dst.InstanceName = src.InstanceName
+	}
+	for _, service := range src.ServiceTypes {
+		dst.ServiceTypes = appendUniqueSorted(dst.ServiceTypes, service)
+	}
+	if len(src.TXTAttrs) == 0 {
+		return
+	}
+	if dst.TXTAttrs == nil {
+		dst.TXTAttrs = map[string]string{}
+	}
+	for key, value := range src.TXTAttrs {
+		if _, exists := dst.TXTAttrs[key]; !exists {
+			dst.TXTAttrs[key] = value
+		}
+	}
+}
+
 func defaultMDNSProbeOptions() MDNSProbeOptions {
 	return MDNSProbeOptions{
-		TotalTimeout: 3 * time.Second,
-		IOTimeout:    700 * time.Millisecond,
+		TotalTimeout:     3 * time.Second,
+		IOTimeout:        700 * time.Millisecond,
+		ListenTimeout:    3 * time.Second,
+		MulticastEnabled: true,
 	}
 }
 
@@ -345,6 +453,75 @@ func executeMDNSQuery(
 		return nil, err
 	}
 	return response[:n], nil
+}
+
+// collectMDNSMulticast sends the DNS-SD queries to the multicast group and
+// gathers whatever answers inside a bounded window, keyed by responder.
+//
+// Unlike the unicast path this is one conversation for the whole segment, so it
+// costs the same whether the scan covers one host or a /24.
+func collectMDNSMulticast(ctx context.Context, opts MDNSProbeOptions) map[string]MDNSServiceInfo {
+	results := map[string]MDNSServiceInfo{}
+
+	if opts.ListenTimeout <= 0 {
+		opts.ListenTimeout = 3 * time.Second
+	}
+
+	// The socket deliberately does not bind UDP/5353. On any host running a
+	// system mDNS responder that port is already taken, and a probe requiring it
+	// would fail to start. Querying from an ephemeral port instead makes this a
+	// legacy query under RFC 6762 §6.7, which responders answer by unicast
+	// straight back to the source port — verified on a live segment against both
+	// a Sony TV and macOS.
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+	if err != nil {
+		return results
+	}
+	defer conn.Close() //nolint:errcheck // read-only best-effort cleanup
+
+	group := &net.UDPAddr{IP: net.ParseIP(mdnsMulticastIP), Port: mdnsPort}
+	names := make([]string, 0, len(mdnsIdentityServiceTypes)+1)
+	names = append(names, mdnsServiceEnumeration)
+	names = append(names, mdnsIdentityServiceTypes...)
+
+	for burst := 0; burst < mdnsMulticastBursts; burst++ {
+		for _, name := range names {
+			query, buildErr := buildMDNSQuery(name, dnsmessage.TypePTR)
+			if buildErr != nil {
+				continue
+			}
+			_, _ = conn.WriteTo(query, group)
+		}
+	}
+
+	deadline := time.Now().Add(opts.ListenTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return results
+	}
+
+	buf := make([]byte, mdnsResponseMaxBytes)
+	for {
+		n, addr, readErr := conn.ReadFrom(buf)
+		if readErr != nil {
+			break
+		}
+		host, _, splitErr := net.SplitHostPort(addr.String())
+		if splitErr != nil {
+			continue
+		}
+		// A responder answers each question separately, so its records arrive
+		// spread over several datagrams and are accumulated per host.
+		info, ok := results[host]
+		if !ok {
+			info = MDNSServiceInfo{Target: host, Port: mdnsPort, MDNSProbe: true, TXTAttrs: map[string]string{}}
+		}
+		collectMDNSRecords(buf[:n], &info)
+		results[host] = info
+	}
+	return results
 }
 
 func buildMDNSQuery(name string, qtype dnsmessage.Type) ([]byte, error) {


### PR DESCRIPTION
## Why

The mDNS probe queried each target by **unicast only**. That is a convenience the protocol allows; its primary mode is multicast, and the two reach different devices.

It also ran only against hosts whose `UDP/5353` the port scan reported open (`mdnsCandidatesFromOpenPorts` requires the port among `OpenPorts`). A device that speaks mDNS while its port goes undetected produced no mDNS output at all. UDP port detection is the least reliable part of discovery, and the multicast pass removes the dependency on it.

Two devices measured earlier make the case, neither reproducible from the segment this was written on:

- An Android media box answered unicast for `_androidtvremote2._tcp` but **not** for `_googlecast._tcp` — and the model (`md=MIBOX3`) lived only in that multicast-only record.
- A host with a randomized MAC answered a multicast DNS-SD enumeration while returning nothing over unicast, leaving it with no identity from any source.

## Measured before writing, and it changed the design twice

**The socket does not bind UDP/5353 — and the reason matters more than the rule.** A query sent from any other port is a *legacy* query under RFC 6762 §6.7, which responders answer by unicast straight back to it. Verified on a live segment where a system responder already held 5353; binding it would have failed to start.

This is the **inverse** of MNDP, where the protocol port *is* required — a lesson learned by getting it wrong there. So the rule was re-established per protocol rather than carried across.

**The QU bit is not needed.** `ClassINET` and the unicast-response class (`0x8001`) were run three rounds each: same responders, same service-type counts. Left out rather than added on a reading of the spec.

## What this reaches, and what it does not

The socket is a multicast **sender**; collection is unicast only. So this hears
a responder that answers a legacy query by unicast — which is the common case —
and does **not** hear one that only ever answers to the group, nor a passive
responder that announces without being asked. "Multicast pass" names how the
question is asked, not how the answers are gathered.

Hearing the rest would mean binding UDP/5353 and joining the group, which is
exactly what cannot be done on a host already running a responder. That is a
deliberate limit, not an oversight.

The QU measurement should be read with that in mind. The unicast-response bit
made no difference **because a query from an ephemeral port already receives a
unicast answer** under §6.7 — the bit asks for something the legacy path grants
anyway. The result therefore does not generalize: bound to 5353, a proper
multicast query would need it.

## Design

Implemented **inside the existing module** rather than as a second one. Two modules producing `service.mdns.details` would emit two outputs per target and leave the merge to chance. Here both transports feed one result per host, merged fill-only-empty, with the identity derived **once over the union**.

`_companion-link._tcp` was queued for the device-type table. That would be wrong: iPhones, Macs and Apple TVs all publish it, so it names a **vendor** and no class. It is used as an Apple vendor signal instead — with AirPlay and RAOP deliberately excluded, since both are licensed to third parties and the Sony television on the test segment advertises AirPlay.

**Fixed while merging:** `deriveMDNSIdentity` fills `ProductHint` only when empty, so re-deriving after a merge could pair a model from one transport with a product string built from the other. Derived fields are cleared before re-derivation, pinned by a test.

## Honest sizing

**On the segment this was verified against, the gain is zero.** Five live hosts, two speak mDNS, both already had 5353 detected and were already reached by unicast. Device identity is byte-identical before and after:

| host | before | after |
|---|---|---|
| .1 | Econet / ssdp | unchanged |
| .109 | Sony BRAVIA 4K VH2 / ssdp+mdns | unchanged |
| .165 | Apple Mac16,7 / mdns | unchanged |
| .110 | Huawei / mac_oui | unchanged |

The justification rests on the two devices above, recorded on other segments. What is *not* segment-specific is the removed dependency on UDP port detection.

## Tests

`Execute` had **no test at all**. Eleven added, including the out-of-scope responder filter that the SSDP and MNDP probes already pin — a segment-wide query reaches devices nobody asked to scan, and reporting one would invent an asset. All stub the collector, so unit tests put nothing on the network. A live test is available behind `MDNS_LIVE=1`.

## Not in this PR

The Mac on the test segment is classified `media-device` because it advertises AirPlay while its model is `Mac16,7`. Review established the root cause is larger than the ordering decision it was first attributed to: **there is no precedence among service types at all** — `deriveMDNSDeviceType` returns the first match while walking a slice `appendUniqueSorted` keeps sorted, so the class is decided by the alphabet.

Measured: the same two services added in either order both yield `media-device`, because `_airplay` sorts before `_ipp`. And the test that appears to cover it assigns `ServiceTypes` directly, unsorted — an input shape production never builds — so it would keep passing through any change to the real ordering.

This predates the branch and is unchanged with multicast disabled. Filed as #231.

Independent of #228 and #229.
