### PR TITLE
feat(fingerprint): identify MikroTik RouterOS from its HTTP title

### DIFF
--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -175,6 +175,25 @@ rules:
 
     pattern_strength: 0.85
 
+  # No Server: header on MikroTik's WebFig login page -- the only
+  # self-identifying string is the HTML <title>. Matched against the full
+  # response body like any other rule here (see http.lenovo_imm2 for the
+  # same shape against a header instead), so no new mechanism is needed.
+  - id: 'http.mikrotik_routeros'
+    protocol: 'http'
+    description: 'MikroTik RouterOS WebFig HTML title, no Server: header present'
+    product: 'RouterOS'
+    vendor: 'MikroTik'
+    cpe: 'cpe:2.3:o:mikrotik:routeros:*:*:*:*:*:*:*:*'
+    match: '<title>\s*routeros router configuration page\s*</title>'
+
+    soft_exclude_patterns:
+      - "error"
+      - "unavailable"
+
+    pattern_strength: 0.9
+    port_bonuses: [80, 443]
+
   # FTP Servers
   - id: 'ftp.pureftpd'
     protocol: 'ftp'

--- a/pkg/fingerprint/testdata/validation_dataset.yaml
+++ b/pkg/fingerprint/testdata/validation_dataset.yaml
@@ -332,6 +332,14 @@ true_positives:
     expected_version: ''
     description: 'sfcHttpd CIM/WBEM interface, attributed to the SBLIM project not the device vendor, previously unmatched (cyprob#275)'
 
+  - protocol: http
+    port: 80
+    banner: '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><title>RouterOS router configuration page</title></head></html>'
+    expected_product: 'RouterOS'
+    expected_vendor: 'MikroTik'
+    expected_version: ''
+    description: 'MikroTik RouterOS WebFig page, no Server: header, identified only by HTML title, previously unmatched (cyprob#276)'
+
   # FTP Servers (10 cases)
   - protocol: ftp
     port: 21


### PR DESCRIPTION
## Problem

`192.168.0.41` (MikroTik RouterOS, office network) is correctly identified
on `21/tcp` ("RouterOS Telnet", vendor MikroTik) and `22/tcp` ("ROSSSH")
via their own native probes. `80/tcp` on the same device carries only
protocol-level tags (`http`/`http_server`/`web_server`) -- no product, no
vendor -- despite the page stating the product outright:

```
<title>RouterOS router configuration page</title>
```

There is no `Server:` header on this endpoint at all, only the title.

## Fix

New rule in `pkg/fingerprint/data/fingerprint_db.yaml`:

- `http.mikrotik_routeros` -- matches
  `<title>RouterOS router configuration page</title>` in the response
  body. This is the same matching mechanism every other rule in the file
  already uses (the resolver matches the full lowercased response, not
  just headers) -- see `http.lenovo_imm2` (cyprob#275) for the same shape
  matched against a header instead of a body string. No new mechanism
  needed, just a rule that targets the body.

Also added a `validation_dataset.yaml` entry alongside it (Talos flagged
this as a routine addition in #277's review, not just an on-request one).

## Evidence

Measured live against the reporting host, not inferred:

- `curl -i` against `192.168.0.41:80` directly, before writing anything --
  confirmed there's genuinely no `Server:` header, only the title in the
  body.
- Ran a real targeted scan (`cyprob scan -t 192.168.0.41 -p 21,22,80`)
  with the fix -- port 80's `service.product`/`parsed_attributes.vendor`/
  `parsed_attributes.cpe` are now populated with
  `field_sources.vendor: "fingerprint"`, matching what 21/22 already
  report via their native probes. 21/22 unaffected, as expected -- this
  rule only had to cover the gap on 80.
- A/B'd against a binary built from the same tree *without* the fix --
  before: port 80's product is a bare `"HTTP"` heuristic guess, vendor
  empty; after: both populated. Matches the issue's reported symptom
  exactly.
- `cyprob fingerprint validate --strict` -- clean.
- `go test ./pkg/fingerprint/...` -- passes, 0 false positives on the full
  167-case validation suite (up from 166 after #277, +1 for this rule).

## Not established

Whether MikroTik's WebFig title string is stable across RouterOS firmware
versions -- only measured on this one live device's current version. The
match targets the exact observed string rather than a looser pattern,
consistent with not guessing at variations that weren't measured.

## Risk / Rollback

One new additive fingerprint rule, no existing rule modified. The title
string is specific enough (`routeros router configuration page`) that a
collision with an unrelated device is unlikely, and `go test
./pkg/fingerprint/...`'s collision guard passes. Rollback is reverting
this one file.

Refs #276
