### PR TITLE
feat(fingerprint): identify IBM block storage arrays

### DIFF
--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -992,3 +992,83 @@ rules:
   # Note: RPC responses are binary protocol that's difficult to fingerprint reliably.
   # RPC portmapper detection relies on port-based hints (port 111) and active probes
   # rather than banner pattern matching to avoid false positives.
+
+  # IBM block storage
+  #
+  # These arrays state their exact model in the page title of their management
+  # interface, and the SAN Volume Controller family in the Server header. Both
+  # are readable without credentials. Written from banners captured on live
+  # arrays, 2026-08-12, and each model below was observed on a real device.
+  #
+  # Two of the four served no Server header at all, so the title is the only
+  # anchor for them; two served the header with no title on some ports. Neither
+  # rule type covers the estate alone.
+  #
+  # The model goes in `product`, never in `version`: that field feeds
+  # version-based CVE correlation, and a model number read as a firmware version
+  # mismatches every advisory. `version` stays free for the firmware, which none
+  # of these state without credentials.
+  #
+  # The CPEs follow NVD naming convention but were NOT verified against the
+  # dictionary. The risk is bounded -- a product string that does not exist
+  # yields no CVEs, and one under vendor `ibm` cannot pull in another vendor's
+  # advisories -- but verify before relying on CVE counts for these models.
+  #
+  # Model rules outrank the family rule below, so a title that names the model
+  # wins over a header that names only the family.
+
+  - id: 'http.ibm_storwize_v3700'
+    protocol: 'http'
+    description: 'IBM Storwize V3700 management interface'
+    product: 'Storwize V3700'
+    vendor: 'IBM'
+    cpe: 'cpe:2.3:h:ibm:storwize_v3700:*:*:*:*:*:*:*:*'
+    match: '<title[^>]*>[^<]*ibm\s+storwize\s+v3700'
+    pattern_strength: 0.95
+    port_bonuses: [80, 443, 8443]
+
+  - id: 'http.ibm_storwize_v5000'
+    protocol: 'http'
+    description: 'IBM Storwize V5000 management interface'
+    product: 'Storwize V5000'
+    vendor: 'IBM'
+    cpe: 'cpe:2.3:h:ibm:storwize_v5000:*:*:*:*:*:*:*:*'
+    match: '<title[^>]*>[^<]*ibm\s+storwize\s+v5000'
+    pattern_strength: 0.95
+    port_bonuses: [80, 443, 8443]
+
+  # "IBM FlashSystem 5000" and "IBM Storage FlashSystem 5300" are both observed
+  # spellings of the same product line, so the word is optional.
+  - id: 'http.ibm_flashsystem_5000'
+    protocol: 'http'
+    description: 'IBM FlashSystem 5000 management interface'
+    product: 'FlashSystem 5000'
+    vendor: 'IBM'
+    cpe: 'cpe:2.3:h:ibm:flashsystem_5000:*:*:*:*:*:*:*:*'
+    match: '<title[^>]*>[^<]*ibm\s+(?:storage\s+)?flashsystem\s+5000'
+    pattern_strength: 0.95
+    port_bonuses: [80, 443, 8443]
+
+  - id: 'http.ibm_flashsystem_5300'
+    protocol: 'http'
+    description: 'IBM FlashSystem 5300 management interface'
+    product: 'FlashSystem 5300'
+    vendor: 'IBM'
+    cpe: 'cpe:2.3:h:ibm:flashsystem_5300:*:*:*:*:*:*:*:*'
+    match: '<title[^>]*>[^<]*ibm\s+(?:storage\s+)?flashsystem\s+5300'
+    pattern_strength: 0.95
+    port_bonuses: [80, 443, 8443]
+
+  # Family fallback. "SVC GUI" is the SAN Volume Controller interface every array
+  # above serves, including its Service Assistant pages, and it is the only
+  # anchor on ports that answer with no title. It names the family and not the
+  # model, so it stays unspecific and ranks below the model rules.
+  - id: 'http.ibm_svc'
+    protocol: 'http'
+    description: 'IBM SAN Volume Controller management interface'
+    product: 'SAN Volume Controller'
+    vendor: 'IBM'
+    cpe: 'cpe:2.3:a:ibm:san_volume_controller:*:*:*:*:*:*:*:*'
+    match: 'server:\s*svc gui'
+    pattern_strength: 0.75
+    port_bonuses: [80, 443, 8443]

--- a/pkg/fingerprint/ibm_storage_test.go
+++ b/pkg/fingerprint/ibm_storage_test.go
@@ -1,0 +1,206 @@
+package fingerprint
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The banners below keep the shape captured from live arrays on 2026-08-12:
+// the title wraps across lines and is indented, and two of the four models
+// serve no Server header at all. Session cookies are dropped because they
+// differ per capture and carry no identity.
+const (
+	ibmStorwizeV3700Banner = "HTTP/1.1 200 OK\r\n" +
+		"Cache-Control: no-cache, no-store, must-revalidate\r\n" +
+		"X-Content-Type-Options: nosniff\r\n" +
+		"Content-Type: text/html;charset=UTF-8\r\n" +
+		"Server: SVC GUI\r\n\r\n" +
+		"<html><head><title>\n    LS_V3700 - Log in - \n    IBM Storwize V3700\n  </title></head>"
+
+	ibmStorwizeV5000Banner = "HTTP/1.1 200 OK\r\n" +
+		"X-Content-Type-Options: nosniff\r\n" +
+		"Content-Type: text/html;charset=UTF-8\r\n" +
+		"Server: SVC GUI\r\n\r\n" +
+		"<html><head><title>\n    LSV5030 - Log in - \n    IBM Storwize V5000\n  </title></head>"
+
+	// No Server header, which is how this one answers.
+	ibmFlashSystem5000Banner = "HTTP/1.1 200 \r\n" +
+		"Cache-Control: no-cache, no-store, must-revalidate\r\n" +
+		"X-Content-Type-Options: nosniff\r\n" +
+		"Content-Type: text/html;charset=UTF-8\r\n\r\n" +
+		"<html><head><title>\n    LS5030FLASH - Log in - \n    IBM FlashSystem 5000\n  </title></head>"
+
+	// Also no Server header, and it spells the line "IBM Storage FlashSystem".
+	ibmFlashSystem5300Banner = "HTTP/1.1 200 \r\n" +
+		"Content-Security-Policy: frame-ancestors 'self'\r\n" +
+		"X-Content-Type-Options: nosniff\r\n" +
+		"Content-Type: text/html;charset=UTF-8\r\n\r\n" +
+		"<html><head><title>\n    LS_FS5300 - Log in - \n    IBM Storage FlashSystem 5300\n  </title></head>"
+
+	// A port that redirects and offers no title at all. The header is the only
+	// anchor here, which is why the family rule exists.
+	ibmSVCRedirectBanner = "HTTP/1.1 302 Found\r\n" +
+		"Location: /service/\r\n" +
+		"Connection: close\r\n" +
+		"Server: SVC GUI\r\n\r\n"
+)
+
+// Production hands the resolver "http" for these services: the pipeline maps an
+// https hint to http when the response looks like HTTP. Fallback mode is what it
+// uses on a port the catalog does not recognize. Both are exercised, because a
+// rule that only fires in one of them is dead on half the estate.
+func TestIBMStorage_ModelsAreIdentifiedFromTheirOwnBanners(t *testing.T) {
+	for _, tc := range []struct {
+		name, banner, product string
+		port                  int
+	}{
+		{"Storwize V3700", ibmStorwizeV3700Banner, "Storwize V3700", 443},
+		{"Storwize V5000", ibmStorwizeV5000Banner, "Storwize V5000", 8443},
+		{"FlashSystem 5000, no Server header", ibmFlashSystem5000Banner, "FlashSystem 5000", 443},
+		{"FlashSystem 5300, spelled IBM Storage", ibmFlashSystem5300Banner, "FlashSystem 5300", 80},
+	} {
+		for _, protocol := range []string{"", "http"} {
+			t.Run(tc.name+"/hint="+protocol, func(t *testing.T) {
+				result := requireResolved(t, tc.banner, protocol, tc.port)
+
+				require.Equal(t, "IBM", result.Vendor)
+				require.Equal(t, tc.product, result.Product)
+				require.Empty(t, result.Version,
+					"the model belongs in product; version feeds CVE correlation and "+
+						"none of these state a firmware without credentials")
+			})
+		}
+	}
+}
+
+// The header names the family and not the model, and on a port that answers
+// with no title it is the only thing to go on.
+func TestIBMStorage_TheHeaderAloneNamesTheFamily(t *testing.T) {
+	result := requireResolved(t, ibmSVCRedirectBanner, "http", 8080)
+
+	require.Equal(t, "IBM", result.Vendor)
+	require.Equal(t, "SAN Volume Controller", result.Product)
+}
+
+// Both rules match an array that serves a title, and the specific one has to
+// win — otherwise adding the family rule would cost the model.
+func TestIBMStorage_TheModelOutranksTheFamily(t *testing.T) {
+	result := requireResolved(t, ibmStorwizeV3700Banner, "http", 443)
+
+	require.Equal(t, "Storwize V3700", result.Product,
+		"the title names the model, so the header rule must not win")
+}
+
+// Each rule names one model. A pattern loose enough to match a sibling would
+// report the wrong hardware, which is worse than reporting the family.
+func TestIBMStorage_ModelsDoNotMatchEachOther(t *testing.T) {
+	for _, tc := range []struct{ name, banner, mustNotBe string }{
+		{"V3700 is not V5000", ibmStorwizeV3700Banner, "Storwize V5000"},
+		{"V5000 is not V3700", ibmStorwizeV5000Banner, "Storwize V3700"},
+		{"5000 is not 5300", ibmFlashSystem5000Banner, "FlashSystem 5300"},
+		{"5300 is not 5000", ibmFlashSystem5300Banner, "FlashSystem 5000"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := requireResolved(t, tc.banner, "http", 443)
+			require.NotEqual(t, tc.mustNotBe, result.Product)
+		})
+	}
+}
+
+// The rules anchor on a title element, and a title carrying attributes is
+// common enough that a literal <title> would miss it.
+func TestIBMStorage_MatchesATitleWithAttributes(t *testing.T) {
+	banner := "HTTP/1.1 200 OK\r\nServer: SVC GUI\r\n\r\n" +
+		`<html><head><title lang="en" dir="ltr">LS_V3700 - Log in - IBM Storwize V3700</title></head>`
+
+	require.Equal(t, "Storwize V3700", requireResolved(t, banner, "http", 443).Product)
+}
+
+// Nothing here may claim a host that merely mentions the words.
+func TestIBMStorage_DoesNotClaimUnrelatedBanners(t *testing.T) {
+	for _, banner := range []string{
+		"HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\n\r\n<title>IBM Support Portal</title>",
+		"HTTP/1.1 200 OK\r\nServer: Apache/2.4.58\r\n\r\n<title>Storage Overview</title>",
+		"SSH-2.0-OpenSSH_7.4\r\n",
+	} {
+		result, err := NewRuleBasedResolver(loadBuiltinRules()).
+			Resolve(context.Background(), Input{Protocol: "", Banner: banner, Port: 443})
+		if err == nil {
+			require.NotEqual(t, "IBM", result.Vendor, "banner %q", banner)
+		}
+	}
+}
+
+func requireResolved(t *testing.T, banner, protocol string, port int) Result {
+	t.Helper()
+	result, err := NewRuleBasedResolver(loadBuiltinRules()).
+		Resolve(context.Background(), Input{Protocol: protocol, Banner: banner, Port: port})
+	require.NoError(t, err, "expected a match for hint %q on port %d", protocol, port)
+	return result
+}
+
+// ibmRule returns a shipped rule by id.
+func ibmRule(t *testing.T, id string) StaticRule {
+	t.Helper()
+	for _, rule := range loadBuiltinRules() {
+		if rule.ID == id {
+			return rule
+		}
+	}
+	t.Fatalf("rule %q is not in the shipped database", id)
+	return StaticRule{}
+}
+
+// Each model pattern must match its own banner and no sibling's. Asserting this
+// on the compiled patterns rather than through the resolver is deliberate: when
+// two rules match, the winner is decided by confidence and then by the order
+// they appear in the file, so a resolver-level assertion can pass because a
+// rule happens to be listed first rather than because it is the only one that
+// matches.
+func TestIBMStorage_EachModelPatternMatchesOnlyItsOwnBanner(t *testing.T) {
+	banners := map[string]string{
+		"http.ibm_storwize_v3700":   ibmStorwizeV3700Banner,
+		"http.ibm_storwize_v5000":   ibmStorwizeV5000Banner,
+		"http.ibm_flashsystem_5000": ibmFlashSystem5000Banner,
+		"http.ibm_flashsystem_5300": ibmFlashSystem5300Banner,
+	}
+
+	for id, own := range banners {
+		t.Run(id, func(t *testing.T) {
+			pattern := regexp.MustCompile(ibmRule(t, id).Match)
+
+			require.True(t, pattern.MatchString(strings.ToLower(own)),
+				"%s does not match the banner it was written from", id)
+			for otherID, other := range banners {
+				if otherID == id {
+					continue
+				}
+				require.False(t, pattern.MatchString(strings.ToLower(other)),
+					"%s also matches the banner of %s", id, otherID)
+			}
+		})
+	}
+}
+
+// The family rule has to stay below the model rules by enough that the port
+// bonus cannot close the gap. Confidence saturates at 1.0, so two strengths
+// near the top become a tie the file order silently resolves -- which would
+// make the precedence an accident of listing rather than a decision.
+func TestIBMStorage_TheFamilyRuleStaysBelowTheModelRules(t *testing.T) {
+	family := ibmRule(t, "http.ibm_svc")
+
+	for _, id := range []string{
+		"http.ibm_storwize_v3700",
+		"http.ibm_storwize_v5000",
+		"http.ibm_flashsystem_5000",
+		"http.ibm_flashsystem_5300",
+	} {
+		model := ibmRule(t, id)
+		require.Less(t, family.PatternStrength+0.05, model.PatternStrength,
+			"%s must outrank the family rule even with a port bonus applied", id)
+	}
+}


### PR DESCRIPTION
## Why

Six IBM storage arrays on the lab subnet resolved to **nothing**. They state their exact model in the page title of their management interface and the SAN Volume Controller family in the `Server` header — both readable without credentials — and no rule asked.

This is the class the `fingerprint gaps` report (#229) is meant to surface; these rules are the first thing it argued for.

## What

Four model rules plus a family fallback, written from banners **captured on live arrays**, not from documentation. Every model here was observed on a real device:

| rule | product | anchor |
|---|---|---|
| `http.ibm_storwize_v3700` | Storwize V3700 | title |
| `http.ibm_storwize_v5000` | Storwize V5000 | title |
| `http.ibm_flashsystem_5000` | FlashSystem 5000 | title |
| `http.ibm_flashsystem_5300` | FlashSystem 5300 | title |
| `http.ibm_svc` | SAN Volume Controller | `Server: SVC GUI` |

**Both rule types are needed, and the corpus settled it:** two of the four arrays serve **no `Server` header at all**, so the title is their only anchor; and some ports answer with a redirect that carries the header and no title.

## Measured

Full sweep of the 148-banner lab corpus, in both fallback and service-named modes, against binaries built from `main` and from this branch:

```
296 probes    28 verdicts changed
              28 no-match -> match
               0 product -> different product
               0 match -> no match
```

Six distinct arrays now identified across their ports. Validation metrics identical to main (TP 106, TPR 84.13%, F1 0.9138).

## Shape

- **The model goes in `product`, never `version`.** That field feeds version-based CVE correlation, and a model number read as a firmware release mismatches every advisory. None of these arrays states a firmware without credentials, so `version` stays empty rather than being filled with something else.
- `IBM FlashSystem 5000` and `IBM Storage FlashSystem 5300` are both observed spellings of one product line, so the middle word is optional in those two patterns.
- The title anchor allows attributes. A literal `<title>` misses a title carrying any, and that miss is silent.
- **The CPEs follow NVD convention but were not verified against the dictionary**, and the file says so. The risk is bounded — a product string that does not exist yields no CVEs, and one under vendor `ibm` cannot pull in another vendor's advisories — but confirm before reading a CVE count for these models.

## Tests, and why two of them bypass the resolver

Mutation-checked. Three ways these rules could be wrong were introduced one at a time; each is caught:

| mutation | caught |
|---|---|
| title anchor made a literal `<title>` | ✅ |
| family rule raised above the model rules | ✅ |
| `5300` pattern widened to match siblings | ✅ |

The last two were **not** caught by the first version of the tests, and the reason is worth stating: when two rules match, the winner is decided by confidence and then by **the order they appear in the file**. Raising the family rule to `0.99` left every resolver-level assertion green, because confidence saturates at 1.0 and file order broke the tie in the model's favour — the right answer for the wrong reason.

So two tests assert on the compiled patterns instead: each model pattern must match its own banner and no sibling's, and the family strength must stay below the model strengths by more than a port bonus can close. That makes the precedence a property of the rules rather than an accident of listing.

This is the same failure mode as #231, reached from a different direction.

## Scope

Independent of #229. Touches only `fingerprint_db.yaml` and a new test file.
