### PR TITLE
feat(fingerprint): identify Lenovo IMM2 and SFCB BMC banners

### DIFF
--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -781,6 +781,41 @@ rules:
     pattern_strength: 0.95
     port_bonuses: [902]
 
+  - id: 'http.lenovo_imm2'
+    protocol: 'http'
+    description: 'Lenovo IMM2 (Integrated Management Module II) BMC web server banner'
+    product: 'Integrated Management Module II (IMM2)'
+    vendor: 'Lenovo'
+    cpe: 'cpe:2.3:o:lenovo:integrated_management_module_ii_firmware:*:*:*:*:*:*:*:*'
+    match: 'server:\s*lenovo imm2 web server'
+
+    soft_exclude_patterns:
+      - "error"
+      - "unavailable"
+
+    pattern_strength: 0.95
+    port_bonuses: [5985, 5986]
+
+  # sfcHttpd is the HTTP front end of SFCB (Small Footprint CIM Broker, the
+  # SBLIM project) -- an open-source CIM/WBEM broker bundled into several
+  # vendors' BMC firmware (observed alongside Lenovo IMM2, but SFCB itself
+  # isn't Lenovo's). Attributed to the upstream project, not the device
+  # vendor it happens to ship inside on any one host.
+  - id: 'http.sfcb'
+    protocol: 'http'
+    description: 'SFCB (Small Footprint CIM Broker) CIM/WBEM HTTP interface banner'
+    product: 'SFCB (Small Footprint CIM Broker)'
+    vendor: 'SBLIM'
+    cpe: 'cpe:2.3:a:sblim:sfcb:*:*:*:*:*:*:*:*'
+    match: 'server:\s*sfchttpd'
+
+    soft_exclude_patterns:
+      - "error"
+      - "unavailable"
+
+    pattern_strength: 0.85
+    port_bonuses: [5988, 5989]
+
   - id: 'vnc.realvnc'
     protocol: 'vnc'
     description: 'RealVNC or VNC protocol banner'

--- a/pkg/fingerprint/testdata/validation_dataset.yaml
+++ b/pkg/fingerprint/testdata/validation_dataset.yaml
@@ -316,6 +316,22 @@ true_positives:
     expected_version: ''
     description: 'libwebsockets server on the conventional VNC port, previously unmatched (cyprob-ee#157)'
 
+  - protocol: http
+    port: 5985
+    banner: 'HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Basic realm="avocent.com"\r\nServer: Lenovo IMM2 Web Server'
+    expected_product: 'Integrated Management Module II (IMM2)'
+    expected_vendor: 'Lenovo'
+    expected_version: ''
+    description: 'Lenovo IMM2 BMC web server, WinRM-labeled port, previously unmatched (cyprob#275)'
+
+  - protocol: http
+    port: 5988
+    banner: 'HTTP/1.1 501 Not Implemented\r\nServer: sfcHttpd'
+    expected_product: 'SFCB (Small Footprint CIM Broker)'
+    expected_vendor: 'SBLIM'
+    expected_version: ''
+    description: 'sfcHttpd CIM/WBEM interface, attributed to the SBLIM project not the device vendor, previously unmatched (cyprob#275)'
+
   # FTP Servers (10 cases)
   - protocol: ftp
     port: 21


### PR DESCRIPTION
## Problem

`192.168.0.43` (office network) has a BMC-style management interface with
two clearly self-identifying `Server:` banners, neither recognized:

```
5985/tcp, 5986/tcp (WinRM-labeled): Server: Lenovo IMM2 Web Server
5988/tcp, 5989/tcp (CIM/WBEM):      Server: sfcHttpd
```

`service_product`/`service_vendor` were empty for all four rows in
`asset_services`; `tech_tags` carried only protocol-level tags.

## Fix

Two new rules in `pkg/fingerprint/data/fingerprint_db.yaml`:

- `http.lenovo_imm2` — matches `Server: Lenovo IMM2 Web Server` →
  vendor Lenovo, product Integrated Management Module II (IMM2).
- `http.sfcb` — matches `Server: sfcHttpd` → vendor SBLIM, product
  SFCB (Small Footprint CIM Broker).

On the "is this Lenovo-specific" question the issue raised: SFCB/sfcHttpd
is the HTTP front end of the open-source SBLIM CIM broker project, bundled
into multiple vendors' BMC firmware — not exclusive to Lenovo. Attributed
the rule to the upstream project (SBLIM), not the device vendor it happens
to ship inside of on this one host, per the issue's own suggested fallback.

## Evidence

Measured live against the reporting host, not inferred from the banner
strings alone:

- Grabbed raw `Server:` headers from all four ports directly (`curl -i`)
  before writing anything — confirmed the exact banner text.
- Ran a real targeted scan (`cyprob scan -t 192.168.0.43 -p
  5985,5986,5988,5989`) with the fix applied — `service.product`,
  `parsed_attributes.vendor`, and `parsed_attributes.cpe` are populated
  with `field_sources.vendor: "fingerprint"` for all four ports.
- A/B'd against a binary built from the same tree *without* the fix —
  before: `product` is a bare banner-string heuristic and `vendor` is
  empty (matches the issue's reported symptom exactly); after: both
  populated via the new fingerprint rules. Confirms the fix, not some
  other variable, is what moved the fields.
- `cyprob fingerprint validate --strict` — clean.
- `go test ./pkg/fingerprint/...` — passes, including the
  double-escape/regex-collision guard added in #274.

## Not established

Whether these four ports are the same physical BMC as the host's other
services (137/443 etc.) — reasonable inference from the banners, not
confirmed via a shared serial/MAC. Not addressed by this PR (not what
was asked; fingerprint identification doesn't need that confirmed).

## Risk / Rollback

Two new additive fingerprint rules, no existing rule modified. Worst case
if a match pattern is too broad: a wrong product/vendor label on some
other service's banner — bounded by the regex specificity ("lenovo imm2
web server" and "sfchttpd" are both full product-name strings, not generic
words) and by `go test ./pkg/fingerprint/...`'s collision guard, which
passes. Rollback is reverting this one file.

Refs #275
