### PR TITLE
fix(discovery): detect raw ICMP capability by trying it, not by checking for root

### DIFF
--- a/pkg/modules/discovery/icmp_ping.go
+++ b/pkg/modules/discovery/icmp_ping.go
@@ -24,6 +24,37 @@ import (
 	"github.com/cyprob/cyprob/pkg/output"
 )
 
+// canOpenRawICMPSocket reports whether this process can actually send raw
+// ICMP, by attempting the thing itself rather than inferring it from identity.
+//
+// Being root is sufficient but not necessary: a process granted CAP_NET_RAW —
+// via setcap on the binary, or AmbientCapabilities on a systemd unit — can
+// open the socket while running as an ordinary user, which is how a scanner
+// should be deployed. Testing `os.Geteuid() != 0` misses that case entirely
+// and silently downgrades to unprivileged ping, which then fails on any host
+// where net.ipv4.ping_group_range excludes the running group (the default on
+// Ubuntu, where the range ships as "1 0" — an empty set).
+//
+// The failure that produced this check: an appliance with CAP_NET_RAW granted
+// still logged "socket: permission denied" for every target and reported
+// sent=0, because the module had already turned privileged mode off before
+// the first packet.
+// Indirected so tests can drive both branches without depending on whether
+// the test process happens to be root or hold CAP_NET_RAW.
+var canOpenRawICMPSocket = func() bool {
+	if os.Geteuid() == 0 {
+		return true
+	}
+	c, err := net.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return false
+	}
+	if closeErr := c.Close(); closeErr != nil {
+		log.Debug().Err(closeErr).Msg("closing ICMP capability probe socket")
+	}
+	return true
+}
+
 // ICMPPingDiscoveryResult stores the outcome of the ping discovery.
 type ICMPPingDiscoveryResult struct {
 	LiveHosts []string `json:"live_hosts"`
@@ -204,8 +235,8 @@ func (m *ICMPPingDiscoveryModule) Init(instanceID string, configMap map[string]a
 
 	// Handle privileged mode warning/downgrade for non-Windows OS
 	if cfg.Privileged && runtime.GOOS != "windows" {
-		if os.Geteuid() != 0 {
-			log.Warn().Msgf("Module '%s': Privileged ping requested, but process is not running as root. Falling back to unprivileged ping.", m.meta.Name)
+		if !canOpenRawICMPSocket() {
+			log.Warn().Msgf("Module '%s': Privileged ping requested, but this process cannot open a raw ICMP socket (not root and no CAP_NET_RAW). Falling back to unprivileged ping.", m.meta.Name)
 			cfg.Privileged = false
 		}
 	} else if cfg.Privileged && runtime.GOOS == "windows" {

--- a/pkg/modules/discovery/icmp_ping_test.go
+++ b/pkg/modules/discovery/icmp_ping_test.go
@@ -420,3 +420,47 @@ func TestICMPPingModuleFactory_ReturnsModule(t *testing.T) {
 		t.Errorf("Expected module Type '%s', got '%s'", engine.DiscoveryModuleType, meta.Type)
 	}
 }
+
+// TestICMPPingDiscoveryModule_Init_PrivilegedSurvivesCapabilityWithoutRoot
+// covers the case that made privileged ICMP unusable in production: a
+// non-root process that holds CAP_NET_RAW. The old check tested
+// os.Geteuid() != 0 and silently downgraded, so an appliance granted the
+// capability still logged "socket: permission denied" and sent zero packets.
+func TestICMPPingDiscoveryModule_Init_PrivilegedSurvivesCapabilityWithoutRoot(t *testing.T) {
+	original := canOpenRawICMPSocket
+	t.Cleanup(func() { canOpenRawICMPSocket = original })
+	canOpenRawICMPSocket = func() bool { return true }
+
+	mod := newICMPPingDiscoveryModule()
+	if err := mod.Init("instanceId", map[string]any{
+		"targets":    []string{"127.0.0.1"},
+		"privileged": true,
+	}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	if !mod.config.Privileged {
+		t.Error("privileged must stay enabled when a raw ICMP socket can be opened, even as a non-root process")
+	}
+}
+
+// TestICMPPingDiscoveryModule_Init_PrivilegedDowngradesWhenSocketUnavailable
+// keeps the protective half: when raw ICMP genuinely is not available, the
+// module must still fall back rather than attempt it and fail per-packet.
+func TestICMPPingDiscoveryModule_Init_PrivilegedDowngradesWhenSocketUnavailable(t *testing.T) {
+	original := canOpenRawICMPSocket
+	t.Cleanup(func() { canOpenRawICMPSocket = original })
+	canOpenRawICMPSocket = func() bool { return false }
+
+	mod := newICMPPingDiscoveryModule()
+	if err := mod.Init("instanceId", map[string]any{
+		"targets":    []string{"127.0.0.1"},
+		"privileged": true,
+	}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	if mod.config.Privileged {
+		t.Error("privileged must be downgraded when no raw ICMP socket can be opened")
+	}
+}


### PR DESCRIPTION
## Problem

The ICMP ping module gates privileged mode on `os.Geteuid() != 0` and silently downgrades when the process is not root:

```go
if cfg.Privileged && runtime.GOOS != "windows" {
    if os.Geteuid() != 0 {
        log.Warn()... "Falling back to unprivileged ping."
        cfg.Privileged = false
    }
}
```

That misses `CAP_NET_RAW` entirely — the capability a scanner should actually be deployed with, granted via `setcap` on the binary or `AmbientCapabilities=CAP_NET_RAW` on a systemd unit, rather than running the whole process as root.

## User / Ops Impact

Measured on the alpha appliance (`10.20.30.148`) today. The binary held `cap_net_raw=ep`, confirmed with `getcap`, and privileged mode was still switched off before the first packet:

```
Pinger.Run() error error="socket: permission denied"
Host did not respond  recv=0 sent=0
```

The downgrade sends every target through the unprivileged path, which then fails on any host where `net.ipv4.ping_group_range` excludes the running group. That range ships as `"1 0"` on Ubuntu — lower bound above upper bound, an empty set — so no group qualifies. Net effect: ICMP discovery cannot work at all on a stock appliance, whatever capability is granted.

Worse, it does not look broken from outside. The run still reported a live host and counted it under ICMP, because a separate ARP-confirmation path inside the same module contributed it. `sent=0` was only visible in debug-level logs.

## Fix Summary

Replace the identity test with the operation itself: attempt `net.ListenPacket("ip4:icmp", ...)`. Root short-circuits to `true`; every other process is decided by whether the syscall actually succeeds. This is the same approach the EE side already uses in its own privilege check (`internal/worker/scanner/adapter.go`, `hasICMPPrivilege`) — the two components were answering the same question two different ways, and only one of them was right.

Indirected through a package-level `var` so both branches are testable without depending on whether the test process happens to be root.

## Behavior Change

- A non-root process holding `CAP_NET_RAW` now keeps privileged mode instead of silently downgrading.
- Root behavior is unchanged.
- The protective half is unchanged: when raw ICMP genuinely is unavailable, privileged mode is still downgraded rather than attempted and failed per packet.

## Evidence

End-to-end on the appliance, against a **routed** target (`192.168.0.57`) chosen deliberately: ARP cannot cross a router, so it contributes nothing and ICMP is the only possible source of any change in the result.

```
patched CE, capability granted:
  before:  "Discovered 1 live hosts (icmp=0 tcp=1 arp=0)"
  after:   "Discovered 1 live hosts (icmp=1 tcp=1 arp=0)"
```

Same binary, same host, same flags — only the CE patch differs. On a local-segment target the two signals cannot be told apart, which is why the routed target is the one that settles it.

Unit tests cover both branches. The first was verified to fail against the pre-fix check by reinstating `os.Geteuid() != 0` and re-running:

```
--- FAIL: TestICMPPingDiscoveryModule_Init_PrivilegedSurvivesCapabilityWithoutRoot
```

`go build ./...`, `go vet ./pkg/modules/discovery/...`, `go test ./pkg/modules/discovery/ -count=1`, `golangci-lint run pkg/modules/discovery/...` — all clean.

## Risk / Rollback

Confined to one condition in module init. The probe opens and immediately closes a socket, once per module init, not per target. The plausible regression is an environment where opening the socket succeeds but sending still fails; that host previously got the unprivileged path and would now attempt privileged — the module's existing per-packet error handling already covers a failed send, and such a host is precisely the case the old check was wrong about anyway. Rollback is reverting this commit.

## Not in this PR

This unblocks the CE half only. Privileged ICMP still cannot be reached from a normal EE scan: `DiscoveryPrivileged` is only ever set by the EE debug CLI, and the real job path (`handleHostDiscovery`) never populates it. Granting the shipped binary or its unit the capability is likewise an appliance packaging change. Both tracked EE-side.