### PR TITLE
ci: report vulnerabilities a change makes reachable, and watch main for new ones

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -72,6 +72,39 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+  vulncheck:
+    name: Vulnerability Scan (delta)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          # Both the base and the head commit have to be present locally: the
+          # scan below builds each in its own worktree, and a shallow clone has
+          # neither.
+          fetch-depth: 0
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+
+      # Reports what this pull request ADDS to the set of vulnerabilities
+      # reachable from our own code, and deliberately does not fail on it yet.
+      #
+      # Set GOVULNCHECK_BLOCK=1 to make additions fail the job. It is off until
+      # this has run for two weeks without a false positive (cyprob/cyprob#247).
+      # A gate nobody has watched is worse than no gate, because it is trusted
+      # without being looked at — and this repository runs with `strict: false`,
+      # so a required check is less required than it looks anyway.
+      - name: govulncheck (delta against base)
+        run: |
+          ./scripts/govulncheck-delta.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"
+
   fingerprint-db-validation:
     name: Validate Fingerprint Database
     runs-on: ubuntu-latest

--- a/.github/workflows/vulncheck-schedule.yaml
+++ b/.github/workflows/vulncheck-schedule.yaml
@@ -1,0 +1,114 @@
+name: Vulnerability Watch
+
+# The delta gate on pull requests answers "did this change add one". It cannot
+# answer "did one appear", because the code does not move when an advisory is
+# published — and that is the case that had gone unmeasured for a year here.
+#
+# So: same tool, different trigger, different verdict. This one never fails a
+# build. It opens an issue, or updates the one it opened before, and closes it
+# when the tree comes back clean.
+
+on:
+  schedule:
+    # Daily. The database moves on its own schedule and nothing here is urgent
+    # enough to want a red mark before someone is awake to read it.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  GO_VERSION: '1.26.6'
+  ISSUE_TITLE: 'Reachable vulnerabilities on main'
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+
+      - name: Scan main
+        id: scan
+        run: |
+          set -euo pipefail
+          # --scan never fails on findings, so a non-zero here means the scan
+          # itself broke and the result below must not be read as "clean".
+          ./scripts/govulncheck-delta.sh --scan "${GITHUB_SHA}" > /tmp/reachable.txt
+          COUNT="$(grep -c '[^[:space:]]' /tmp/reachable.txt || true)"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "found ${COUNT} reachable"
+
+      - name: Open, update or close the issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COUNT: ${{ steps.scan.outputs.count }}
+        run: |
+          set -euo pipefail
+
+          # `gh issue list` prints nothing and exits 0 when there is no match, so
+          # an empty NUMBER means "none open" rather than "the query failed".
+          #
+          # The first match is taken inside jq rather than with `| head -1`: this
+          # block runs under `set -euo pipefail`, and a reader that leaves early
+          # makes the writer take SIGPIPE, which pipefail then turns into a dead
+          # step with nothing printed. Same shape cost three rounds in
+          # cyprob/cyprob-appliance-builder#7.
+          NUMBER="$(gh issue list --state open --search "\"${ISSUE_TITLE}\" in:title" \
+                    --json number,title \
+                    --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | first // empty")"
+
+          if [ "${COUNT}" = "0" ]; then
+            if [ -n "${NUMBER}" ]; then
+              gh issue close "${NUMBER}" --comment \
+                "Nothing reachable from this code as of \`${GITHUB_SHA}\`. Reopened automatically if that changes."
+              echo "closed #${NUMBER}"
+            else
+              echo "clean, and no issue open"
+            fi
+            exit 0
+          fi
+
+          {
+            echo "\`govulncheck\` reports ${COUNT} vulnerabilities reachable from our own code on \`main\`."
+            echo ""
+            echo "Commit: \`${GITHUB_SHA}\`"
+            echo ""
+            # if/then rather than `[ -n "$ID" ] && echo`. Measured, because the
+            # obvious claim is wrong: under `set -e` a false test in an AND-list
+            # does NOT kill the loop — bash exempts every element of an AND-OR
+            # list except the one after the final `&&`, so the loop runs to
+            # completion either way.
+            #
+            # What it does do is leave 1 as the exit status. Harmless here, fatal
+            # the moment such a list is the LAST command of a step, which is how
+            # it killed a step in cyprob/cyprob-appliance-builder#6. if/then
+            # cannot acquire that property by being moved.
+            while IFS= read -r ID; do
+              if [ -n "${ID}" ]; then
+                echo "- [${ID}](https://pkg.go.dev/vuln/${ID})"
+              fi
+            done < /tmp/reachable.txt
+            echo ""
+            echo "Reachable means our code calls the affected symbol, not merely that the module is in the graph."
+            echo "Nothing changed in this repository to cause this — an advisory was published, or the toolchain moved."
+            echo ""
+            echo "Updated by \`.github/workflows/vulncheck-schedule.yaml\` (run ${GITHUB_RUN_ID})."
+          } > /tmp/body.md
+
+          if [ -n "${NUMBER}" ]; then
+            gh issue edit "${NUMBER}" --body-file /tmp/body.md
+            echo "updated #${NUMBER}"
+          else
+            gh issue create --title "${ISSUE_TITLE}" --body-file /tmp/body.md
+            echo "opened a new issue"
+          fi

--- a/scripts/govulncheck-delta.sh
+++ b/scripts/govulncheck-delta.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Report vulnerabilities that are REACHABLE FROM THIS CODE and that a change
+# introduces, by scanning two refs in one process.
+#
+# Why two refs, in one run:
+#
+#   govulncheck queries the live vulnerability database. A base result cached
+#   from an earlier run is therefore not comparable with a head result produced
+#   now -- the difference between them would include every advisory published in
+#   between, and the gate would report findings the change did not cause. Both
+#   scans happen here, seconds apart, against the same snapshot.
+#
+# Why the delta rather than the absolute count:
+#
+#   An advisory published today can make a pull request red without its author
+#   having touched anything. A check that does that gets called flaky and then
+#   gets switched off. Gating on what the change ADDS removes that failure mode
+#   instead of trading against it. Database drift is real and still needs
+#   answering -- it belongs to the scheduled run on main (--scan), not here.
+#
+# Usage:
+#   govulncheck-delta.sh <base-ref> <head-ref>   compare two refs, report additions
+#   govulncheck-delta.sh --scan <ref>            list what is reachable at one ref
+#
+# Exit status:
+#   0  no additions (or --scan, which never fails on findings)
+#   1  additions found AND GOVULNCHECK_BLOCK=1
+#   2  usage or environment error
+#
+# GOVULNCHECK_BLOCK is off by default on purpose: this gate has no track record
+# in this repository yet, and a blocking check whose behaviour nobody has watched
+# is worse than no check, because it is trusted without being looked at. Turn it
+# on once it has run for two weeks without a false positive.
+
+set -euo pipefail
+
+GOVULNCHECK_VERSION="${GOVULNCHECK_VERSION:-latest}"
+GOVULNCHECK_BLOCK="${GOVULNCHECK_BLOCK:-0}"
+
+usage() {
+  echo "usage: $0 <base-ref> <head-ref>" >&2
+  echo "       $0 --scan <ref>" >&2
+  exit 2
+}
+
+# reachable_ids <worktree-dir>
+#
+# Prints the sorted OSV ids that this code actually CALLS, one per line.
+#
+# The filter is the whole point. govulncheck reports a finding for every
+# advisory against a module in the graph, and separately for the subset our code
+# reaches; the text output describes the difference as "your code doesn't appear
+# to call these". Both kinds arrive as `finding` records, so comparing raw osv
+# ids gates on the module-level set -- far larger, and mostly advisories against
+# dependencies nobody calls. A finding is reachable when the first frame of its
+# trace names a `function`; module-level findings have none.
+#
+# `-format json` exits 0 whether or not anything is found -- unlike the text
+# mode, which exits 3 on findings. So the exit status here means "the scan ran",
+# never "the tree is clean", and nothing downstream may read it as the latter.
+reachable_ids() {
+  local dir="$1" out="$2"
+
+  if ! (cd "$dir" && GOFLAGS=-mod=mod go run "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}" \
+        -format json ./... > "$out" 2>"${out}.err"); then
+    echo "govulncheck failed in ${dir}:" >&2
+    tail -20 "${out}.err" >&2
+    exit 2
+  fi
+
+  jq -r 'select(.finding != null)
+         | select(.finding.trace[0].function != null)
+         | .finding.osv' < "$out" | sort -u
+}
+
+# scan_ref <ref> <label>
+#
+# Scans a ref in its own worktree, so neither side depends on the state of the
+# checkout this runs from and the two scans cannot contaminate each other.
+scan_ref() {
+  local ref="$1" label="$2" wt json started elapsed
+  wt="$(mktemp -d)"
+  json="$(mktemp)"
+
+  git worktree add --detach -q "$wt" "$ref"
+  started="$SECONDS"
+  reachable_ids "$wt" "$json"
+  elapsed="$(( SECONDS - started ))"
+  echo "scanned ${label} (${ref}) in ${elapsed}s" >&2
+
+  git worktree remove --force "$wt"
+  rm -f "$json" "${json}.err"
+}
+
+main() {
+  command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+
+  if [[ "${1:-}" == "--scan" ]]; then
+    [[ $# -eq 2 ]] || usage
+    scan_ref "$2" "ref"
+    return 0
+  fi
+
+  [[ $# -eq 2 ]] || usage
+
+  local base_ids head_ids added
+  base_ids="$(scan_ref "$1" "base")"
+  head_ids="$(scan_ref "$2" "head")"
+
+  # comm needs sorted input and both sides may legitimately be empty, which is
+  # why they are passed as process substitutions of already-sorted output rather
+  # than files that might not exist.
+  added="$(comm -13 <(echo "$base_ids") <(echo "$head_ids") | grep -v '^$' || true)"
+
+  echo "base reachable: $(echo "$base_ids" | grep -c '[^[:space:]]' || true)"
+  echo "head reachable: $(echo "$head_ids" | grep -c '[^[:space:]]' || true)"
+
+  if [[ -z "$added" ]]; then
+    echo "no vulnerability reachable from this code was introduced by this change"
+    return 0
+  fi
+
+  echo ""
+  echo "introduced by this change:"
+  while IFS= read -r id; do
+    echo "  ${id}"
+  done <<< "$added"
+  echo ""
+  echo "https://pkg.go.dev/vuln/ carries the details for each id."
+
+  if [[ "$GOVULNCHECK_BLOCK" == "1" ]]; then
+    return 1
+  fi
+  echo ""
+  echo "reporting only: GOVULNCHECK_BLOCK is not set."
+  return 0
+}
+
+main "$@"


### PR DESCRIPTION
Closes #247 for the CE side. Reporting only, as decided — the switch is in the file, not in anyone's memory.

## Shape

| | trigger | verdict |
|---|---|---|
| `vulncheck` job in `validate.yaml` | pull request | reports what the change **adds** |
| `vulncheck-schedule.yaml` | daily on `main` + manual | opens / updates / closes an issue |

Both call `scripts/govulncheck-delta.sh`. Base and head are scanned **in the same process**, seconds apart, so both see the same database snapshot — a cached base result would make the delta include everything published in between, which is the noise the design exists to avoid.

## Reachability is read from the trace

```
jq 'select(.finding.trace[0].function != null) | .finding.osv'
```

Confirmed on this tree rather than assumed. On `main` today `govulncheck` emits two `finding` records, both with `trace[0].function == null`, and the text output says *"0 vulnerabilities … 2 in modules you require"*. So the module-level set is exactly what the null-function findings are, and comparing raw ids would gate on it.

## Verified against real history

`b6df488` (before the toolchain fix) has three reachable; `main` has none. Both directions run:

```
base=b6df488  head=main     ->  base 3, head 0, no additions,            rc=0
base=main     head=b6df488  ->  base 0, head 3, lists GO-2026-5037,
                                 GO-2026-5039, GO-2026-5856,             rc=0
                                 same with GOVULNCHECK_BLOCK=1           rc=1
--scan main     -> (nothing)
--scan b6df488  -> the three ids
no args / --scan without a ref -> rc=2
```

## Two traps found by running it, not reading it

**`-format json` always exits 0.** The text mode exits 3 on findings; the JSON mode exits 0 either way. So the exit status means "the scan ran", never "the tree is clean" — `govulncheck -format json ./... && echo clean` is wrong and looks right. Written into the script.

**One of my own comments was false and is now corrected in place.** I replaced `[ -n "$ID" ] && echo …` inside a loop with `if/then`, and wrote that the AND-list "kills the loop on the first blank line". It does not — bash exempts every element of an AND-OR list except the one after the final `&&`, so the loop completes:

```
blank first, then a finding  -> survived, printed the finding
blank last                   -> survived
```

What it actually does is leave `1` as the exit status, which is fatal only when such a list is the **last command of a step** — the shape that killed a step in cyprob/cyprob-appliance-builder#6. `if/then` is still right, because it cannot acquire that property by being moved later, but the comment now says the true reason.

## Cost — measured locally, CI number to follow

Locally, warm module cache: 3s + 2s. That is not the CI number and should not be quoted as one; the first run here will include a cold cache and `go run govulncheck@latest`. I will post the CI wall-clock against Unit Tests once this has run, per the sequencing agreed in #247. If it lands badly, `-scan module` on the PR side is the fallback — cheap, no reachability analysis — but that decision belongs after the measurement, not before it.

## Not in this change

**EE.** The eight reachable vulnerabilities are in EE, not here — CE is at zero since #246. The gate does not close them; cyprob/cyprob-ee#108 does, and until it lands the drift job would open an issue duplicating it on its first run. So: prove the shape here, add it to EE after #108.

**Blocking.** `GOVULNCHECK_BLOCK=1` flips it. The condition for flipping is written next to the job: two weeks without a false positive. Worth noting this repository runs `strict: false`, so a required check is less required than it looks regardless.
