### PR TITLE
fix(fingerprint): stop protocol hints no rule declares from excluding every candidate

### DIFF
--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -922,6 +922,11 @@ rules:
     product: 'BIND'
     vendor: 'ISC'
     cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
+    # The leading boundaries keep rpcbind, dnsmasq and powerdns from being
+    # reported as BIND; there is deliberately none after 'bind', or the
+    # bind9 spelling stops matching. Guarded by
+    # TestDNSIdentificationSurvivesTheNarrowing in pkg/modules/parse, which
+    # cannot live here: that package imports this one.
     match: '\bbind|\bnamed|\bdns\b'
     version_extraction: "(?:bind|named)[\\s/_-]+([\\d\\.]+)"
 

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -922,7 +922,7 @@ rules:
     product: 'BIND'
     vendor: 'ISC'
     cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
-    match: 'bind|named|dns'
+    match: '\bbind\b|\bnamed\b|\bdns\b'
     version_extraction: "(?:bind|named)[\\s/_-]+([\\d\\.]+)"
 
     exclude_patterns:

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -922,7 +922,7 @@ rules:
     product: 'BIND'
     vendor: 'ISC'
     cpe: 'cpe:2.3:a:isc:bind:*:*:*:*:*:*:*:*'
-    match: '\bbind\b|\bnamed\b|\bdns\b'
+    match: '\bbind|\bnamed|\bdns\b'
     version_extraction: "(?:bind|named)[\\s/_-]+([\\d\\.]+)"
 
     exclude_patterns:

--- a/pkg/fingerprint/loader.go
+++ b/pkg/fingerprint/loader.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 //go:embed data/fingerprint_db.yaml
@@ -24,6 +25,30 @@ func loadBuiltinRules() []StaticRule {
 		return nil
 	}
 	return prepareRules(rules)
+}
+
+// DeclaredProtocols returns, sorted, every protocol value the shipped rules
+// declare.
+//
+// It exists so that anything producing a protocol hint can check its
+// vocabulary against the rules' rather than the two drifting apart in silence.
+// The failure is not a missed match but a total one: a hint no rule declares
+// is still specific enough to switch fallback off, so it excludes every
+// candidate and the service resolves to nothing at all.
+func DeclaredProtocols() []string {
+	seen := make(map[string]struct{})
+	for _, rule := range loadBuiltinRules() {
+		if rule.Protocol != "" {
+			seen[rule.Protocol] = struct{}{}
+		}
+	}
+
+	protocols := make([]string, 0, len(seen))
+	for protocol := range seen {
+		protocols = append(protocols, protocol)
+	}
+	sort.Strings(protocols)
+	return protocols
 }
 
 // loadExternalCatalog attempts to load fingerprint rules from workspace cache.

--- a/pkg/modules/parse/fingerprint_parser.go
+++ b/pkg/modules/parse/fingerprint_parser.go
@@ -478,10 +478,16 @@ func normalizeResolverProtocol(protocolHint, response, probeID string) string {
 	if protocolHint != "https" {
 		return protocolHint
 	}
-	if !looksLikeHTTPResponse(response, probeID) {
-		return protocolHint
+	if looksLikeHTTPResponse(response, probeID) {
+		return "http"
 	}
-	return "http"
+	// No rule declares https, and a hint no rule declares is still specific
+	// enough to switch fallback off -- so returning it here excluded every
+	// candidate. What is actually known at this point is that the service
+	// answered over TLS with something that is not HTTP, which says nothing
+	// about the protocol; an empty hint says exactly that and lets every rule
+	// compete. SSH on 443 and SMTP on 8443 both resolve to nothing otherwise.
+	return ""
 }
 
 func looksLikeHTTPResponse(response, probeID string) bool {
@@ -565,23 +571,25 @@ func detectProtocolFromPort(port int) string {
 	case 389, 636, 3268, 3269:
 		return "ldap"
 	case 5672, 5671:
-		return "rabbitmq"
+		// The rule for RabbitMQ declares amqp; naming the product here instead
+		// of the protocol filtered every rule out and resolved the port to
+		// nothing.
+		return "amqp"
 	case 9092, 9093:
 		return "kafka"
 	case 9200, 9300:
-		return "elasticsearch"
+		// Elasticsearch answers over HTTP and both of its rules declare http.
+		return "http"
 	case 161, 162:
 		return "snmp"
 	// File Sharing / Windows Services
-	case 135:
-		return "msrpc"
-	case 139:
-		return "netbios"
-	case 445:
+	// 135 is the RPC endpoint mapper and no rule identifies it. An empty hint
+	// says that honestly and lets every rule compete; a hint no rule declares
+	// says the opposite while excluding all of them.
+	case 139, 445:
 		return "smb"
 	// Infrastructure Services
-	case 111:
-		return "rpc"
+	// 111 is rpcbind, which no rule identifies either. See 135 above.
 	}
 	return ""
 }

--- a/pkg/modules/parse/fingerprint_parser_test.go
+++ b/pkg/modules/parse/fingerprint_parser_test.go
@@ -358,18 +358,26 @@ func TestDetectProtocolFromPort(t *testing.T) {
 		{"LDAPS secure port", 636, "ldap"},
 		{"LDAP global catalog", 3268, "ldap"},
 		{"LDAP global catalog SSL", 3269, "ldap"},
-		{"RabbitMQ standard port", 5672, "rabbitmq"},
-		{"RabbitMQ secure port", 5671, "rabbitmq"},
+		// These four named the product or the service rather than the
+		// protocol the rules declare, and this test asserted that as correct.
+		// A hint no rule declares excludes every candidate, so each of them
+		// meant the port resolved to nothing at all.
+		{"RabbitMQ standard port hints its rule's protocol", 5672, "amqp"},
+		{"RabbitMQ secure port hints its rule's protocol", 5671, "amqp"},
 		{"Kafka standard port", 9092, "kafka"},
 		{"Kafka secure port", 9093, "kafka"},
-		{"Elasticsearch HTTP port", 9200, "elasticsearch"},
-		{"Elasticsearch transport port", 9300, "elasticsearch"},
+		{"Elasticsearch answers over HTTP", 9200, "http"},
+		{"Elasticsearch transport port answers over HTTP", 9300, "http"},
 		{"SNMP standard port", 161, "snmp"},
 		{"SNMP trap port", 162, "snmp"},
-		{"msrpc", 135, "msrpc"},
-		{"netbios", 139, "netbios"},
+		{"netbios", 139, "smb"},
 		{"smb", 445, "smb"},
-		{"rpc", 111, "rpc"},
+
+		// No rule identifies the RPC endpoint mapper or rpcbind. An empty
+		// hint is the honest answer and lets every rule compete; naming a
+		// protocol no rule declares does the opposite.
+		{"msrpc has no rule, so no hint", 135, ""},
+		{"rpcbind has no rule, so no hint", 111, ""},
 
 		// Unknown ports
 		{"Unknown port 1234", 1234, ""},
@@ -685,7 +693,12 @@ func TestFingerprintParserModule_HTTPSResolverProtocolNormalization(t *testing.T
 	}
 }
 
-func TestFingerprintParserModule_HTTPSResolverProtocolNotNormalizedForNonHTTPResponse(t *testing.T) {
+// A TLS probe that gets back something which is not HTTP knows only that: not
+// the protocol. This asserted the resolver was handed "https", which no rule
+// declares -- and a hint no rule declares excludes every candidate, so the
+// service resolved to nothing. The fixture below is the case itself: an SMTP
+// greeting answering on 443, which is identifiable the moment the hint is empty.
+func TestFingerprintParserModule_HTTPSResolverProtocolIsClearedForNonHTTPResponse(t *testing.T) {
 	originalGetResolver := getResolver
 	defer func() { getResolver = originalGetResolver }()
 
@@ -727,8 +740,9 @@ func TestFingerprintParserModule_HTTPSResolverProtocolNotNormalizedForNonHTTPRes
 	if len(calledInputs) != 1 {
 		t.Fatalf("expected 1 resolver call, got %d", len(calledInputs))
 	}
-	if calledInputs[0].Protocol != "https" {
-		t.Fatalf("expected resolver protocol https, got %q", calledInputs[0].Protocol)
+	if calledInputs[0].Protocol != "" {
+		t.Fatalf("expected an empty resolver protocol so every rule competes, got %q",
+			calledInputs[0].Protocol)
 	}
 }
 

--- a/pkg/modules/parse/protocol_hint_vocabulary_test.go
+++ b/pkg/modules/parse/protocol_hint_vocabulary_test.go
@@ -145,3 +145,41 @@ func TestRPCBindIsNotIdentifiedAsBIND(t *testing.T) {
 			"the substring bind inside rpcbind must not identify a DNS server")
 	}
 }
+
+// The narrowing that keeps rpcbind from being identified as BIND has to leave
+// the spellings a real BIND server answers with, and the validation corpus
+// cannot show that: its four DNS banners all carry the token as a separate
+// word, so every form that a trailing boundary would break is absent from it.
+// These are the forms, asserted directly.
+func TestDNSIdentificationSurvivesTheNarrowing(t *testing.T) {
+	resolver := fingerprint.GetFingerprintResolver()
+
+	identifiedAsBIND := func(t *testing.T, banner string, port int) bool {
+		t.Helper()
+		result, err := resolver.Resolve(context.Background(), fingerprint.Input{
+			Protocol: ResolverProtocolHint("", "tcp", port, banner), Banner: banner, Port: port,
+		})
+		return err == nil && result.Product == "BIND"
+	}
+
+	for _, banner := range []string{
+		"9.16.23-RH BIND",
+		"bind 9.11.4-p2-redhat",
+		// Debian and Ubuntu spell the package bind9, with the version run
+		// straight onto it. A boundary after "bind" drops both.
+		"bind9 9.16.1-0ubuntu2",
+		"bind9.16.1",
+		"named-9.16.1",
+	} {
+		require.True(t, identifiedAsBIND(t, banner, 53), "BIND went unidentified: %q", banner)
+	}
+
+	// Not BIND, and each was reported as ISC BIND before the narrowing.
+	for _, banner := range []string{
+		"dnsmasq-2.85",
+		"powerdns authoritative server 4.7.3",
+	} {
+		require.False(t, identifiedAsBIND(t, banner, 53),
+			"a different DNS server was reported as BIND: %q", banner)
+	}
+}

--- a/pkg/modules/parse/protocol_hint_vocabulary_test.go
+++ b/pkg/modules/parse/protocol_hint_vocabulary_test.go
@@ -1,0 +1,147 @@
+package parse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cyprob/cyprob/pkg/fingerprint"
+)
+
+// A protocol hint no rule declares is worse than no hint at all: it is specific
+// enough to switch the resolver's fallback off, so it excludes every candidate
+// and the service resolves to nothing. The two vocabularies live in different
+// packages -- the hint table here, the rules in pkg/fingerprint -- and nothing
+// held them together, so five of them had drifted apart unnoticed.
+//
+// This test is the thing that was missing. It sweeps the entire port space
+// rather than a list of ports somebody thought of, because the list somebody
+// thinks of is how the last five got in.
+//
+// It has to live in this package: pkg/modules/parse imports pkg/fingerprint, so
+// the same assertion written over there is an import cycle.
+func TestPortHintsAreDeclaredBySomeRule(t *testing.T) {
+	declared := make(map[string]bool)
+	for _, protocol := range fingerprint.DeclaredProtocols() {
+		declared[protocol] = true
+	}
+	require.NotEmpty(t, declared, "the shipped rules must declare protocols")
+
+	for port := 1; port <= 65535; port++ {
+		hint := detectProtocolFromPort(port)
+		if hint == "" {
+			// Deliberate: it puts the resolver into the mode that tries
+			// every rule, which is the right answer for a port whose
+			// service no rule identifies.
+			continue
+		}
+		require.True(t, declared[hint],
+			"port %d hints %q, which no rule declares -- the resolver will "+
+				"exclude every candidate and identify nothing on that port",
+			port, hint)
+	}
+}
+
+// The hint the resolver is actually handed is the normalized one, and
+// normalization can introduce a value the table never returned: https survived
+// it until this was written.
+func TestNormalizedHintsAreDeclaredBySomeRule(t *testing.T) {
+	declared := make(map[string]bool)
+	for _, protocol := range fingerprint.DeclaredProtocols() {
+		declared[protocol] = true
+	}
+
+	// Responses chosen to reach both sides of the https branch and the
+	// generic-transport path, since those are what normalization keys on.
+	responses := []string{
+		"",
+		"HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\n\r\n",
+		"\x16\x03\x01\x00\xa5\x01",
+		"SSH-2.0-OpenSSH_9.6p1\r\n",
+		"220 mail.example.com ESMTP Postfix\r\n",
+	}
+
+	for _, serviceName := range []string{"", "tcp", "udp", "https"} {
+		for _, transport := range []string{"tcp", "udp"} {
+			for port := 1; port <= 65535; port++ {
+				for _, response := range responses {
+					hint := ResolverProtocolHint(serviceName, transport, port, response)
+					if hint == "" {
+						continue
+					}
+					require.True(t, declared[hint],
+						"service=%q transport=%q port=%d yields hint %q, which no rule declares",
+						serviceName, transport, port, hint)
+				}
+			}
+		}
+	}
+}
+
+// The defect the vocabulary guard describes, stated as the answers it costs.
+// The port 445 row is the control: same banner, same rules, a hint that is
+// declared -- so what differs on 139 is the hint and nothing else.
+func TestHintDoesNotCostTheMatch(t *testing.T) {
+	resolver := fingerprint.GetFingerprintResolver()
+
+	for _, tc := range []struct {
+		name, serviceName, banner, want string
+		port                            int
+	}{
+		{
+			name: "Elasticsearch on 9200", serviceName: "", port: 9200,
+			banner: `{"name":"node1","cluster_name":"es","version":{"number":"8.11.1"}}`,
+			want:   "Elasticsearch",
+		},
+		{
+			name: "RabbitMQ on 5672", serviceName: "", port: 5672,
+			banner: "AMQP\x00\x00\x09\x01", want: "RabbitMQ",
+		},
+		{
+			name: "SMB on 139", serviceName: "", port: 139,
+			banner: "\x00\x00\x00\x85\xffSMBr\x00\x00\x00\x00 Windows Server 2019 6.3",
+			want:   "Windows SMB",
+		},
+		{
+			name: "SMB on 445, the control", serviceName: "", port: 445,
+			banner: "\x00\x00\x00\x85\xffSMBr\x00\x00\x00\x00 Windows Server 2019 6.3",
+			want:   "Windows SMB",
+		},
+		{
+			name: "SSH answering on 443", serviceName: "https", port: 443,
+			banner: "SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5\r\n", want: "OpenSSH",
+		},
+		{
+			name: "SMTP answering on 8443", serviceName: "https", port: 8443,
+			banner: "220 mail.example.com ESMTP Postfix (Ubuntu)\r\n", want: "Postfix",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hint := ResolverProtocolHint(tc.serviceName, "tcp", tc.port, tc.banner)
+
+			result, err := resolver.Resolve(context.Background(), fingerprint.Input{
+				Protocol: hint, Banner: tc.banner, Port: tc.port,
+			})
+			require.NoError(t, err, "hint %q excluded every rule", hint)
+			require.Equal(t, tc.want, result.Product)
+		})
+	}
+}
+
+// rpcbind is not BIND. The hint on port 111 was masking this: no rule declares
+// rpc, so nothing was ever a candidate, and dropping the dead hint would have
+// turned a missing answer into a wrong one -- which is worse for a scanner that
+// feeds product names into CVE correlation.
+func TestRPCBindIsNotIdentifiedAsBIND(t *testing.T) {
+	resolver := fingerprint.GetFingerprintResolver()
+	banner := "\x80\x00\x00\x64 rpcbind portmapper v2"
+
+	result, err := resolver.Resolve(context.Background(), fingerprint.Input{
+		Protocol: ResolverProtocolHint("", "tcp", 111, banner), Banner: banner, Port: 111,
+	})
+	if err == nil {
+		require.NotEqual(t, "BIND", result.Product,
+			"the substring bind inside rpcbind must not identify a DNS server")
+	}
+}

--- a/pkg/modules/parse/resolver_protocol_hint_test.go
+++ b/pkg/modules/parse/resolver_protocol_hint_test.go
@@ -26,9 +26,18 @@ func TestResolverProtocolHint(t *testing.T) {
 			want: "http",
 		},
 		{
-			name:        "https stays https when the response is not HTTP",
+			// Not "https": no rule declares it, so keeping it excluded every
+			// rule and the service resolved to nothing. TLS-but-not-HTTP says
+			// nothing about the protocol, and an empty hint says that.
+			name:        "https becomes unknown when the response is not HTTP",
 			serviceName: "https", transport: "tcp", port: 443, banner: "\x16\x03\x01\x00\xa5\x01",
-			want: "https",
+			want: "",
+		},
+		{
+			name:        "SSH answering on 443 is not hidden by the https hint",
+			serviceName: "https", transport: "tcp", port: 443,
+			banner: "SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5\r\n",
+			want:   "",
 		},
 		{
 			name:        "a named service is kept",


### PR DESCRIPTION
Closes #240.

## The defect, and one instance the issue did not find

A protocol hint naming something no rule declares is worse than no hint at all. It is specific enough to switch the resolver's fallback off, so every rule is filtered out and the port resolves to nothing — while an empty hint puts the resolver in the mode that tries every rule.

#240 found five, all in the port table. There is a sixth, and it arrives through normalization rather than the table:

```
443 / any   https  ->  kept as "https" whenever the response is not HTTP
```

No rule declares `https`. Measured on the shipped resolver:

```
SSH answering on 443       chain hint="https"  with hint: NO MATCH   without: OpenSSH
SMTP answering on 8443     chain hint="https"  with hint: NO MATCH   without: Postfix
real HTTP on 443 (control) chain hint="http"   with hint: nginx      without: nginx
```

The doc comment on `ResolverProtocolHint` already describes this failure in those words — *a hint of "https" matches no rule … and the service then looks unrecognized rather than mis-hinted*. Normalization handled only the half where the response looks like HTTP; the other half returned the value the comment warns about.

## What changed

```
5672/5671  rabbitmq       ->  amqp    the rule exists and declares amqp
9200/9300  elasticsearch  ->  http    both Elasticsearch rules declare http
139        netbios        ->  smb
135        msrpc          ->  (none)  no rule identifies the RPC endpoint mapper
111        rpc            ->  (none)  no rule identifies rpcbind
443/any    https          ->  (none)  when the response is not HTTP
```

Ports 135 and 111 get no hint rather than a renamed one, because no rule identifies those services at all. An empty hint states that; a hint no rule declares states the opposite while excluding everything.

Same banner, before and after, with the port 445 row as the control — a hint that *is* declared, so what differs on 139 is the hint and nothing else:

```
port=9200  hint="elasticsearch"  before: NO MATCH   after: Elasticsearch
port=5672  hint="rabbitmq"       before: NO MATCH   after: RabbitMQ
port=139   hint="netbios"        before: NO MATCH   after: Windows SMB
port=445   hint="smb"            before: Windows SMB  after: Windows SMB   <- control
```

## Why a rule change is in here

Dropping the dead hint on port 111 would have introduced a wrong answer. `dns.bind` matches `bind|named|dns`, so the substring inside `rpcbind` identifies it as **ISC BIND at 0.90** the moment the hint stops excluding every rule. A missing answer becoming a wrong one is a regression for a scanner that feeds product names into CVE correlation, so the narrowing is part of this change rather than a follow-up:

```
match: 'bind|named|dns'  ->  '\bbind|\bnamed|\bdns\b'
```

**And it was overdue independently of port 111.** The same substring match was reporting two other DNS servers as ISC BIND:

```
dnsmasq-2.85                          before: ISC/BIND 0.90    after: not BIND
powerdns authoritative server 4.7.3   before: ISC/BIND 0.90    after: not BIND
rpcbind portmapper v2                 before: ISC/BIND 0.85    after: no match
```

dnsmasq and PowerDNS are DNS servers with their own CVE histories, on far more hosts than rpcbind, and both were being handed to correlation under the wrong product name at higher confidence than the case that prompted this.

The leading boundary does the excluding — `rpcbind` has no word break between `c` and `b`. A trailing boundary after `bind` was in the first version of this branch and cost real coverage: Debian and Ubuntu spell the package `bind9`, version run straight onto it, and that form stopped matching. It is gone. The boundary after `dns` stays, or `dnsmasq` and `powerdns` return.

Swept over the corpus, both rule sets, all ports and hints:

```
probes=1932   verdict changes=0   lost=0   gained=0
control: rpcbind banner  before=ISC/BIND 0.85  after=no match
```

Zero is only informative if the corpus exercises the rule, so that was measured: **four corpus banners match the bind pattern, and all four still match after narrowing**.

But that zero is blind to the thing review caught, and worth saying plainly: all four corpus banners carry the token as a separate word, so **no banner in the corpus distinguishes the two candidate patterns**. The `bind9` regression could not have shown up in it. A correct zero over data that cannot produce the condition — the same shape as the soft-exclude sweep in #239, and the reason the spellings are asserted directly in a test rather than left to the sweep.

## The guard is the more valuable half

Nothing asserted that the hint vocabulary and the rule vocabulary agreed, and they had drifted apart in six places. `fingerprint.DeclaredProtocols()` is added so the check can be written, and the test sweeps **the entire port space** rather than a list of ports somebody thought of — that list is how these got in.

It has to live in `pkg/modules/parse`: that package imports `pkg/fingerprint`, so the same assertion written on the other side is an import cycle.

A second guard covers the normalized hint, since normalization can introduce a value the table never returned — which is exactly what `https` did.

## Two tests asserted the defect

Both are updated, and both are worth noting because they passed the whole time:

- `TestDetectProtocolFromPort` listed the five orphan hints as the expected values.
- `TestFingerprintParserModule_HTTPSResolverProtocolNotNormalizedForNonHTTPResponse` asserted the resolver is handed `https` for a non-HTTP response. **Its own fixture is an SMTP greeting on port 443** — the case being lost was sitting inside the test that locked the behaviour in.

## Verification

| check | result |
|---|---|
| `go test ./...` | passes |
| `golangci-lint run ./...` (v2.12.2, CI-pinned) | 0 issues |
| `go vet` on both touched packages | clean |
| mutation: restore any of the six hints | guard fails |
| mutation: restore `bind|named|dns` | guard fails |

Every mutation was checked for compiling before its result was read — a mutation that does not build reads exactly like one nothing catches.

## Not included

The `.golangci.yaml` and probe-catalog vocabularies are untouched. `data/probes.yaml` declares `msrpc`, `netbios` and `rpc` as probe protocols; those are probe identifiers rather than resolver hints and no longer reach the resolver after this change, but the same drift could recur there and it is not covered by this guard.
