### PR TITLE
fix(scan): retry over TLS when a port answers nothing in plain text

### DIFF
--- a/pkg/modules/scan/banner_grab.go
+++ b/pkg/modules/scan/banner_grab.go
@@ -458,6 +458,8 @@ func (m *BannerGrabModule) runActiveProbes(
 			break
 		}
 	}
+
+	m.runTLSFallbackPass(ctx, target, probeHost, port, catalog, observations, lastError, hintAcc, seen)
 }
 
 func (m *BannerGrabModule) runProbes(ctx context.Context, target string, probeHost string, originHost string, port int) BannerGrabResult {

--- a/pkg/modules/scan/banner_grab_tls_fallback.go
+++ b/pkg/modules/scan/banner_grab_tls_fallback.go
@@ -1,0 +1,79 @@
+package scan
+
+import (
+	"context"
+
+	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/fingerprint"
+)
+
+// A TLS-only service on a port nobody thought to list answers nothing in plain
+// text, and the scan records an empty banner — no error, no hint, nothing for a
+// fingerprint rule or a tagger to read. Ten hypervisor reverse-proxies on 9080
+// were invisible this way: plain HTTP returns nothing at all, HTTPS returns 200.
+//
+// The catalog gates the TLS probe on an explicit port list (`https-get` carries
+// port_include 443, 8443, 9443), and the existing fallback pass only runs when
+// *no* port-specific probe matched at all. On 9080 the HTTP probe does match, so
+// neither path ever reaches TLS.
+//
+// Widening the port list is the wrong shape of fix: the next service on the next
+// unlisted port is the same bug again, and attempting TLS everywhere costs a
+// handshake per service for very little — measured on one estate, of the
+// banner-less ports outside the list only 9080 answered TLS at all. What is
+// cheap and general is to try TLS exactly where the evidence says it might help:
+// the port answered nothing, so there is nothing to lose by asking again.
+
+// runTLSFallbackPass retries with a TLS probe when the active pass produced no
+// banner at all.
+//
+// It runs only on complete silence, not on a poor result: a port that answered
+// something has already told us what it is, and re-probing it would spend a
+// handshake to overwrite an answer we have. Probe IDs already attempted are
+// skipped, so this cannot repeat work the main pass did.
+func (m *BannerGrabModule) runTLSFallbackPass(
+	ctx context.Context,
+	target string,
+	probeHost string,
+	port int,
+	catalog *fingerprint.ProbeCatalog,
+	observations *[]engine.ProbeObservation,
+	lastError *string,
+	hintAcc *hintAccumulator,
+	attempted map[string]struct{},
+) {
+	if catalog == nil || ctx.Err() != nil {
+		return
+	}
+	if selectPrimaryBannerObservation(*observations).Banner != "" {
+		return
+	}
+
+	for _, spec := range catalog.FallbackProbesFor(port, hintAcc.slice()) {
+		if !spec.UseTLS {
+			continue
+		}
+		if _, done := attempted[spec.ID]; done {
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+
+		attempted[spec.ID] = struct{}{}
+		obs := m.executeProbeSpec(ctx, target, probeHost, port, spec)
+		if respHint := protocolHintFromBanner(obs.Response); respHint != "" {
+			hintAcc.add(respHint)
+		}
+		classifyHTTPProbeObservation(&obs)
+		m.collectObservation(observations, obs, lastError)
+
+		if selectPrimaryBannerObservation(*observations).Banner != "" {
+			m.logger.Debug().
+				Str("probe_id", spec.ID).
+				Int("port", port).
+				Msg("TLS fallback produced a banner on a port with no plain-text response")
+			return
+		}
+	}
+}

--- a/pkg/modules/scan/banner_grab_tls_fallback_test.go
+++ b/pkg/modules/scan/banner_grab_tls_fallback_test.go
@@ -1,0 +1,158 @@
+package scan
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/fingerprint"
+)
+
+func hintAccumulatorPtr() *hintAccumulator {
+	acc := newHintAccumulator()
+	return &acc
+}
+
+func tlsTestTarget(t *testing.T, handler http.HandlerFunc) (string, int, func()) {
+	t.Helper()
+
+	ts := httptest.NewTLSServer(handler)
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(ts.URL, "https://"))
+	if err != nil {
+		ts.Close()
+		t.Fatalf("split host/port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		ts.Close()
+		t.Fatalf("atoi: %v", err)
+	}
+	return host, port, ts.Close
+}
+
+// The 9080 case: a service that speaks only TLS on a port the catalog does not
+// list, so the plain-text pass records nothing at all.
+func TestRunTLSFallbackPass_RecoversASilentTLSPort(t *testing.T) {
+	host, port, closeServer := tlsTestTarget(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer closeServer()
+
+	catalog, err := fingerprint.GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	m := newBannerGrabModule()
+	observations := make([]engine.ProbeObservation, 0, 2)
+	var lastError string
+	hints := newHintAccumulator()
+
+	m.runTLSFallbackPass(context.Background(), host, host, port, catalog,
+		&observations, &lastError, &hints, map[string]struct{}{})
+
+	banner := selectPrimaryBannerObservation(observations).Banner
+	if banner == "" {
+		t.Fatal("expected the TLS fallback to produce a banner where the plain pass had none")
+	}
+	if !strings.Contains(banner, "200") {
+		t.Fatalf("expected the server's response, got %q", banner)
+	}
+}
+
+// A port that already answered has told us what it is. Re-probing it would spend
+// a handshake to overwrite an answer we hold, so silence is the only trigger.
+func TestRunTLSFallbackPass_LeavesAnExistingBannerAlone(t *testing.T) {
+	host, port, closeServer := tlsTestTarget(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer closeServer()
+
+	catalog, err := fingerprint.GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	existing := engine.ProbeObservation{
+		ProbeID:  "http-get",
+		Response: "HTTP/1.1 401 Unauthorized\r\nServer: something\r\n\r\n",
+	}
+	observations := []engine.ProbeObservation{existing}
+	var lastError string
+
+	m := newBannerGrabModule()
+	m.runTLSFallbackPass(context.Background(), host, host, port, catalog,
+		&observations, &lastError, hintAccumulatorPtr(), map[string]struct{}{})
+
+	if len(observations) != 1 {
+		t.Fatalf("expected no additional probe, got %d observations", len(observations))
+	}
+}
+
+// The pass must not repeat a probe the main loop already ran, whatever the
+// reason that probe produced nothing.
+func TestRunTLSFallbackPass_SkipsProbesAlreadyAttempted(t *testing.T) {
+	host, port, closeServer := tlsTestTarget(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer closeServer()
+
+	catalog, err := fingerprint.GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	attempted := map[string]struct{}{}
+	for _, spec := range catalog.FallbackProbesFor(port, nil) {
+		if spec.UseTLS {
+			attempted[spec.ID] = struct{}{}
+		}
+	}
+	if len(attempted) == 0 {
+		t.Skip("catalog has no TLS fallback probe to exercise")
+	}
+
+	observations := make([]engine.ProbeObservation, 0, 1)
+	var lastError string
+
+	m := newBannerGrabModule()
+	m.runTLSFallbackPass(context.Background(), host, host, port, catalog,
+		&observations, &lastError, hintAccumulatorPtr(), attempted)
+
+	if len(observations) != 0 {
+		t.Fatalf("expected every TLS probe to be skipped as already attempted, got %d", len(observations))
+	}
+}
+
+// A cancelled context must stop the pass before it dials.
+func TestRunTLSFallbackPass_HonoursContextCancellation(t *testing.T) {
+	host, port, closeServer := tlsTestTarget(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer closeServer()
+
+	catalog, err := fingerprint.GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	observations := make([]engine.ProbeObservation, 0, 1)
+	var lastError string
+
+	m := newBannerGrabModule()
+	m.runTLSFallbackPass(ctx, host, host, port, catalog,
+		&observations, &lastError, hintAccumulatorPtr(), map[string]struct{}{})
+
+	if len(observations) != 0 {
+		t.Fatalf("expected no probe after cancellation, got %d", len(observations))
+	}
+}

--- a/pkg/modules/scan/banner_grab_tls_fallback_test.go
+++ b/pkg/modules/scan/banner_grab_tls_fallback_test.go
@@ -130,7 +130,7 @@ func TestRunTLSFallbackPass_SkipsProbesAlreadyAttempted(t *testing.T) {
 	}
 }
 
-// A cancelled context must stop the pass before it dials.
+// A canceled context must stop the pass before it dials.
 func TestRunTLSFallbackPass_HonoursContextCancellation(t *testing.T) {
 	host, port, closeServer := tlsTestTarget(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Fixes the probing half of `cyprob-ee#156`. That issue lives in the EE repo and this PR is here, so the keyword cannot close it — it will need closing by hand on merge.

## Problem

A service that speaks only TLS on a port the catalog does not list is recorded with an empty banner. Nothing errors, nothing hints, and no fingerprint rule or tagger has anything to read.

Two gates have to line up for this to happen, and on 9080 they do. `https-get` carries `port_include: [443, 8443, 9443]`, so `ProbesFor` filters it out. The existing fallback pass would supply it, but only runs when *no* port-specific probe matched at all — and 9080 is in the `http` group's `port_hints`, so `http-get` matches and the fallback never fires.

Measured on an appliance: ten `9080/tcp` services, every banner empty, `tls_enabled` false on all ten.

```
http://10.20.29.11:9080/   → 000  (nothing)
https://10.20.29.11:9080/  → 200
http://10.20.29.23:9080/   → 000
https://10.20.29.23:9080/  → 200
```

## User / Ops Impact

Services that only speak TLS on non-standard ports become identifiable instead of silently blank, which is what selection and tagging both need before they can do anything. On the measured estate this is ten hypervisor reverse-proxies that currently look like closed doors.

## Fix Summary

`runTLSFallbackPass` runs after the active probe loop and retries with a TLS-capable fallback probe, but only when the loop produced no banner at all. Probe IDs already attempted are skipped, and the pass stops as soon as a banner appears.

## Behavior Change

A port that returned nothing now gets one extra TLS attempt. A port that returned anything is untouched: it has already told us what it is, and re-probing would spend a handshake to overwrite an answer we hold.

The alternative — widening `port_include`, or attempting TLS everywhere — was measured and rejected. Of the banner-less ports outside the current list on this estate, four hosts each were probed on 8000, 8300 and 17988 and none answered TLS; only 9080 did, 3 of 4. A blanket attempt would add a handshake per service to find almost nothing, and a wider port list only defers the same bug to the next unlisted port. Triggering on silence costs a handshake exactly where there is no answer to lose.

## Evidence

`go build ./pkg/...` clean, `gofmt` clean, `go test ./pkg/modules/scan/ ./pkg/fingerprint/` fully green.

```
--- PASS: TestRunTLSFallbackPass_RecoversASilentTLSPort
--- PASS: TestRunTLSFallbackPass_LeavesAnExistingBannerAlone
--- PASS: TestRunTLSFallbackPass_SkipsProbesAlreadyAttempted
--- PASS: TestRunTLSFallbackPass_HonoursContextCancellation
```

The first drives a real TLS server on an ephemeral port that the catalog cannot know about, which is the 9080 shape. The other three pin the conditions that keep this cheap: silence only, no repeats, and no dial after cancellation.

Not verified on an appliance: this needs an image carrying the build. The 9080 measurement above is what the change is aimed at, and re-running it against a scan is the check that closes the EE issue.

`go vet ./pkg/modules/scan/` reports two pre-existing context-leak findings in `ftp_native_probe.go` and `mysql_native_probe.go`, untouched by this change.

## Risk / Rollback

One added pass, reachable only when a port produced no banner, on probes the catalog already ships. Worst case is one extra failed handshake per silent port. Rollback is reverting the commit.

## Linked Issue

Refs cyprob-ee#156
