### PR TITLE
fix(ci): an unchanged validation metric is reported as a regression

### DIFF
--- a/scripts/compare-validation-metrics.sh
+++ b/scripts/compare-validation-metrics.sh
@@ -29,6 +29,21 @@ percent_change() {
   awk -v b="$base" -v n="$new" 'BEGIN { printf("%.2f", ((n-b)/b)*100) }'
 }
 
+# percent_change emits the literal "0" only from its divide-by-zero path. Every
+# real metric goes through printf "%.2f" and arrives as "0.00", which a string
+# comparison against "0" does not match — so an unchanged metric fell through to
+# the regression branch and was labelled a regression while nothing had moved.
+#
+# Comparing numerically recognises an unchanged metric whatever it is formatted
+# as, including "-0.00". "inf" is rejected first: it is a sentinel, not a
+# number, and how awk reads it is implementation-defined — some parse it as
+# infinity, some as 0, and the second reading would label a metric that went
+# from nothing to something as unchanged.
+is_no_change() {
+  [[ "$1" == "inf" ]] && return 1
+  awk -v c="$1" 'BEGIN{exit !(c==0)}'
+}
+
 metrics=("False Positive Rate" "True Positive Rate" "Precision" "F1 Score")
 # Use name-mangled variables instead of associative arrays for macOS bash 3.2 compatibility
 for k in "${metrics[@]}"; do
@@ -70,12 +85,12 @@ for k in "${metrics[@]}"; do
   change=$(percent_change "$b" "$n")
   arrow="↑"; color="✅ Improved"; regressed=0
   # Neutral case: baseline==0 and pr==0
-  if [[ "$change" == "0" ]]; then
+  if is_no_change "$change"; then
     arrow="→"; color="OK"; regressed=0
   fi
   if [[ "$k" == "False Positive Rate" ]]; then
     # Lower is better
-    if [[ "$change" == "0" ]]; then
+    if is_no_change "$change"; then
       arrow="→"; color="OK"; regressed=0
     elif [[ "$change" == "inf" ]]; then
       arrow="↑"; color="❌ Regressed"; regressed=1
@@ -86,7 +101,7 @@ for k in "${metrics[@]}"; do
     fi
   else
     # Higher is better
-    if [[ "$change" == "0" ]]; then
+    if is_no_change "$change"; then
       arrow="→"; color="OK"; regressed=0
     elif [[ "$change" == "inf" ]]; then
       arrow="↑"; color="✅ Improved"; regressed=0


### PR DESCRIPTION
Found while reading the baseline comparison on #255, reported there, and split out because it is a different file and a different concern.

## The defect

`percent_change` emits the literal `0` **only** from its divide-by-zero path:

```sh
if awk -v b="$base" 'BEGIN{exit !(b==0)}'; then
  if awk -v n="$new" 'BEGIN{exit !(n==0)}'; then
    echo "0"; return
```

Every real metric falls through to the formatted branch and arrives as `0.00`:

```sh
awk -v b="$base" -v n="$new" 'BEGIN { printf("%.2f", ((n-b)/b)*100) }'
```

All three no-change guards compared the **string**:

```sh
if [[ "$change" == "0" ]]; then
  arrow="→"; color="OK"; regressed=0
fi
```

`"0.00" != "0"`, so an unchanged metric skipped the guard, failed `c > 0`, and landed in the `else` — labelled a regression with `regressed=1` set.

Reproduced directly:

```
base=100      new=100      change=[0.00]    matches =="0" ?  NO
base=0.9138   new=0.9138   change=[0.00]    matches =="0" ?  NO
base=0        new=0        change=[0]       matches =="0" ?  yes
base=100      new=90       change=[-10.00]  matches =="0" ?  NO
```

## Seen on a real pull request

#255 regressed nothing. Its comparison table said otherwise:

```
| False Positive Rate | 0.00   | 0.00   | 0% →     | OK           |
| True Positive Rate  | 84.13  | 84.25  | 0.14% ↑  | ✅ Improved  |
| Precision           | 100.00 | 100.00 | 0.00% ↓  | ❌ Regressed |
| F1 Score            | 0.9138 | 0.9145 | 0.08% ↑  | ✅ Improved  |
```

Only the first row is right for the right reason — its baseline is 0, which is the one case the guard catches.

## Why this is a label bug today and a build bug later

The hard-fail step requires the magnitude to exceed the threshold:

```sh
if awk -v c="$change" -v t="$threshold" 'BEGIN{c=(c<0)?-c:c; exit !(c>t)}'; then
  status=1
fi
```

`0.00 > 5` is false, so the build stays green. But `regressed=1` is set regardless, so the moment anyone tightens `threshold=5` toward zero — a reasonable thing to want from a validation gate — **every pull request fails**, including ones that change nothing.

## The fix

Compare numerically, which recognises an unchanged metric however it is formatted, including `-0.00`:

```sh
is_no_change() {
  [[ "$1" == "inf" ]] && return 1
  awk -v c="$1" 'BEGIN{exit !(c==0)}'
}
```

`inf` is rejected **before** the numeric comparison and that ordering is load-bearing: it is a sentinel rather than a number, and how awk reads it is implementation-defined. Where it parses as `0`, a metric that went from nothing to something would be reported as unchanged — turning a genuine signal into silence, which is worse than the bug being fixed.

## Verified against the previous script, not reasoned about

Both versions driven by synthetic logs in the real format, across every branch:

| case | before | after |
|---|---|---|
| **unchanged, non-zero baseline** | ❌ Regressed | **OK** |
| real regression over 5% | exit 1 | exit 1 |
| small regression under threshold | ❌ Regressed | ❌ Regressed |
| improvement | ✅ Improved | ✅ Improved |
| zero to non-zero (`inf`) | ✅ Improved | ✅ Improved |
| non-zero to zero | exit 1 | exit 1 |

Exactly one row changes, and it is the one the bug produced. Exit codes are identical everywhere.

Also run against the actual numbers from #255: `Precision 100.00 → 100.00` now reads `0.00% → OK`, and the other three rows are untouched.

`shellcheck` clean; `scripts/validate-shell-script.sh` passes.

## Note

This workflow only runs on pull requests touching `pkg/fingerprint/**`, so this PR does not exercise it. The evidence above is the script run directly.
