### PR TITLE
chore: build with Go 1.26.6 to close three reachable stdlib vulnerabilities

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26.6'
   NODE_VERSION: '20'
   VERSION: 'dev'
 
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ['1.25']
+        go-version: ['1.26.6']
 
     steps:
       - name: Check out code

--- a/.github/workflows/validate-fingerprints.yaml
+++ b/.github/workflows/validate-fingerprints.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26.6'
           check-latest: true
 
       - name: Run validation suite (PR)

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26.6'
   GOLANGCI_LINT_VERSION: v2.12.2
   MISSPELL_VERSION: v0.6.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cyprob/cyprob
 
 go 1.25.0
 
+toolchain go1.26.6
+
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
Closes #245.

## What this closes, measured

`govulncheck ./...` on this branch, before and after:

```
before (go1.26.3)                 after (go1.26.6)
GO-2026-5856  crypto/tls          No vulnerabilities found.
GO-2026-5039  net/textproto       0 reachable
GO-2026-5037  crypto/x509
3 reachable
```

All three are standard library, so no dependency bump reaches them — #216 upgraded six `x/` modules and closed only the fourth one, `GO-2026-5942` in `x/net`.

The reachability is not theoretical. `crypto/tls` is reached from six call sites including `banner_grab.go` and `tls_native_probe.go`, `net/textproto` from `http_parser.go:277`, `crypto/x509` from TLS certificate verification — the paths a scanner runs against every host it touches.

## Why the go directive is not raised

`go 1.25.0` stays. What compiles the standard library into the binary is **the toolchain**, not the language version, so `toolchain go1.26.6` is what closes these. Raising the `go` directive would additionally force every downstream consumer — vulntor-ee imports this module — onto 1.26 language semantics while closing nothing extra.

With `GOTOOLCHAIN=auto` (the default), a developer on an older Go downloads 1.26.6 automatically; this was observed rather than assumed:

```
$ go version
go: downloading go1.26.6 (darwin/arm64)
go version go1.26.6 darwin/arm64
```

## This does not close the vulnerability in the shipped product

A `toolchain` directive travels with the module but **does not propagate to consumers** — only the `go` line does. vulntor-ee imports this module and needs the same change in its own `go.mod`. That sentence is easy to read as a footnote. Measured, it is not one.

EE builds what the customer runs, and every one of its build paths is on 1.25:

```
EE go.mod                          go 1.25.0, no toolchain directive
EE ci.yml / pr-review-gate.yml     GO_VERSION: '1.25'
EE release.yaml                    go-version: '1.25'      <- ships binaries
EE release-staging.yaml            go-version: "1.25"      <- ships binaries
EE _build-ee-binary.yml            default: '1.25', and no caller overrides it
```

The same CE tree, resolved against the line EE actually builds with:

```
go1.25.8   ->  8 vulnerabilities
go1.26.3   ->  3
go1.26.6   ->  0
```

So when this merges, CE is clean and the shipped enterprise binary still carries **eight** — more than CE had before this PR, not fewer. Nothing in the diff is wrong; the risk is that #245 reads as closed on the strength of its first sentence.

**EE's fix is smaller than this one.** All eight close inside the 1.25 line:

| id | fixed in |
|---|---|
| GO-2026-4870, 4946, 4947 | 1.25.9 |
| GO-2026-4918, 4971 | 1.25.10 |
| GO-2026-5037, 5039 | 1.25.11 |
| GO-2026-5856 | 1.25.12 |

Pinning EE to `1.25.12` closes all eight: no language version change, no effect on consumers, and none of the `go`-versus-`toolchain` argument above applies there. Verified by resolving this tree at 1.25.12 — zero reachable. Filed separately so it is not lost.

## A fourth pin the issue did not list

#245 named `go.mod`, `test.yaml` and `validate.yaml`. There is one more:

```
.github/workflows/validate-fingerprints.yaml:22   go-version: '1.24'
```

Two minor versions behind, and it runs the fingerprint validation suite. Moved with the rest. `codeql.yml` reads `go-version-file: 'go.mod'` and needs no edit.

## Verification under 1.26.6

| check | result |
|---|---|
| `go build ./...` | passes |
| `go test ./...` | passes, no failures |
| `golangci-lint run ./...` (v2.12.2, the CI-pinned version) | exit 0, 0 issues |
| `govulncheck ./...` | 0 reachable |

The linter was worth checking rather than assuming: a golangci-lint binary built with an older Go cannot read newer export data. The prebuilt release CI downloads reports `built with go1.26.2`, same major, so it reads 1.26.6 fine — confirmed by running that exact binary against this branch, not the one `go install` would build locally.

`go vet` reports eight `lostcancel` findings in `mysql_native_probe.go`, `smtp_native_probe.go` and `winrm_native_probe.go`. These are **pre-existing**: the identical eight appear under 1.25.0. Not touched here, and worth their own issue.

## What still is not measured

Nothing in CI runs `govulncheck`, so the next reachable stdlib vulnerability will land the same way this one did — noticed by hand while reviewing an unrelated dependency PR. A CI job would turn that into a build signal, but it is a separate change and is deliberately not bundled here.

## Left alone deliberately

`.golangci.yaml:491` still declares `go: '1.24'`. That is the language version the linter assumes, not what compiles the binary, so it carries no security weight — but it is stale in the same way and changing it can change lint strictness, which does not belong in a vulnerability fix.
