### PR TITLE
refactor(scan): give each target's probe timeout its own scope

### DIFF
--- a/pkg/modules/scan/ftp_native_probe.go
+++ b/pkg/modules/scan/ftp_native_probe.go
@@ -238,29 +238,40 @@ func (m *ftpNativeProbeModule) Execute(ctx context.Context, inputs map[string]an
 		return left.target < right.target
 	})
 
-	currentTarget := ""
-	var targetCtx context.Context
-	var cancel context.CancelFunc
-	defer func() {
-		if cancel != nil {
-			cancel()
+	// keys are sorted by target first, so each target's candidates are one
+	// contiguous run. Handing the run to a helper gives the per-target timeout
+	// a scope to be created and released in, instead of one iteration canceling
+	// the context the previous iteration made (cyprob#269).
+	for start := 0; start < len(keys); {
+		target := candidates[keys[start]].target
+		end := start
+		for end < len(keys) && candidates[keys[end]].target == target {
+			end++
 		}
-	}()
+		m.probeTargetCandidates(ctx, keys[start:end], candidates, outputChan)
+		start = end
+	}
+
+	return nil
+}
+
+// probeTargetCandidates probes every candidate of one target under a single
+// timeout, and releases that timeout before it returns.
+func (m *ftpNativeProbeModule) probeTargetCandidates(
+	ctx context.Context,
+	keys []string,
+	candidates map[string]ftpProbeCandidate,
+	outputChan chan<- engine.ModuleOutput,
+) {
+	targetCtx := ctx
+	if m.options.TotalTimeout > 0 {
+		var cancel context.CancelFunc
+		targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
+		defer cancel()
+	}
 
 	for _, key := range keys {
 		candidate := candidates[key]
-		if candidate.target != currentTarget {
-			if cancel != nil {
-				cancel()
-			}
-			currentTarget = candidate.target
-			targetCtx = ctx
-			cancel = nil
-			if m.options.TotalTimeout > 0 {
-				targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
-			}
-		}
-
 		result := probeFTPDetailsFunc(targetCtx, candidate.target, candidate.hostname, candidate.port, candidate.protocolHint, m.options)
 		outputChan <- engine.ModuleOutput{
 			FromModuleName: m.meta.ID,
@@ -270,8 +281,6 @@ func (m *ftpNativeProbeModule) Execute(ctx context.Context, inputs map[string]an
 			Target:         candidate.target,
 		}
 	}
-
-	return nil
 }
 
 func defaultFTPProbeOptions() FTPProbeOptions {

--- a/pkg/modules/scan/mysql_native_probe.go
+++ b/pkg/modules/scan/mysql_native_probe.go
@@ -228,29 +228,40 @@ func (m *mysqlNativeProbeModule) Execute(ctx context.Context, inputs map[string]
 		return left.target < right.target
 	})
 
-	currentTarget := ""
-	var targetCtx context.Context
-	var cancel context.CancelFunc
-	defer func() {
-		if cancel != nil {
-			cancel()
+	// keys are sorted by target first, so each target's candidates are one
+	// contiguous run. Handing the run to a helper gives the per-target timeout
+	// a scope to be created and released in, instead of one iteration canceling
+	// the context the previous iteration made (cyprob#269).
+	for start := 0; start < len(keys); {
+		target := candidates[keys[start]].target
+		end := start
+		for end < len(keys) && candidates[keys[end]].target == target {
+			end++
 		}
-	}()
+		m.probeTargetCandidates(ctx, keys[start:end], candidates, outputChan)
+		start = end
+	}
+
+	return nil
+}
+
+// probeTargetCandidates probes every candidate of one target under a single
+// timeout, and releases that timeout before it returns.
+func (m *mysqlNativeProbeModule) probeTargetCandidates(
+	ctx context.Context,
+	keys []string,
+	candidates map[string]mysqlProbeCandidate,
+	outputChan chan<- engine.ModuleOutput,
+) {
+	targetCtx := ctx
+	if m.options.TotalTimeout > 0 {
+		var cancel context.CancelFunc
+		targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
+		defer cancel()
+	}
 
 	for _, key := range keys {
 		candidate := candidates[key]
-		if candidate.target != currentTarget {
-			if cancel != nil {
-				cancel()
-			}
-			currentTarget = candidate.target
-			targetCtx = ctx
-			cancel = nil
-			if m.options.TotalTimeout > 0 {
-				targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
-			}
-		}
-
 		result := probeMySQLDetailsFunc(targetCtx, candidate.target, candidate.hostname, candidate.port, m.options)
 		outputChan <- engine.ModuleOutput{
 			FromModuleName: m.meta.ID,
@@ -260,8 +271,6 @@ func (m *mysqlNativeProbeModule) Execute(ctx context.Context, inputs map[string]
 			Target:         candidate.target,
 		}
 	}
-
-	return nil
 }
 
 func defaultMySQLProbeOptions() MySQLProbeOptions {

--- a/pkg/modules/scan/native_probe_target_timeout_test.go
+++ b/pkg/modules/scan/native_probe_target_timeout_test.go
@@ -1,0 +1,81 @@
+package scan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cyprob/cyprob/pkg/engine"
+	"github.com/cyprob/cyprob/pkg/modules/discovery"
+	"github.com/stretchr/testify/require"
+)
+
+// drainOutputs empties a module's output channel so Execute cannot block on it.
+func drainOutputs(out chan engine.ModuleOutput) {
+	close(out)
+	for range out {
+	}
+}
+
+// The per-target timeout must be released by the code that created it, for
+// every target including the last one (cyprob#269). Capturing the contexts the
+// loop hands to the probe is the only way to see it: the module returns results,
+// not contexts.
+func TestFTPNativeProbe_ReleasesEveryTargetTimeout(t *testing.T) {
+	original := probeFTPDetailsFunc
+	defer func() { probeFTPDetailsFunc = original }()
+
+	var seen []context.Context
+	probeFTPDetailsFunc = func(ctx context.Context, target string, hostname string, port int, protocolHint string, opts FTPProbeOptions) FTPServiceInfo {
+		seen = append(seen, ctx)
+		return FTPServiceInfo{Target: target, Port: port, FTPProbe: true}
+	}
+
+	module := newFTPNativeProbeModule()
+	require.NoError(t, module.Init("test-ftp-native", map[string]any{"total_timeout": "2500ms"}))
+
+	out := make(chan engine.ModuleOutput, 8)
+	require.NoError(t, module.Execute(context.Background(), map[string]any{
+		"discovery.open_tcp_ports": []any{
+			discovery.TCPPortDiscoveryResult{Target: "198.51.100.60", OpenPorts: []int{21}},
+			discovery.TCPPortDiscoveryResult{Target: "198.51.100.61", OpenPorts: []int{21}},
+		},
+	}, out))
+	drainOutputs(out)
+
+	require.Len(t, seen, 2, "one context per target")
+	for i, ctx := range seen {
+		_, hasDeadline := ctx.Deadline()
+		require.True(t, hasDeadline, "context %d carries the per-target timeout", i)
+		require.Error(t, ctx.Err(), "context %d must be released before Execute returns", i)
+	}
+}
+
+// Same property, second module, because the four native probes share this loop
+// shape verbatim and a fix applied to one of them proves nothing about the rest.
+func TestWINRMNativeProbe_ReleasesEveryTargetTimeout(t *testing.T) {
+	original := probeWINRMDetailsFunc
+	defer func() { probeWINRMDetailsFunc = original }()
+
+	var seen []context.Context
+	probeWINRMDetailsFunc = func(ctx context.Context, target string, hostname string, port int, opts WINRMProbeOptions) WINRMServiceInfo {
+		seen = append(seen, ctx)
+		return WINRMServiceInfo{Target: target, Port: port, WINRMProbe: true}
+	}
+
+	module := newWINRMNativeProbeModule()
+	require.NoError(t, module.Init("test-winrm-native", map[string]any{"total_timeout": "2500ms"}))
+
+	out := make(chan engine.ModuleOutput, 8)
+	require.NoError(t, module.Execute(context.Background(), map[string]any{
+		"discovery.open_tcp_ports": []any{
+			discovery.TCPPortDiscoveryResult{Target: "198.51.100.60", OpenPorts: []int{5985}},
+			discovery.TCPPortDiscoveryResult{Target: "198.51.100.61", OpenPorts: []int{5985}},
+		},
+	}, out))
+	drainOutputs(out)
+
+	require.Len(t, seen, 2, "one context per target")
+	for i, ctx := range seen {
+		require.Error(t, ctx.Err(), "context %d must be released before Execute returns", i)
+	}
+}

--- a/pkg/modules/scan/smtp_native_probe.go
+++ b/pkg/modules/scan/smtp_native_probe.go
@@ -245,29 +245,40 @@ func (m *smtpNativeProbeModule) Execute(ctx context.Context, inputs map[string]a
 		return left.target < right.target
 	})
 
-	currentTarget := ""
-	var targetCtx context.Context
-	var cancel context.CancelFunc
-	defer func() {
-		if cancel != nil {
-			cancel()
+	// keys are sorted by target first, so each target's candidates are one
+	// contiguous run. Handing the run to a helper gives the per-target timeout
+	// a scope to be created and released in, instead of one iteration canceling
+	// the context the previous iteration made (cyprob#269).
+	for start := 0; start < len(keys); {
+		target := candidates[keys[start]].target
+		end := start
+		for end < len(keys) && candidates[keys[end]].target == target {
+			end++
 		}
-	}()
+		m.probeTargetCandidates(ctx, keys[start:end], candidates, outputChan)
+		start = end
+	}
+
+	return nil
+}
+
+// probeTargetCandidates probes every candidate of one target under a single
+// timeout, and releases that timeout before it returns.
+func (m *smtpNativeProbeModule) probeTargetCandidates(
+	ctx context.Context,
+	keys []string,
+	candidates map[string]smtpProbeCandidate,
+	outputChan chan<- engine.ModuleOutput,
+) {
+	targetCtx := ctx
+	if m.options.TotalTimeout > 0 {
+		var cancel context.CancelFunc
+		targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
+		defer cancel()
+	}
 
 	for _, key := range keys {
 		candidate := candidates[key]
-		if candidate.target != currentTarget {
-			if cancel != nil {
-				cancel()
-			}
-			currentTarget = candidate.target
-			targetCtx = ctx
-			cancel = nil
-			if m.options.TotalTimeout > 0 {
-				targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
-			}
-		}
-
 		result := probeSMTPDetailsFunc(targetCtx, candidate.target, candidate.hostname, candidate.port, m.options)
 		outputChan <- engine.ModuleOutput{
 			FromModuleName: m.meta.ID,
@@ -277,8 +288,6 @@ func (m *smtpNativeProbeModule) Execute(ctx context.Context, inputs map[string]a
 			Target:         candidate.target,
 		}
 	}
-
-	return nil
 }
 
 func defaultSMTPProbeOptions() SMTPProbeOptions {

--- a/pkg/modules/scan/winrm_native_probe.go
+++ b/pkg/modules/scan/winrm_native_probe.go
@@ -178,29 +178,40 @@ func (m *winrmNativeProbeModule) Execute(ctx context.Context, inputs map[string]
 		return left.target < right.target
 	})
 
-	currentTarget := ""
-	var targetCtx context.Context
-	var cancel context.CancelFunc
-	defer func() {
-		if cancel != nil {
-			cancel()
+	// keys are sorted by target first, so each target's candidates are one
+	// contiguous run. Handing the run to a helper gives the per-target timeout
+	// a scope to be created and released in, instead of one iteration canceling
+	// the context the previous iteration made (cyprob#269).
+	for start := 0; start < len(keys); {
+		target := candidates[keys[start]].target
+		end := start
+		for end < len(keys) && candidates[keys[end]].target == target {
+			end++
 		}
-	}()
+		m.probeTargetCandidates(ctx, keys[start:end], candidates, outputChan)
+		start = end
+	}
+
+	return nil
+}
+
+// probeTargetCandidates probes every candidate of one target under a single
+// timeout, and releases that timeout before it returns.
+func (m *winrmNativeProbeModule) probeTargetCandidates(
+	ctx context.Context,
+	keys []string,
+	candidates map[string]winrmProbeCandidate,
+	outputChan chan<- engine.ModuleOutput,
+) {
+	targetCtx := ctx
+	if m.options.TotalTimeout > 0 {
+		var cancel context.CancelFunc
+		targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
+		defer cancel()
+	}
 
 	for _, key := range keys {
 		candidate := candidates[key]
-		if candidate.target != currentTarget {
-			if cancel != nil {
-				cancel()
-			}
-			currentTarget = candidate.target
-			targetCtx = ctx
-			cancel = nil
-			if m.options.TotalTimeout > 0 {
-				targetCtx, cancel = context.WithTimeout(ctx, m.options.TotalTimeout)
-			}
-		}
-
 		result := probeWINRMDetailsFunc(targetCtx, candidate.target, candidate.hostname, candidate.port, m.options)
 		outputChan <- engine.ModuleOutput{
 			FromModuleName: m.meta.ID,
@@ -210,8 +221,6 @@ func (m *winrmNativeProbeModule) Execute(ctx context.Context, inputs map[string]
 			Target:         candidate.target,
 		}
 	}
-
-	return nil
 }
 
 func defaultWINRMProbeOptions() WINRMProbeOptions {


### PR DESCRIPTION
## Problem

`go vet` reports a possible context leak in four native probe modules (#269) — `ftp`, `mysql`, `smtp` and `winrm`, two findings each, eight in total, blocking a clean vet run.

**The report is real; its premise is not.** All four already release the last context, through a deferred closure that each `Execute` declares right after `var cancel context.CancelFunc`. What `lostcancel` cannot do is see a cancel that happens inside a deferred func literal, so it flags the `context.WithTimeout` assignment and every `return` below it.

Measured before changing anything: a test that captures the contexts the loop hands to the probe shows **both** of them, including the last, carrying `context canceled` by the time `Execute` returns — on `main`, before this change.

## User / Ops Impact

None. Nothing was leaking, and nothing about scanning changes. The value is a vet run whose findings are all worth reading, and a loop that is easier to be right about.

## Fix Summary

Give the timeout a scope instead of a lifetime that spans iterations.

The candidate keys are already sorted by target, so each target's candidates form one contiguous run. Handing that run to `probeTargetCandidates` lets the helper create the timeout and `defer cancel()` it three lines later — the shape `lostcancel` is built to recognise, and the shape the rest of this file already uses for single-shot probes.

The cross-iteration dance goes away with it: no `currentTarget` string, no cancel belonging to the previous target, no `cancel = nil` reset. Four files, the same edit in each, because the four share this loop verbatim.

## Behavior Change

None. Same candidates, same order, one timeout per target as before, same outputs on the same channel. The difference is where the release happens: at the end of the target's own work rather than at the start of the next target's, or in a deferred closure at function exit.

## Evidence

- `GOWORK=off go vet ./pkg/modules/scan/...` — **0 findings**, down from 8. That is the point of the change.
- `GOWORK=off go build ./...` and `go test ./pkg/modules/scan/...` — clean, full package green including every pre-existing probe test.
- **Two new tests** — `TestFTPNativeProbe_ReleasesEveryTargetTimeout` and `TestWINRMNativeProbe_ReleasesEveryTargetTimeout` — capture the per-target contexts through the module's own probe seam and assert each carries a deadline and is released before `Execute` returns. Two modules rather than one because the four share the loop verbatim and a property proved on one of them proves nothing about the rest.
- **Mutation-tested:** replacing `defer cancel()` with `_ = cancel` in both modules fails both tests; restored, both pass. The tests observe the property rather than the code shape.

## Risk / Rollback

Low. No behaviour change, no new dependency, no config. The one thing worth a reviewer's eye is the grouping loop — it assumes `keys` is sorted by target, which is what `sort.Slice` above it guarantees (target first, then port). Rollback is reverting this commit.

## Linked Issue

Closes #269
