### PR TITLE
fix(discovery): report ARP-confirmed hosts separately so ICMP counts mean ICMP

### DIFF
--- a/pkg/modules/discovery/arp_liveness_test.go
+++ b/pkg/modules/discovery/arp_liveness_test.go
@@ -17,14 +17,14 @@ func TestAppendARPConfirmedHosts(t *testing.T) {
 
 	t.Run("keeps existing hosts and never removes any", func(t *testing.T) {
 		live := []string{"192.0.2.1", "192.0.2.2"}
-		got := appendARPConfirmedHosts(live, []string{"192.0.2.1", "192.0.2.2"}, &logger)
+		got, _ := appendARPConfirmedHosts(live, []string{"192.0.2.1", "192.0.2.2"}, &logger)
 		require.Subset(t, got, live, "hosts found by ICMP must survive")
 	})
 
 	t.Run("a host not in the target list is never added", func(t *testing.T) {
 		// Whatever the local neighbor table holds, nothing outside the requested
 		// targets may appear in the result.
-		got := appendARPConfirmedHosts(nil, []string{"198.51.100.77"}, &logger)
+		got, _ := appendARPConfirmedHosts(nil, []string{"198.51.100.77"}, &logger)
 		for _, host := range got {
 			require.Equal(t, "198.51.100.77", host,
 				"only requested targets may be reported as live")
@@ -32,7 +32,9 @@ func TestAppendARPConfirmedHosts(t *testing.T) {
 	})
 
 	t.Run("no targets means no additions", func(t *testing.T) {
-		require.Empty(t, appendARPConfirmedHosts(nil, nil, &logger))
+		combined, arpConfirmed := appendARPConfirmedHosts(nil, nil, &logger)
+		require.Empty(t, combined)
+		require.Empty(t, arpConfirmed)
 	})
 
 	t.Run("a host is not reported twice", func(t *testing.T) {
@@ -41,7 +43,7 @@ func TestAppendARPConfirmedHosts(t *testing.T) {
 			t.Skip("no neighbor table entries available on this host")
 		}
 		first := table[0]
-		got := appendARPConfirmedHosts([]string{first}, []string{first}, &logger)
+		got, _ := appendARPConfirmedHosts([]string{first}, []string{first}, &logger)
 		count := 0
 		for _, host := range got {
 			if host == first {
@@ -49,6 +51,40 @@ func TestAppendARPConfirmedHosts(t *testing.T) {
 			}
 		}
 		require.Equal(t, 1, count, "an ICMP-confirmed host must not be duplicated by ARP")
+	})
+
+	// The attribution split is the point of cyprob-ee#141: a caller must be able
+	// to say how many hosts actually answered an echo request. Anything the
+	// neighbor table supplied has to be reported separately, and only that.
+	t.Run("what ARP supplied is reported separately, and is exactly the additions", func(t *testing.T) {
+		table := ARPTableForTest(t)
+		if len(table) == 0 {
+			t.Skip("no neighbor table entries available on this host")
+		}
+		neighbor := table[0]
+
+		combined, arpConfirmed := appendARPConfirmedHosts(nil, []string{neighbor}, &logger)
+
+		require.Equal(t, []string{neighbor}, arpConfirmed,
+			"a host that never answered ICMP must be attributed to ARP, not to ICMP")
+		require.Equal(t, len(combined), len(arpConfirmed),
+			"with no ICMP replies, every host in the result came from the neighbor table")
+		require.Subset(t, combined, arpConfirmed,
+			"the ARP-confirmed set must be a subset of the combined result, not a parallel list")
+	})
+
+	t.Run("a host that answered ICMP is never claimed by ARP", func(t *testing.T) {
+		table := ARPTableForTest(t)
+		if len(table) == 0 {
+			t.Skip("no neighbor table entries available on this host")
+		}
+		answered := table[0]
+
+		// Same host, but this time ICMP already found it.
+		_, arpConfirmed := appendARPConfirmedHosts([]string{answered}, []string{answered}, &logger)
+
+		require.Empty(t, arpConfirmed,
+			"an echo reply must keep its attribution even when the host is also in the neighbor table")
 	})
 }
 

--- a/pkg/modules/discovery/icmp_ping.go
+++ b/pkg/modules/discovery/icmp_ping.go
@@ -56,8 +56,23 @@ var canOpenRawICMPSocket = func() bool {
 }
 
 // ICMPPingDiscoveryResult stores the outcome of the ping discovery.
+//
+// LiveHosts is every host this module found alive, by either route. Some of
+// them never answered an echo request: they are in the kernel neighbor table,
+// which is stronger evidence than an echo reply on a directly attached segment
+// (see appendARPConfirmedHosts). Those are listed again, on their own, in
+// ARPConfirmedHosts.
+//
+// The split exists because a caller that reports "ICMP found N hosts" from
+// LiveHosts alone states something false when the neighbor table supplied
+// them — a scan reported `icmp=1` after sending zero packets (cyprob-ee#141),
+// and that number is what an operator reads to answer "does ICMP work here".
+// A caller that only wants "who is alive" can keep using LiveHosts and ignore
+// this field.
 type ICMPPingDiscoveryResult struct {
 	LiveHosts []string `json:"live_hosts"`
+	// ARPConfirmedHosts is the subset of LiveHosts that did not answer ICMP.
+	ARPConfirmedHosts []string `json:"arp_confirmed_hosts,omitempty"`
 }
 
 // ICMPPingDiscoveryConfig holds configuration for the ICMP ping module.
@@ -416,9 +431,10 @@ func (m *ICMPPingDiscoveryModule) Execute(ctx context.Context, inputs map[string
 
 	wg.Wait()
 
-	liveHosts = appendARPConfirmedHosts(liveHosts, finalTargetsToScan, &logger)
+	icmpAnswered := len(liveHosts)
+	liveHosts, arpConfirmed := appendARPConfirmedHosts(liveHosts, finalTargetsToScan, &logger)
 
-	resultData := ICMPPingDiscoveryResult{LiveHosts: liveHosts}
+	resultData := ICMPPingDiscoveryResult{LiveHosts: liveHosts, ARPConfirmedHosts: arpConfirmed}
 	outputChan <- engine.ModuleOutput{
 		FromModuleName: m.meta.ID,
 		DataKey:        m.meta.Produces[0].Key, // "discovery.live_hosts"
@@ -426,7 +442,15 @@ func (m *ICMPPingDiscoveryModule) Execute(ctx context.Context, inputs map[string
 		Timestamp:      time.Now(),
 	}
 
-	logger.Info().Int("live_hosts_found", len(liveHosts)).Int("targets_processed", len(finalTargetsToScan)).Msg("ICMP Ping Discovery completed")
+	// icmp_answered is logged next to live_hosts_found because the two differ
+	// exactly when the neighbor table contributed, and reading the total as an
+	// ICMP result is the mistake this split exists to prevent.
+	logger.Info().
+		Int("live_hosts_found", len(liveHosts)).
+		Int("icmp_answered", icmpAnswered).
+		Int("arp_confirmed", len(arpConfirmed)).
+		Int("targets_processed", len(finalTargetsToScan)).
+		Msg("ICMP Ping Discovery completed")
 	return nil
 }
 
@@ -470,10 +494,14 @@ func (r *realPingerAdapter) GetTimeout() time.Duration   { return r.p.Timeout }
 //
 // This only ever adds hosts, and only ones that were asked for; an empty
 // neighbor table (remote segment, unsupported platform) changes nothing.
-func appendARPConfirmedHosts(liveHosts []string, targets []string, logger *zerolog.Logger) []string {
+//
+// It returns the combined list and, separately, just what it added, so the
+// caller can tell the two signals apart instead of reporting layer-2 evidence
+// as an ICMP reply (cyprob-ee#141).
+func appendARPConfirmedHosts(liveHosts []string, targets []string, logger *zerolog.Logger) (combined, arpConfirmed []string) {
 	neighbors := netutil.ARPTable()
 	if len(neighbors) == 0 {
-		return liveHosts
+		return liveHosts, nil
 	}
 
 	known := make(map[string]struct{}, len(neighbors))
@@ -485,7 +513,6 @@ func appendARPConfirmedHosts(liveHosts []string, targets []string, logger *zerol
 		already[host] = struct{}{}
 	}
 
-	added := 0
 	for _, target := range targets {
 		if _, seen := already[target]; seen {
 			continue
@@ -494,12 +521,13 @@ func appendARPConfirmedHosts(liveHosts []string, targets []string, logger *zerol
 			continue
 		}
 		liveHosts = append(liveHosts, target)
+		arpConfirmed = append(arpConfirmed, target)
 		already[target] = struct{}{}
-		added++
 	}
+	added := len(arpConfirmed)
 	if added > 0 && logger != nil {
 		logger.Info().Int("arp_confirmed_hosts", added).
 			Msg("Added hosts confirmed by the neighbor table that did not answer ICMP")
 	}
-	return liveHosts
+	return liveHosts, arpConfirmed
 }


### PR DESCRIPTION
## What this changes

`appendARPConfirmedHosts` adds hosts that are in the kernel neighbor table but
never answered an echo request. They went into `LiveHosts` unmarked, so anything
downstream reporting "ICMP found N hosts" from that list can be stating the
opposite of the truth.

They are now returned separately and carried in a new
`ICMPPingDiscoveryResult.ARPConfirmedHosts` — a subset of `LiveHosts`, not a
replacement for any part of it.

## Why

`cyprob-ee#141`, measured on the appliance while checking whether privileged
ICMP worked at all:

```
Pinger.Run() error  error="socket: permission denied"
Host did not respond  recv=0 sent=0
Added hosts confirmed by the neighbor table that did not answer ICMP  arp_confirmed_hosts=1
ICMP Ping Discovery completed  live_hosts_found=1
```

and the scan then reported `Discovered 1 live hosts (icmp=1 tcp=0 arp=1)`. Not
one packet was sent. `icmp=1` is the number an operator reads to answer "does
ICMP work here", and it answered yes while ICMP was completely broken — the same
device also counted under `arp=1`, so one host appeared as evidence from two
signals, one of which did nothing.

## Behavior Change

No host is added or removed from discovery by this change, and `LiveHosts` keeps
exactly the contents it had before, in the same order. What changes is that the
result now says which of those hosts came from layer 2, and the completion log
prints `icmp_answered` and `arp_confirmed` alongside `live_hosts_found`. A
consumer that ignores the new field behaves identically to today.

## Risk

Low, and bounded to attribution rather than detection. The function is
additive-only as before; the second return value is derived from the same loop
that already produced the count in the log line, so there is no new source of
truth to disagree with. A stale consumer reading only `LiveHosts` is unaffected,
which is what makes this safe to ship ahead of the EE side that will use it.

## Test Plan

`go test ./pkg/modules/discovery/` and the full `go test ./...` suite,
`golangci-lint run` clean on the package. Two new cases pin the attribution: a
neighbor-table host with no echo reply must appear in `ARPConfirmedHosts`, and a
host that did answer ICMP must never be claimed by ARP even though it is also in
the table. Both use whatever neighbor entries the machine actually has and skip
when it has none, so they assert nothing about a particular network.

## Evidence

`go test ./... -count=1` passes with no failures; `golangci-lint run
./pkg/modules/discovery/...` reports `0 issues`. Mutation check rather than a
green tick alone: with the fix reverted to `return liveHosts, nil`, the new
attribution test fails with `a host that never answered ICMP must be attributed
to ARP, not to ICMP`; restoring it passes.

## Rollback

Revert the commit. Nothing persists this field and no schema depends on it; the
EE side does not read it until its own change lands, so a revert here cannot
strand a consumer mid-upgrade.