### PR TITLE
docs(ci): record that enabling the govulncheck block also requires pinning the tool version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -95,7 +95,10 @@ jobs:
       # reachable from our own code, and deliberately does not fail on it yet.
       #
       # Set GOVULNCHECK_BLOCK=1 to make additions fail the job. It is off until
-      # this has run for two weeks without a false positive (cyprob/cyprob#247).
+      # this has run for two weeks without a false positive (cyprob/cyprob#247),
+      # and the commit that sets it must also pin GOVULNCHECK_VERSION — a
+      # floating tool version is harmless while this reports and is a way to
+      # stop CI from outside git once it blocks. See scripts/govulncheck-delta.sh.
       # A gate nobody has watched is worse than no gate, because it is trusted
       # without being looked at — and this repository runs with `strict: false`,
       # so a required check is less required than it looks anyway.

--- a/scripts/govulncheck-delta.sh
+++ b/scripts/govulncheck-delta.sh
@@ -32,6 +32,16 @@
 # in this repository yet, and a blocking check whose behaviour nobody has watched
 # is worse than no check, because it is trusted without being looked at. Turn it
 # on once it has run for two weeks without a false positive.
+#
+# TURNING IT ON IS TWO CHANGES, NOT ONE. Pin GOVULNCHECK_VERSION in the same
+# commit that sets GOVULNCHECK_BLOCK=1.
+#
+# A floating `latest` is right while this only reports: the newest advisory data
+# is what you want, and base and head share one process, so both sides see the
+# same tool and the delta stays consistent. Once it blocks, that same float is a
+# tool upgrade that can stop CI on a day no commit in this repository changed
+# anything — and nothing in git says what moved, so nobody can find it. The
+# variable already exists; only its default has to change.
 
 set -euo pipefail
 


### PR DESCRIPTION
Comment-only follow-up to #250, raised by hq during review.

`GOVULNCHECK_VERSION` floats on `latest`. That is right while the job only reports — the newest advisory data is the point, and base and head share one process, so both sides see the same tool and the delta stays consistent.

Once `GOVULNCHECK_BLOCK=1`, the same float is a tool upgrade that can stop CI on a day no commit in this repository changed anything, with nothing in git recording what moved. So enabling the block is two changes, not one, and the condition now sits next to the two-week trigger in both places it is stated:

- `scripts/govulncheck-delta.sh` — the header that explains why the block is off
- `.github/workflows/validate.yaml` — the comment on the job itself

No behaviour change: `+15/-2`, all of it comments. The variable already exists; only its default would move.

## First scheduled run, since it was an open question on #250

Now that the workflow is on the default branch, `workflow_dispatch` accepts it, so this did not have to wait for 06:00 — [run 31741546322](https://github.com/cyprob/cyprob/actions/runs/31741546322):

```
scanned ref (c11dcc6d) in 7s
found 0 reachable
clean, and no issue open
```

That confirms the scan step, the count extraction and the `gh issue list --search` query against the real API. It does **not** confirm `issues: write`: with zero findings and no issue open, the run took the branch that writes nothing. The write path stays proven only against the local stub until a real finding appears or someone opens an issue with that exact title.