### PR TITLE
fix(ui): move tailwindcss and its vite plugin to devDependencies — pnpm audit --prod drops 32 findings to 6

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,6 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.3",
     "@tanstack/react-router": "^1.131.16",
     "@tanstack/react-table": "^8.21.3",
@@ -51,7 +50,6 @@
     "recharts": "^3.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.12",
     "tw-animate-css": "^1.3.6",
     "zod": "^4.0.17",
     "zustand": "^5.0.7"
@@ -59,6 +57,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@faker-js/faker": "^9.9.0",
+    "@tailwindcss/vite": "^4.1.12",
     "@tanstack/eslint-plugin-query": "^5.83.1",
     "@tanstack/react-query-devtools": "^5.85.3",
     "@tanstack/react-router-devtools": "^1.131.16",
@@ -75,6 +74,7 @@
     "knip": "^5.62.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "tailwindcss": "^4.1.12",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.11"

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tailwindcss/vite':
-        specifier: ^4.1.12
-        version: 4.1.12(vite@7.1.11(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@tanstack/react-query':
         specifier: ^5.85.3
         version: 5.85.3(react@19.1.1)
@@ -122,9 +119,6 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
-      tailwindcss:
-        specifier: ^4.1.12
-        version: 4.1.12
       tw-animate-css:
         specifier: ^1.3.6
         version: 1.3.6
@@ -141,6 +135,9 @@ importers:
       '@faker-js/faker':
         specifier: ^9.9.0
         version: 9.9.0
+      '@tailwindcss/vite':
+        specifier: ^4.1.12
+        version: 4.1.12(vite@7.1.11(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@tanstack/eslint-plugin-query':
         specifier: ^5.83.1
         version: 5.83.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
@@ -189,6 +186,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
         version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2))(prettier@3.6.2)
+      tailwindcss:
+        specifier: ^4.1.12
+        version: 4.1.12
       typescript:
         specifier: ~5.9.2
         version: 5.9.2


### PR DESCRIPTION
Two lines move from `dependencies` to `devDependencies` in `ui/package.json`. Found while measuring for #252.

## Why these two, and not the third

| package | where it is used | verdict |
|---|---|---|
| `@tailwindcss/vite` | `vite.config.ts:4` — imported by the build config | build tool → `devDependencies` |
| `tailwindcss` | `src/styles/index.css:1` — `@import 'tailwindcss'`, processed by that plugin | build tool → `devDependencies` |
| `tailwind-merge` | `src/lib/utils.ts:2` — `import { twMerge }`, runs in the browser | **stays** in `dependencies` |

No file under `ui/src` imports `tailwindcss` or `@tailwindcss/vite` as a module.

## This is not a new rule, it is two lines out of step with the rest

The repository already classifies build plugins correctly everywhere else:

```
devDependencies:  @tanstack/router-plugin, @vitejs/plugin-react-swc,
                  prettier-plugin-tailwindcss, vite, typescript, eslint
```

`@tanstack/router-plugin` is the closest parallel — a vite plugin, in `devDependencies`, where it belongs.

## What it changes, measured

`pnpm audit --prod` on this branch versus `main` at `7fae5153`:

```
before   32 advisories    9 moderate, 21 high, 2 critical
after     6 advisories              5 high, 1 critical
```

The 26 that disappear are `vite`, `rollup`, `postcss`, `tar`, `nanoid`, `picomatch` and the build-chain copy of `seroval` — build tooling that was being reported as shipping code.

The 6 that remain are all `seroval`, and they are real:

```
$ pnpm why seroval --prod
seroval@1.3.2
├─┬ @tanstack/router-core@1.131.16
│ └─┬ @tanstack/react-router@1.131.16
│   └── vulntor-ui@dev (dependencies)
```

`@tanstack/react-router` ships. So after this change `--prod` reports one package with advisories instead of seven, and that one is a genuine finding rather than noise.

**Control:** the full tree is unchanged at **61** advisories before and after. Nothing was removed from the dependency graph — this only moves where two of them are counted.

## Build is unaffected, verified rather than assumed

`make build-ui` on this branch produces the same CSS file with the same content hash:

```
before  pkg/ui/dist/assets/index-DFX59qXj.css  87263 bytes
after   pkg/ui/dist/assets/index-DFX59qXj.css  87263 bytes
```

Same filename means the same content hash, so Tailwind still ran and emitted identical output. Had the plugin gone missing, that file would be a fraction of the size or absent.

## Why it matters beyond tidiness

`#252` proposes a vulnerability gate for `ui/`. A gate that starts from 32 findings, none of which are runtime problems, is a gate people stop reading within a week — and nobody announces that, they just stop looking. Starting from 6 real ones is a signal. This is a prerequisite for that issue being worth implementing, which is why it is a separate one-line change rather than part of it.

## Note for reviewers

Local `pnpm` is 11.x and gates postinstall scripts behind an approval prompt; CI pins `pnpm/action-setup@v4` with `version: 9`, which has no such gate. The lockfile was regenerated with `--lockfile-only` and the build verified separately. `pnpm-workspace.yaml`, which pnpm 11 writes for that approval, is deliberately not committed.
