### PR TITLE
fix(fingerprint): rank on the score, not on the order rules are listed in

### DIFF
--- a/pkg/fingerprint/resolver_rulebased.go
+++ b/pkg/fingerprint/resolver_rulebased.go
@@ -73,16 +73,31 @@ func (r *RuleBasedResolver) SetTelemetry(telemetry *TelemetryWriter) {
 //	Result - The result of the fingerprinting process, populated if a rule matches.
 //	error             - An error if no matching rule is found.
 //
+// ruleCandidate is a rule that matched, with the score used to rank it and the
+// confidence reported for it.
+//
+// The two are not the same number. Confidence is clamped to 1.0 because that is
+// what the field means to a reader, but clamping before the comparison threw
+// away the ordering: 8 of the shipped rules reach the ceiling once a port bonus
+// applies, so within that band pattern_strength distinguished nothing and the
+// winner was decided by the order the rules appear in the file.
+//
 //nolint:gocyclo // Telemetry logging adds complexity, refactor planned for later
-func (r *RuleBasedResolver) Resolve(_ context.Context, in Input) (Result, error) {
-	normalizedBanner := strings.ToLower(in.Banner)
+type ruleCandidate struct {
+	rule       StaticRule
+	version    string
+	score      float64
+	confidence float64
+}
 
-	type candidate struct {
-		rule       StaticRule
-		version    string
-		confidence float64
-	}
-	cands := make([]candidate, 0, 8)
+// rankedCandidates returns every rule that matched, strongest first.
+//
+// Exposed to the package so a test can assert on the ranking itself rather than
+// only on the winner. A test that checks the winner alone cannot tell a rule
+// that won on merit from one that won because it is listed first.
+func (r *RuleBasedResolver) rankedCandidates(in Input) []ruleCandidate {
+	normalizedBanner := strings.ToLower(in.Banner)
+	cands := make([]ruleCandidate, 0, 8)
 
 	// Phase 1: Determine if we should try all rules (fallback mode)
 	// Fallback activates when protocol hint is generic (tcp/udp) or unknown
@@ -122,6 +137,8 @@ func (r *RuleBasedResolver) Resolve(_ context.Context, in Input) (Result, error)
 		}
 		// Base strength defaulted in prepareRules()
 		base := rule.PatternStrength
+		// Ranked on the unclamped score, reported on the clamped one.
+		score := base - softPenalty + portBonus
 		conf := calculateConfidence(base, softPenalty, portBonus)
 
 		// Threshold filter
@@ -132,8 +149,15 @@ func (r *RuleBasedResolver) Resolve(_ context.Context, in Input) (Result, error)
 			}
 			continue
 		}
-		cands = append(cands, candidate{rule: rule, version: version, confidence: conf})
+		cands = append(cands, ruleCandidate{rule: rule, version: version, score: score, confidence: conf})
 	}
+
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].score > cands[j].score })
+	return cands
+}
+
+func (r *RuleBasedResolver) Resolve(_ context.Context, in Input) (Result, error) {
+	cands := r.rankedCandidates(in)
 
 	if len(cands) == 0 {
 		// Log no match if telemetry is enabled
@@ -142,7 +166,6 @@ func (r *RuleBasedResolver) Resolve(_ context.Context, in Input) (Result, error)
 		}
 		return Result{}, fmt.Errorf("no matching rule found")
 	}
-	sort.SliceStable(cands, func(i, j int) bool { return cands[i].confidence > cands[j].confidence })
 	best := cands[0]
 
 	result := Result{

--- a/pkg/fingerprint/rule_precedence_test.go
+++ b/pkg/fingerprint/rule_precedence_test.go
@@ -1,0 +1,90 @@
+package fingerprint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A tie between the winner and the runner-up is resolved by sort.SliceStable,
+// which means by the order the rules appear in the YAML. That is not a decision
+// anybody made, and it is invisible: the right answer still comes out, until
+// somebody reorders the file or adds a rule above another one.
+//
+// This test turns "file order is saving us" into a build failure. It is the
+// cheap half of the fix; the other half is ranking on the unclamped score, so
+// that pattern_strength keeps distinguishing rules in its top band instead of
+// saturating.
+func TestRulePrecedence_NoTieDecidesAMatchInTheShippedCorpus(t *testing.T) {
+	resolver := NewRuleBasedResolver(loadBuiltinRules())
+
+	for _, sample := range loadValidationCorpus(t) {
+		for _, protocol := range []string{sample.Protocol, ""} {
+			candidates := resolver.rankedCandidates(Input{
+				Protocol: protocol, Banner: sample.Banner, Port: sample.Port,
+			})
+			if len(candidates) < 2 {
+				continue
+			}
+
+			winner, runnerUp := candidates[0], candidates[1]
+			require.NotEqual(t, runnerUp.score, winner.score,
+				"%q on port %d (hint %q) is decided by a tie between %s and %s at "+
+					"score %.2f, which sort.SliceStable resolves by their order in "+
+					"the YAML rather than by anything anybody decided",
+				truncateForMessage(sample.Banner), sample.Port, protocol,
+				winner.rule.ID, runnerUp.rule.ID, winner.score)
+		}
+	}
+}
+
+// The clamp belongs on the number reported to a reader, not on the comparison.
+// Two rules whose strengths differ must keep differing after a port bonus that
+// would push both past 1.0.
+func TestRulePrecedence_TheCeilingDoesNotFlattenTheRanking(t *testing.T) {
+	rules := []StaticRule{
+		{ID: "specific", Protocol: "http", Product: "Specific", Vendor: "V",
+			CPE: "cpe:2.3:a:v:specific:*:*:*:*:*:*:*:*", Match: `acme`,
+			PatternStrength: 0.95, PortBonuses: []int{8080}},
+		{ID: "generic", Protocol: "http", Product: "Generic", Vendor: "V",
+			CPE: "cpe:2.3:a:v:generic:*:*:*:*:*:*:*:*", Match: `acme`,
+			PatternStrength: 0.99, PortBonuses: []int{8080}},
+	}
+	// Listed with the weaker rule first, so file order cannot supply the answer.
+	candidates := NewRuleBasedResolver(rules).
+		rankedCandidates(Input{Protocol: "http", Banner: "acme", Port: 8080})
+
+	require.Len(t, candidates, 2)
+	require.Equal(t, "generic", candidates[0].rule.ID,
+		"0.99 must outrank 0.95 even though both clamp to 1.0 when reported")
+	require.Equal(t, 1.0, candidates[0].confidence, "the reported value is still clamped")
+	require.Greater(t, candidates[0].score, candidates[1].score,
+		"the ranking runs on the unclamped score")
+}
+
+// loadValidationCorpus reads the banners the repository already ships as its
+// validation set, through the loader production uses rather than a second
+// parser of the same file. The corpus grows without this test being edited.
+func loadValidationCorpus(t *testing.T) []ValidationTestCase {
+	t.Helper()
+
+	dataset, err := LoadValidationDataset("testdata/validation_dataset.yaml")
+	require.NoError(t, err)
+
+	cases := make([]ValidationTestCase, 0,
+		len(dataset.TruePositives)+len(dataset.TrueNegatives)+len(dataset.EdgeCases))
+	cases = append(cases, dataset.TruePositives...)
+	cases = append(cases, dataset.TrueNegatives...)
+	cases = append(cases, dataset.EdgeCases...)
+	require.NotEmpty(t, cases, "the validation corpus must not be empty")
+	return cases
+}
+
+func truncateForMessage(banner string) string {
+	const limit = 48
+	if len(banner) <= limit {
+		return banner
+	}
+	return fmt.Sprintf("%s...", banner[:limit])
+}

--- a/pkg/fingerprint/rule_precedence_test.go
+++ b/pkg/fingerprint/rule_precedence_test.go
@@ -1,6 +1,7 @@
 package fingerprint
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,10 +13,17 @@ import (
 // anybody made, and it is invisible: the right answer still comes out, until
 // somebody reorders the file or adds a rule above another one.
 //
-// This test turns "file order is saving us" into a build failure. It is the
-// cheap half of the fix; the other half is ranking on the unclamped score, so
-// that pattern_strength keeps distinguishing rules in its top band instead of
-// saturating.
+// This test turns "file order is saving us" into a build failure.
+//
+// It finds nothing today, and it is worth recording how hard that was looked
+// for: 322 probes here (161 banners x 2 hints), and 11,130 in the review
+// sweep (161 banners x 7 hints x 10 ports), producing 250 probes with more
+// than one candidate and zero ties in either. The emptiness is structural
+// rather than a sampling accident -- no shipped rule can exceed the ceiling,
+// so a tie needs equal pattern_strength, equal bonus eligibility, and a banner
+// matching both, and the corpus holds no such banner. One exists in reality:
+// a page serving `Server: Jetty(9.4.z)` with an IBM Storwize title puts two
+// rules at exactly 1.0000.
 func TestRulePrecedence_NoTieDecidesAMatchInTheShippedCorpus(t *testing.T) {
 	resolver := NewRuleBasedResolver(loadBuiltinRules())
 
@@ -87,4 +95,34 @@ func truncateForMessage(banner string) string {
 		return banner
 	}
 	return fmt.Sprintf("%s...", banner[:limit])
+}
+
+// Resolve must answer with what the ranking says, or extracting the ranking
+// bought nothing: a helper production has stopped calling is worse than never
+// having extracted it, because the tests around it keep passing while the
+// behavior they describe has moved elsewhere.
+func TestRulePrecedence_ResolveAnswersWithTheTopRankedCandidate(t *testing.T) {
+	resolver := NewRuleBasedResolver(loadBuiltinRules())
+	checked := 0
+
+	for _, sample := range loadValidationCorpus(t) {
+		for _, protocol := range []string{sample.Protocol, ""} {
+			input := Input{Protocol: protocol, Banner: sample.Banner, Port: sample.Port}
+
+			ranked := resolver.rankedCandidates(input)
+			result, err := resolver.Resolve(context.Background(), input)
+
+			if len(ranked) == 0 {
+				require.Error(t, err, "no candidate ranked, so nothing may be resolved")
+				continue
+			}
+			require.NoError(t, err)
+			require.Equal(t, ranked[0].rule.Product, result.Product,
+				"Resolve disagreed with the ranking on %q", truncateForMessage(sample.Banner))
+			require.Equal(t, ranked[0].rule.Vendor, result.Vendor)
+			require.Equal(t, ranked[0].confidence, result.Confidence)
+			checked++
+		}
+	}
+	require.NotZero(t, checked, "the corpus must exercise at least one match")
 }


### PR DESCRIPTION
Closes the fingerprint half of #235.

## The defect

Two rules with equal confidence are ordered by `sort.SliceStable` — which means **by the order they appear in the YAML**. Nobody decided that, and it is invisible: the right answer still comes out, until someone reorders the file or adds a rule above another one.

It is reachable because confidence saturates:

```go
if conf > 1 { conf = 1 }
```

**8 of the 50 shipped rules reach 1.0 once a port bonus applies** — `http.jetty`, `ftp.crushftp`, `imap.smartermail`, `pop3.dovecot`, and the four IBM model rules from #234. Within that band `pattern_strength` distinguished nothing.

Measured while reviewing #234: raising the IBM family rule from `0.75` to **`0.99`** — above every model rule — left every test green. Both saturated at 1.00 and the model rules happen to be listed first. The right answer for the wrong reason.

## The fix, and what it does not do

Rank on the unclamped score; report the clamped confidence, which is what the field means to a reader.

**Correction, from review: this changes no behaviour today, and the example first given here did not show what it claimed.**

`score` and `confidence` diverge only when the unclamped value **exceeds** 1.0. Measured over the shipped database:

```
rules                                50
highest pattern_strength           0.95
highest port bonus                 0.05
rules that can exceed 1.0             0     <- what the clamp would truncate
rules that reach exactly 1.0          8
```

Reaching the ceiling is not the same as being cut by it. Nothing is cut, so `score == confidence` for every shipped rule and both ranking keys give the same order — before and after this change. The earlier IBM example (`1.00` against `0.80`) is arithmetically right and identical on `main`.

So this is a **forward guard**: it makes raising a strength to `0.99` safe later, rather than fixing something now. Worth having on those terms and not on the ones first claimed here.

**The live defect survives this PR.** A tie at *exactly* 1.0 is still broken by file order.

**Correction, after the change was merged:** the example given here was published without its condition, and the condition inverts it. `http.jetty` carries `forbidden` and `error` among its soft-exclude patterns; the four IBM rules carry none. So the tie only holds on a page that says neither:

```
--- 200 OK page ---
   http.jetty               score=1.0000   -> Resolve: "Jetty"
   http.ibm_storwize_v3700  score=1.0000

--- the SAME page returning 403 ---
   http.ibm_storwize_v3700  score=1.0000   -> Resolve: "Storwize V3700"
   http.jetty               score=0.8000
```

On the error page the right answer wins — for a reason nobody designed. The tie is real and so is the file-order resolution, but this example demonstrates it only under a condition the original text did not state.

The scale was also understated. Three independent derivations agree on 350 tie pairs, of which 41 are same-protocol; 18 of those are live ties verified through `rankedCandidates`, all 18 won by file order. The remaining 309 are cross-protocol and were initially excluded — wrongly, because the fallback path removes the protocol restriction, and a port scan produces exactly that path. Roughly 297 of them are live co-candidates. So: **18 on the protocol-pinned path, around 315 on the fallback path.**

Closing that needs a decision this PR does not make — see the note at the end.

## Tests, and what each is worth

**The corpus guard** fails if the winner and runner-up ever tie on any banner in the shipped validation set. Honest about its reach:

```
322 probes  ->  9 banners with more than one candidate  ->  0 ties
```

It finds nothing today. It is a guard against a rule being added into the saturating band later, not evidence about now.

**The behaviour is pinned by a direct case instead**: two rules differing only in strength, both pushed past 1.0 by a port bonus, listed **weaker-first** so file order cannot supply the answer. Reverting the fix fails this one — verified, with the build confirmed green first so a compile error could not stand in for a caught mutation.

## Verified

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` clean.
- Validation metrics identical to main: TP 106, TPR 84.13%, F1 0.9138.

## What still has to be decided

A pairwise property test — fail when two rules can reach the same score at some port — was suggested as the way to close #235's fingerprint half. Measured before writing it:

```
rule pairs                    1225
pairs that can tie somewhere   350   (41 of them within one protocol)
```

So "no two rules may tie" is not a property this database has, or plausibly could: it would mean fifty distinct strength values carrying precision nobody chose. A tie only matters when both rules can match the *same banner*, and that is the narrower property the corpus guard checks — finding nothing today because the corpus holds no co-matching banner, while the Jetty/Storwize page shows one exists.

That leaves a real choice, and it belongs to whoever owns the rule vocabulary:

- give distinct strengths only to rules that can co-match, which needs a way to decide co-matching that is cheaper than "try every banner"; or
- break ties on something stated rather than on file position — pattern specificity, an explicit precedence, or refusing to answer when the top two tie.

Filed under #235. This PR does not close it.

## Not in this PR

The mDNS half of #235 — device class decided by the alphabet — is unchanged and still tracked in #231. Different fix, same principle.


