### PR TITLE
fix(scan): never send a payload to a port that prints it

### DIFF
--- a/pkg/fingerprint/data/probes.yaml
+++ b/pkg/fingerprint/data/probes.yaml
@@ -1,6 +1,13 @@
 # Built-in probe catalog for banner grabbing.
 # Phase 1.5: Fallback probes for non-standard ports (e.g., HTTP on 2096, MySQL on 3210)
 # These probes are tried when no port-specific probes match AND passive banner is empty/timeout.
+# Ports where a payload becomes a printed page (515 LPD, 9100-9102 JetDirect)
+# are refused in code, not here, so that a catalog loaded from a cache
+# directory cannot re-enable them - see printPorts in probe_catalog.go.
+# never_probe_ports below adds to that floor; it cannot shrink it.
+#
+# never_probe_ports: [4000]
+
 fallback_probes:
   - http-get      # Most common: web services on unusual ports (cPanel, proxies, etc.)
   - https-get     # HTTPS fallback

--- a/pkg/fingerprint/probe_catalog.go
+++ b/pkg/fingerprint/probe_catalog.go
@@ -163,18 +163,23 @@ func (g ProbeGroup) matches(port int, hints map[string]struct{}) bool {
 	return false
 }
 
+// IsPrintPort reports whether writing to this port produces paper rather than a
+// reply. Exported because probe selection is not the only path that writes:
+// redirect-following dials a port the catalog never chose, so it has to ask the
+// same question without a catalog in hand (cyprob#268 review).
+func IsPrintPort(port int) bool {
+	return port > 0 && containsInt(printPorts, port)
+}
+
 // payloadForbidden reports whether sending anything to this port would produce
 // physical output rather than a reply. Port 0 means "no port in hand" — the
 // legacy unfiltered fallback set asks that way — and cannot be judged, so it is
 // allowed through unchanged.
 func (c *ProbeCatalog) payloadForbidden(port int) bool {
-	if port <= 0 {
-		return false
-	}
-	if containsInt(printPorts, port) {
+	if IsPrintPort(port) {
 		return true
 	}
-	return c != nil && containsInt(c.NeverProbePorts, port)
+	return port > 0 && c != nil && containsInt(c.NeverProbePorts, port)
 }
 
 func (p ProbeSpec) allowsPort(port int) bool {

--- a/pkg/fingerprint/probe_catalog.go
+++ b/pkg/fingerprint/probe_catalog.go
@@ -10,10 +10,30 @@ import (
 // Groups can map to protocol families (HTTP, SMTP, etc.) and expose one or more probe
 // definitions that should be attempted when their match conditions are satisfied.
 // FallbackProbeIDs lists probe IDs to try when no port-specific probes match (Phase 1.5).
+// NeverProbePorts extends the built-in print-port floor; it can add ports but
+// never remove one, because a catalog shipped from outside this binary is not
+// allowed to re-enable printing.
 type ProbeCatalog struct {
 	Groups           []ProbeGroup `yaml:"groups" json:"groups"`
 	FallbackProbeIDs []string     `yaml:"fallback_probes,omitempty" json:"fallback_probes,omitempty"`
+	NeverProbePorts  []int        `yaml:"never_probe_ports,omitempty" json:"never_probe_ports,omitempty"`
 }
+
+// printPorts carry no request/response protocol: the listener treats whatever
+// arrives as a job and puts it on paper. A probe payload is therefore not a
+// question the service can decline — it is a printed page, produced by the act
+// of asking. Reported from the field with the pages in hand (cyprob#268): an
+// office sweep printed our own `GET / HTTP/1.1` header block on a JetDirect
+// device, followed by a second sheet of binary.
+//
+// 9100 is raw JetDirect and 9101/9102 are its multi-port variants; 515 is LPD,
+// which spools what it is given. TCP connect and any read still work — this
+// only forbids sending bytes.
+//
+// The floor lives in code rather than in probes.yaml because the catalog can be
+// replaced at runtime from a cache directory (WarmProbeCatalogWithExternal): a
+// stale or hand-edited catalog must not be able to start printing again.
+var printPorts = []int{515, 9100, 9101, 9102}
 
 // ProbeGroup describes a family of probes sharing similar trigger conditions.
 type ProbeGroup struct {
@@ -48,6 +68,10 @@ func (c *ProbeCatalog) ProbesFor(port int, hints []string) []ProbeSpec {
 		return nil
 	}
 
+	if c.payloadForbidden(port) {
+		return nil
+	}
+
 	normalizedHints := normalizeHints(hints)
 	out := make([]ProbeSpec, 0)
 
@@ -77,6 +101,13 @@ func (c *ProbeCatalog) FallbackProbes() []ProbeSpec {
 // existing hints already point at that protocol family.
 func (c *ProbeCatalog) FallbackProbesFor(port int, hints []string) []ProbeSpec {
 	if c == nil || len(c.FallbackProbeIDs) == 0 {
+		return nil
+	}
+
+	// The fallback set exists precisely for ports the catalog does not describe,
+	// so it is the path that reaches a print port — including the TLS retry
+	// added in #267, which draws its probes from here.
+	if c.payloadForbidden(port) {
 		return nil
 	}
 
@@ -130,6 +161,20 @@ func (g ProbeGroup) matches(port int, hints map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+// payloadForbidden reports whether sending anything to this port would produce
+// physical output rather than a reply. Port 0 means "no port in hand" — the
+// legacy unfiltered fallback set asks that way — and cannot be judged, so it is
+// allowed through unchanged.
+func (c *ProbeCatalog) payloadForbidden(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	if containsInt(printPorts, port) {
+		return true
+	}
+	return c != nil && containsInt(c.NeverProbePorts, port)
 }
 
 func (p ProbeSpec) allowsPort(port int) bool {

--- a/pkg/fingerprint/probe_catalog_test.go
+++ b/pkg/fingerprint/probe_catalog_test.go
@@ -168,3 +168,92 @@ func TestProbeCatalog_Validate_Errors(t *testing.T) {
 		t.Fatalf("expected probe missing payload error")
 	}
 }
+
+// A print port answers a payload with paper, so no probe may be selected for
+// one — not by port hint, not by protocol hint, not through the fallback set
+// (cyprob#268).
+func TestProbeCatalog_PrintPortsSelectNoProbe(t *testing.T) {
+	catalog := ProbeCatalog{
+		Groups: []ProbeGroup{{
+			ID:            "g1",
+			PortHints:     []int{9100},
+			ProtocolHints: []string{"http"},
+			Probes:        []ProbeSpec{{ID: "p1", Protocol: "tcp", Payload: "X"}},
+		}},
+		FallbackProbeIDs: []string{"p1"},
+	}
+
+	for _, port := range []int{515, 9100, 9101, 9102} {
+		if out := catalog.ProbesFor(port, []string{"http"}); len(out) != 0 {
+			t.Fatalf("port %d selected %d probes; a payload here prints", port, len(out))
+		}
+		if out := catalog.FallbackProbesFor(port, []string{"http"}); len(out) != 0 {
+			t.Fatalf("port %d selected %d fallback probes; a payload here prints", port, len(out))
+		}
+	}
+
+	// A neighbouring port is untouched: the guard is about these ports, not
+	// about the probes.
+	if out := catalog.ProbesFor(9103, []string{"http"}); len(out) != 0 {
+		t.Fatalf("9103 is not a print port and has no group; got %#v", out)
+	}
+	if out := catalog.FallbackProbesFor(9103, []string{"http"}); len(out) != 1 {
+		t.Fatalf("expected the fallback set on a non-print port, got %#v", out)
+	}
+}
+
+// The floor is not data: a catalog loaded from outside the binary may add
+// ports and may not drop one.
+func TestProbeCatalog_NeverProbePortsExtendsButCannotShrink(t *testing.T) {
+	catalog := ProbeCatalog{
+		Groups: []ProbeGroup{{
+			ID:        "g1",
+			PortHints: []int{9100, 9200},
+			Probes:    []ProbeSpec{{ID: "p1", Protocol: "tcp", Payload: "X"}},
+		}},
+		FallbackProbeIDs: []string{"p1"},
+		NeverProbePorts:  []int{9200},
+	}
+
+	if out := catalog.ProbesFor(9200, nil); len(out) != 0 {
+		t.Fatalf("never_probe_ports did not take effect: %#v", out)
+	}
+	if out := catalog.ProbesFor(9100, nil); len(out) != 0 {
+		t.Fatalf("a catalog that omits 9100 must not re-enable it: %#v", out)
+	}
+}
+
+// FallbackProbes() asks with no port at all; it predates this guard and must
+// keep returning the legacy set rather than nothing.
+func TestProbeCatalog_UnportedFallbackIsUnaffected(t *testing.T) {
+	catalog := ProbeCatalog{
+		Groups:           []ProbeGroup{{ID: "g1", Probes: []ProbeSpec{{ID: "p1", Protocol: "tcp", Payload: "X"}}}},
+		FallbackProbeIDs: []string{"p1"},
+	}
+
+	if out := catalog.FallbackProbes(); len(out) != 1 {
+		t.Fatalf("expected the legacy unfiltered set, got %#v", out)
+	}
+}
+
+// The shipped catalog, not a hand-built one.
+func TestProbeCatalog_EmbeddedCatalogRefusesPrintPorts(t *testing.T) {
+	catalog, err := GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	for _, port := range []int{515, 9100, 9101, 9102} {
+		if out := catalog.ProbesFor(port, []string{"http", "web"}); len(out) != 0 {
+			t.Fatalf("shipped catalog selects %d probes on %d", len(out), port)
+		}
+		if out := catalog.FallbackProbesFor(port, []string{"http", "web"}); len(out) != 0 {
+			t.Fatalf("shipped catalog selects %d fallback probes on %d", len(out), port)
+		}
+	}
+
+	// Control: the fallback set is still reachable on an unlisted, harmless port.
+	if out := catalog.FallbackProbesFor(2096, nil); len(out) == 0 {
+		t.Fatal("fallback probes disappeared on a non-print port")
+	}
+}

--- a/pkg/fingerprint/probe_catalog_test.go
+++ b/pkg/fingerprint/probe_catalog_test.go
@@ -192,7 +192,7 @@ func TestProbeCatalog_PrintPortsSelectNoProbe(t *testing.T) {
 		}
 	}
 
-	// A neighbouring port is untouched: the guard is about these ports, not
+	// A neighboring port is untouched: the guard is about these ports, not
 	// about the probes.
 	if out := catalog.ProbesFor(9103, []string{"http"}); len(out) != 0 {
 		t.Fatalf("9103 is not a print port and has no group; got %#v", out)

--- a/pkg/modules/scan/banner_grab.go
+++ b/pkg/modules/scan/banner_grab.go
@@ -1180,6 +1180,16 @@ func resolveRedirectRequest(currentScheme string, currentHost string, currentPor
 		req.Port = currentPort
 	}
 
+	// A redirect chooses a port that probe selection never saw, so the print-port
+	// floor has to be asked again here: a same-host, same-scheme `Location` at
+	// 9100 is accepted by every check above, and following it writes a request
+	// (or a ClientHello) onto a listener that turns bytes into paper
+	// (cyprob#268 review).
+	if fingerprint.IsPrintPort(req.Port) {
+		req.SkipError = "redirect_print_port_blocked"
+		return req
+	}
+
 	req.Scheme = targetScheme
 	req.Host = currentHost
 	req.Path = requestURIForURL(resolved)
@@ -1403,6 +1413,14 @@ func (m *BannerGrabModule) runCommandProbe(ctx context.Context, dialHost string,
 		Description: spec.Description,
 		Protocol:    spec.Protocol,
 		IsTLS:       spec.UseTLS,
+	}
+
+	// Last line rather than the only one: callers are expected to have filtered
+	// the port already, but every writer in this file funnels through here, so a
+	// future path that forgets stops at the dial instead of at the paper tray.
+	if fingerprint.IsPrintPort(port) {
+		obs.Error = "print_port_write_blocked"
+		return obs
 	}
 
 	address := net.JoinHostPort(dialHost, strconv.Itoa(port))

--- a/pkg/modules/scan/banner_grab_print_ports_test.go
+++ b/pkg/modules/scan/banner_grab_print_ports_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strconv"
 	"sync/atomic"
@@ -78,5 +79,52 @@ func TestRunActiveProbes_SendsNothingToAPrintPort(t *testing.T) {
 	}
 	if len(observations) != 0 {
 		t.Fatalf("expected no probe observations on a print port, got %d", len(observations))
+	}
+}
+
+// The bypass Talos found reviewing cyprob#270: probe selection is not the only
+// path that writes. A same-host, same-scheme redirect naming a print port
+// passes every other check in resolveRedirectRequest, and following it puts a
+// request — or a TLS ClientHello — on the wire.
+func TestResolveRedirectRequest_RefusesAPrintPort(t *testing.T) {
+	for _, port := range []int{515, 9100, 9101, 9102} {
+		req := resolveRedirectRequest("https", "10.0.0.1", 8443, "/",
+			fmt.Sprintf("https://10.0.0.1:%d/", port), 1)
+		if req.SkipError != "redirect_print_port_blocked" {
+			t.Fatalf("port %d: expected the redirect to be refused, got SkipError=%q port=%d",
+				port, req.SkipError, req.Port)
+		}
+	}
+
+	// A redirect to an ordinary port on the same host is still followed.
+	req := resolveRedirectRequest("https", "10.0.0.1", 8443, "/", "https://10.0.0.1:9443/x", 1)
+	if req.SkipError != "" || req.Port != 9443 {
+		t.Fatalf("expected an ordinary redirect to survive, got SkipError=%q port=%d", req.SkipError, req.Port)
+	}
+}
+
+// Every writer in banner_grab funnels through runCommandProbe, so it carries
+// the same refusal as a backstop for paths that have not been written yet.
+func TestRunCommandProbe_RefusesToDialAPrintPort(t *testing.T) {
+	const printPort = 9100
+
+	ln, received := listenCountingBytes(t, printPort)
+	defer func() { _ = ln.Close() }()
+
+	m := newBannerGrabModule()
+	obs := m.runCommandProbe(context.Background(), "127.0.0.1", "127.0.0.1", printPort, commandProbeSpec{
+		ProbeID:  "redirect-hop-1",
+		Protocol: "https",
+		UseTLS:   true,
+		Commands: []string{"GET / HTTP/1.1\r\n\r\n"},
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if obs.Error != "print_port_write_blocked" {
+		t.Fatalf("expected the probe to refuse, got error=%q response=%q", obs.Error, obs.Response)
+	}
+	if n := atomic.LoadInt64(received); n != 0 {
+		t.Fatalf("%d bytes reached the print port", n)
 	}
 }

--- a/pkg/modules/scan/banner_grab_print_ports_test.go
+++ b/pkg/modules/scan/banner_grab_print_ports_test.go
@@ -1,0 +1,82 @@
+package scan
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/fingerprint"
+)
+
+// listenCountingBytes accepts one connection on the given port and records how
+// many bytes the client sent. A print port cannot be simulated any other way:
+// the defect is not what comes back, it is what goes out.
+func listenCountingBytes(t *testing.T, port int) (*net.TCPListener, *int64) {
+	t.Helper()
+
+	addr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}
+	ln, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Skipf("cannot bind 127.0.0.1:%d here: %v", port, err)
+	}
+
+	var received int64
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+				buf := make([]byte, 4096)
+				n, _ := c.Read(buf)
+				atomic.AddInt64(&received, int64(n))
+			}(conn)
+		}
+	}()
+
+	return ln, &received
+}
+
+// The cyprob#268 report, as a test: an office sweep put our probe payload on
+// paper. Nothing may be written to a JetDirect port, by either probe path.
+func TestRunActiveProbes_SendsNothingToAPrintPort(t *testing.T) {
+	const printPort = 9100
+
+	ln, received := listenCountingBytes(t, printPort)
+	defer func() { _ = ln.Close() }()
+
+	catalog, err := fingerprint.GetProbeCatalog()
+	if err != nil {
+		t.Fatalf("probe catalog: %v", err)
+	}
+
+	m := newBannerGrabModule()
+	observations := make([]engine.ProbeObservation, 0, 2)
+	var lastError string
+	hints := newHintAccumulator()
+	hints.add("http") // the hint that used to pull http-get onto any port
+
+	host := "127.0.0.1"
+	m.runActiveProbes(context.Background(), net.JoinHostPort(host, strconv.Itoa(printPort)),
+		host, host, printPort, catalog, &observations, &lastError, &hints)
+
+	m.runTLSFallbackPass(context.Background(), host, host, printPort, catalog,
+		&observations, &lastError, &hints, map[string]struct{}{})
+
+	// Give any connection the listener did accept time to be read.
+	time.Sleep(200 * time.Millisecond)
+
+	if n := atomic.LoadInt64(received); n != 0 {
+		t.Fatalf("%d bytes reached the print port; on a real device that is a printed page", n)
+	}
+	if len(observations) != 0 {
+		t.Fatalf("expected no probe observations on a print port, got %d", len(observations))
+	}
+}


### PR DESCRIPTION
## Problem

A JetDirect listener has no request/response protocol: whatever arrives is a job, and the device puts it on paper. Probing one is therefore not a question the service can decline — the act of asking produces a printed page. Reported from the field with the pages in hand (#268): an office sweep printed our own `GET / HTTP/1.1` header block on an HP device, followed by a second sheet of binary.

The cause is an omission rather than a wrong rule. 9100 matches no probe group, so selection falls through to `FallbackProbesFor`, where `redis-ping` and `ftp-feat` are hint-gated and `https-get` carries `port_include: [443, 8443, 9443]` — but `http-get` has no port restriction at all, so it fires on any port that reaches the fallback path.

## User / Ops Impact

A scan of a segment containing a network printer consumes paper and toner, and leaves the operator's own probe payload sitting in an output tray where anyone can read it. It is the one defect class in this scanner that is visible to people who never open the product. It reaches an appliance as soon as EE picks up a CE version containing the fallback path, which it now has (`cyprob-ee#164`, CE v0.17.3).

## Fix Summary

The guard belongs to the port, not to the probe: any payload prints, so excluding a single probe would leave the next one added to reopen it. `printPorts` — 515 (LPD) and 9100–9102 (JetDirect and its multi-port variants) — is checked in both `ProbesFor` and `FallbackProbesFor`, which also covers the TLS retry from #267, since that pass draws its probe list from the fallback set.

The list lives in Go rather than in `probes.yaml` because the catalog can be replaced at runtime from a cache directory (`WarmProbeCatalogWithExternal`); a stale or hand-edited catalog must not be able to start printing again. A new `never_probe_ports` key lets a catalog **add** ports to that floor and never remove one.

`FallbackProbes()` asks with no port at all (port 0). That call predates this guard, so it is left returning the legacy unfiltered set rather than nothing.

## Behavior Change

On 515 and 9100–9102 no active probe runs and no bytes are written. TCP connect, port state and passive reads are untouched, so a print port is still discovered and still reported as open — only the writing stops. On every other port, selection is byte-for-byte what it was.

## Evidence

- `GOWORK=off go build ./...` — clean.
- `GOWORK=off go vet ./pkg/fingerprint/... ./pkg/modules/scan/...` — the only findings are the four pre-existing context leaks already filed as #269 (`smtp_native_probe.go`, `winrm_native_probe.go` and two others); nothing from this branch.
- `GOWORK=off go test ./pkg/fingerprint/... ./pkg/modules/scan/...` — green.
- **New end-to-end test, `TestRunActiveProbes_SendsNothingToAPrintPort`:** binds `127.0.0.1:9100`, counts bytes the client sends, and drives both `runActiveProbes` and `runTLSFallbackPass` at it with an `http` hint already in the accumulator. Zero bytes, zero observations. The listener is the only way to test this honestly — the defect is not what comes back, it is what goes out. It skips rather than fails where the port cannot be bound.
- **Mutation-tested the guard**, not just the arithmetic: with the two `payloadForbidden` checks disabled, the same test reports **1479 bytes reaching the print port** and the catalog test fails; restored, both pass. The 1479 bytes are the printed page, measured.
- Catalog-level tests cover the shipped catalog (not a hand-built one), the `never_probe_ports` extension, the refusal to let a catalog shrink the floor, and a control on a neighbouring non-print port where the fallback set is still returned.

## Risk / Rollback

Low. The change only removes probes from a selection result, and only for four ports. If a print port ever needs probing for diagnostics, the floor is a single slice in `probe_catalog.go`. Rollback is reverting this commit; nothing persists and no data shape changes.

Not addressed here, deliberately: 631 (IPP) and 9110+ vendor ports. IPP is a real HTTP service that answers rather than prints, and the vendor ports were not observed in the field report — widening the floor on speculation would remove identification we currently get for free.

## Linked Issue

Closes #268
