### PR TITLE
ci: drop macos-latest from Build Binary matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,7 +122,12 @@ jobs:
         # check's identity -- so a required check named after the Go version
         # can never run again once the version changes, and every bump blocks
         # itself with all checks green. See #248.
-        os: [ubuntu-latest, macos-latest]
+        #
+        # macos-latest dropped: CE is documented as cross-platform (macOS,
+        # Linux, Windows) but that's a future intent, not a current one --
+        # nothing ships or runs on macOS today, so the leg was pure CI
+        # latency with no real signal. Re-add when macOS is an actual target.
+        os: [ubuntu-latest]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Problem

`Build Binary` runs as a 2-item matrix (`ubuntu-latest`, `macos-latest`).
`macos-latest` is not a required status check (only `Build Binary
(ubuntu-latest)` is), but it still runs on every PR, and it's routinely
the slowest leg -- both of today's fingerprint PRs (#277, #278) sat
waiting on it after every other check had already passed.

CE's own docs describe cross-platform support (macOS, Linux, Windows) as
the intended direction, but that's a future target, not a current one --
nothing ships, is tested, or runs on macOS today. The leg builds and
smoke-tests a native Darwin binary that no one uses, on every single PR.

## Fix

Drop `macos-latest` from the `test-build` matrix in
`.github/workflows/test.yaml`, leaving `ubuntu-latest` only.

## Behavior Change

`Build Binary (macos-latest)` no longer runs. `Build Binary
(ubuntu-latest)` (the required check) is unaffected. No product code
changed.

## Evidence

Confirmed via `gh api repos/cyprob/cyprob/branches/main/protection/required_status_checks`
that `Build Binary (macos-latest)` is absent from the required-checks
list (only `Build Binary (ubuntu-latest)` is required) -- removing it
does not leave a required check that can never run.

## Risk / Rollback

None to product behavior -- CI-only change. If macOS becomes an actual
target later, re-add `macos-latest` to the matrix array (one line).

## Linked Issue

None