### PR TITLE
ci: take the Go version out of the build check's name, so a bump stops blocking itself

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,17 +117,21 @@ jobs:
     needs: test-unit
     strategy:
       matrix:
+        # The Go version is deliberately not a matrix dimension. GitHub appends
+        # matrix values to the job name, which makes them part of the status
+        # check's identity -- so a required check named after the Go version
+        # can never run again once the version changes, and every bump blocks
+        # itself with all checks green. See #248.
         os: [ubuntu-latest, macos-latest]
-        go-version: ['1.26.6']
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Set up pnpm


### PR DESCRIPTION
Closes #248.

## The defect

GitHub appends matrix values to a job name, so **a matrix dimension is part of the status check's identity**. `go-version` was a matrix dimension carrying a single value:

```yaml
      matrix:
        os: [ubuntu-latest, macos-latest]
        go-version: ['1.26.6']       # -> Build Binary (ubuntu-latest, 1.26.6)
```

Branch protection matches required checks by name. So the moment the version changes, the required context becomes unreachable, and the PR that changes it blocks itself.

## Why this one is worth a PR rather than a shrug

**It has now happened twice, and both times the symptom pointed somewhere else.**

- `#225` — nine checks green, `BLOCKED`
- `#246` — nine checks green, `BLOCKED`, cleared by editing branch protection

Neither had a failing check to look at. A green PR that will not merge reads as a permissions problem, not as a naming one, and nothing anywhere says *this required check can no longer run*. That is the expensive part: the diagnosis costs more than the fix, and it costs it again on every bump.

The branch-protection edit that cleared #246 re-pinned the context to `1.26.6`, so the trap was reset rather than removed:

```
required context (before this PR): Build Binary (ubuntu-latest, 1.26.6)
```

## The change

`go-version` leaves the matrix and comes from `env.GO_VERSION`, which the other jobs in this file already read — so the version still lives in exactly one place, and that place is unchanged.

```
Build Binary (ubuntu-latest, 1.26.6)  ->  Build Binary (ubuntu-latest)
```

`os` stays a matrix dimension: it is a genuine dimension, both values run, and neither is going to be renamed by a routine bump.

## Cost

The Go version no longer appears in the check name, so it is not visible from the checks list at a glance. It is in the job log, in the step title, and in `env.GO_VERSION` at the top of the file. Against that: no manual intervention on any future bump.

## This PR is an instance of the defect it removes

It renames the required check, so the currently required context will not appear on it. **It needs the required context updated once — the last time — before it can merge.** Sequencing agreed with the repo admin: open the PR, let CI produce the new name, then swap the required context in one operation, then merge.

Known side effect, being handled deliberately rather than discovered later: the five open PRs are all built on `main` before this change and will produce the old name, so they will block until Dependabot rebases them. They are the last PRs this defect blocks.
