### PR TITLE
fix: pace port scan probes and stop retrying refusals

### DIFF
--- a/pkg/modules/discovery/tcp_port_discovery.go
+++ b/pkg/modules/discovery/tcp_port_discovery.go
@@ -43,6 +43,16 @@ type TCPPortDiscoveryConfig struct {
 	Retries                 int                   `json:"retries"`
 	StopOnFirstOpen         bool                  `json:"stop_on_first_open"`
 	VerificationPassEnabled bool                  `json:"verification_pass_enabled"`
+	// BatchEnabled paces a target's port probes in groups of BatchSize,
+	// waiting BatchDelay between groups, instead of letting Concurrency alone
+	// decide how many connections a single host receives at once. EE has
+	// plumbed batch_enabled/batch_size/batch_delay through since before this
+	// module read them (cyprob-ee#97) - a single scan of one host could open
+	// up to Concurrency simultaneous connections against it with nothing to
+	// space them out.
+	BatchEnabled bool          `json:"batch_enabled,omitempty"`
+	BatchSize    int           `json:"batch_size,omitempty"`
+	BatchDelay   time.Duration `json:"batch_delay,omitempty"`
 }
 
 // TCPPortDiscoveryModule implements the engine.Module interface for TCP port discovery.
@@ -191,6 +201,24 @@ func newTCPPortDiscoveryModule() *TCPPortDiscoveryModule {
 					Required:    false,
 					Default:     defaultConfig.VerificationPassEnabled,
 				},
+				"batch_enabled": {
+					Description: "Pace a target's port probes in groups of batch_size, waiting batch_delay between groups, instead of sending all of them at once (bounded only by concurrency).",
+					Type:        "bool",
+					Required:    false,
+					Default:     defaultConfig.BatchEnabled,
+				},
+				"batch_size": {
+					Description: "Number of ports probed per group when batch_enabled is true.",
+					Type:        "int",
+					Required:    false,
+					Default:     0,
+				},
+				"batch_delay": {
+					Description: "Pause between port groups when batch_enabled is true (e.g., '500ms').",
+					Type:        "duration",
+					Required:    false,
+					Default:     "0s",
+				},
 			},
 			// ActivationTriggers: Usually none for a primary discovery module, unless it depends on a very specific prior state.
 			// IsDynamic: false,
@@ -258,6 +286,23 @@ func (m *TCPPortDiscoveryModule) Init(instanceID string, moduleConfig map[string
 	}
 	if verificationPassEnabled, ok := moduleConfig["verification_pass_enabled"]; ok {
 		cfg.VerificationPassEnabled = cast.ToBool(verificationPassEnabled)
+	}
+	if batchEnabledVal, ok := moduleConfig["batch_enabled"]; ok {
+		cfg.BatchEnabled = cast.ToBool(batchEnabledVal)
+	}
+	if batchSizeVal, ok := moduleConfig["batch_size"]; ok {
+		cfg.BatchSize = cast.ToInt(batchSizeVal)
+		if cfg.BatchSize < 0 {
+			fmt.Printf("[WARN] Module '%s': batch_size in config is < 0 (%d). Disabling pacing.\n", m.meta.Name, cfg.BatchSize)
+			cfg.BatchSize = 0
+		}
+	}
+	if batchDelayStr, ok := moduleConfig["batch_delay"].(string); ok && strings.TrimSpace(batchDelayStr) != "" {
+		if dur, err := time.ParseDuration(batchDelayStr); err == nil && dur >= 0 {
+			cfg.BatchDelay = dur
+		} else {
+			fmt.Printf("[WARN] Module '%s': Invalid 'batch_delay' format in config: '%s'. Keeping default: %s\n", m.meta.Name, batchDelayStr, cfg.BatchDelay)
+		}
 	}
 
 	// Sanitize final values
@@ -691,7 +736,60 @@ func (m *TCPPortDiscoveryModule) scanTargetPortsAll(
 	return openPorts
 }
 
+// scanPortBatch probes ports, optionally paced in groups of m.config.BatchSize
+// with m.config.BatchDelay between groups (cyprob-ee#97): without pacing,
+// Concurrency alone bounds how many connections a single host receives at
+// once, and a single-target scan can open up to Concurrency of them
+// simultaneously against that one IP.
 func (m *TCPPortDiscoveryModule) scanPortBatch(
+	ctx context.Context,
+	ip string,
+	ports []int,
+	sem chan struct{},
+	outcomes *tcpPortScanOutcomes,
+	timeout time.Duration,
+) {
+	chunks := m.chunkPortsForPacing(ports)
+
+	for i, chunk := range chunks {
+		if ctx.Err() != nil {
+			return
+		}
+
+		m.dialChunk(ctx, ip, chunk, sem, outcomes, timeout)
+
+		if i == len(chunks)-1 || m.config.BatchDelay <= 0 {
+			continue
+		}
+
+		timer := time.NewTimer(m.config.BatchDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// chunkPortsForPacing splits ports into BatchSize-sized groups when pacing is
+// enabled; otherwise every port stays in a single group, which is the
+// original, unpaced behavior.
+func (m *TCPPortDiscoveryModule) chunkPortsForPacing(ports []int) [][]int {
+	if !m.config.BatchEnabled || m.config.BatchSize <= 0 || m.config.BatchSize >= len(ports) {
+		return [][]int{ports}
+	}
+
+	chunks := make([][]int, 0, (len(ports)+m.config.BatchSize-1)/m.config.BatchSize)
+	for start := 0; start < len(ports); start += m.config.BatchSize {
+		end := min(start+m.config.BatchSize, len(ports))
+		chunks = append(chunks, ports[start:end])
+	}
+	return chunks
+}
+
+// dialChunk probes one group of ports concurrently, bounded by sem.
+func (m *TCPPortDiscoveryModule) dialChunk(
 	ctx context.Context,
 	ip string,
 	ports []int,
@@ -781,6 +879,15 @@ func (m *TCPPortDiscoveryModule) dialWithRetries(ctx context.Context, address st
 			return conn, nil
 		}
 		lastErr = err
+
+		// A refusal is a definitive answer, and EHOSTUNREACH is the target's
+		// own back-off signal - retrying either only adds churn against a
+		// host that already gave us the answer (cyprob-ee#97, field-measured:
+		// a refused-like error retried at the forced top_1000 retries=3
+		// quadrupled connection attempts against healthy hosts).
+		if isRefusedLikeError(err) || isHostUnreachableError(err) {
+			break
+		}
 	}
 
 	return nil, lastErr
@@ -802,6 +909,19 @@ func isRefusedLikeError(err error) bool {
 		return false
 	}
 	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// isHostUnreachableError reports EHOSTUNREACH, which a device emits when its
+// own defenses are engaging under load - field-measured on this estate
+// (cyprob-ee#97): 30 rapid sequential connects to one management controller
+// produced EHOSTUNREACH on 443/8443. It is the target telling the scanner to
+// back off, not a transient hiccup, so unlike a plain timeout it must not be
+// retried or re-probed at a longer timeout.
+func isHostUnreachableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.EHOSTUNREACH)
 }
 
 func recordNegativeOutcome(
@@ -827,10 +947,14 @@ func recordNegativeOutcome(
 }
 
 type tcpPortScanOutcomes struct {
-	mu          sync.Mutex
-	open        map[int]struct{}
-	timedOut    map[int]struct{}
-	refused     map[int]struct{}
+	mu       sync.Mutex
+	open     map[int]struct{}
+	timedOut map[int]struct{}
+	refused  map[int]struct{}
+	// backoff holds EHOSTUNREACH ports: reported alongside otherErrors (no
+	// external schema change) but, unlike otherErrors, never handed to
+	// reverifyPorts - see isHostUnreachableError.
+	backoff     map[int]struct{}
 	otherErrors map[int]struct{}
 }
 
@@ -839,6 +963,7 @@ func newTCPPortScanOutcomes() *tcpPortScanOutcomes {
 		open:        make(map[int]struct{}),
 		timedOut:    make(map[int]struct{}),
 		refused:     make(map[int]struct{}),
+		backoff:     make(map[int]struct{}),
 		otherErrors: make(map[int]struct{}),
 	}
 }
@@ -850,6 +975,7 @@ func (o *tcpPortScanOutcomes) recordOpen(port int) {
 	o.open[port] = struct{}{}
 	delete(o.timedOut, port)
 	delete(o.refused, port)
+	delete(o.backoff, port)
 	delete(o.otherErrors, port)
 }
 
@@ -863,6 +989,7 @@ func (o *tcpPortScanOutcomes) recordNegative(port int, err error) {
 
 	delete(o.timedOut, port)
 	delete(o.refused, port)
+	delete(o.backoff, port)
 	delete(o.otherErrors, port)
 
 	switch {
@@ -870,6 +997,8 @@ func (o *tcpPortScanOutcomes) recordNegative(port int, err error) {
 		o.timedOut[port] = struct{}{}
 	case isRefusedLikeError(err):
 		o.refused[port] = struct{}{}
+	case isHostUnreachableError(err):
+		o.backoff[port] = struct{}{}
 	default:
 		o.otherErrors[port] = struct{}{}
 	}
@@ -877,7 +1006,8 @@ func (o *tcpPortScanOutcomes) recordNegative(port int, err error) {
 
 // reverifyPorts returns the ports worth a second, full-timeout probe: those
 // that timed out or hit a transient error on the first (possibly short) pass.
-// Open ports need no recheck; refused ports are definitively closed.
+// Open ports need no recheck; refused ports are definitively closed; backoff
+// (EHOSTUNREACH) ports are the target telling us to stop, not to try harder.
 func (o *tcpPortScanOutcomes) reverifyPorts() []int {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -905,8 +1035,22 @@ func (o *tcpPortScanOutcomes) refusedPorts() []int {
 	return sortedPortsFromSet(o.refused)
 }
 
+// otherErrorPorts reports backoff (EHOSTUNREACH) ports together with the
+// genuinely-unclassified ones: from the result schema's point of view both
+// are still "some other error", the only change is that backoff ports are
+// excluded from reverifyPorts.
 func (o *tcpPortScanOutcomes) otherErrorPorts() []int {
-	return sortedPortsFromSet(o.otherErrors)
+	if len(o.backoff) == 0 {
+		return sortedPortsFromSet(o.otherErrors)
+	}
+	merged := make(map[int]struct{}, len(o.otherErrors)+len(o.backoff))
+	for port := range o.otherErrors {
+		merged[port] = struct{}{}
+	}
+	for port := range o.backoff {
+		merged[port] = struct{}{}
+	}
+	return sortedPortsFromSet(merged)
 }
 
 func sortedPortsFromSet(set map[int]struct{}) []int {

--- a/pkg/modules/discovery/tcp_port_discovery_test.go
+++ b/pkg/modules/discovery/tcp_port_discovery_test.go
@@ -1058,3 +1058,178 @@ func TestTCPPortDiscoveryModule_SweepOptOut(t *testing.T) {
 		require.Equal(t, defaultTCPSweepTimeout, module.config.SweepTimeout)
 	})
 }
+
+// cyprob-ee#97: a refused connection is a definitive answer; retrying it only
+// adds churn against a healthy host for zero new information.
+func TestTCPPortDiscoveryModule_DialWithRetriesDoesNotRetryRefusedConnection(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = 10 * time.Millisecond
+	module.config.Retries = 3 // top_1000's forced retry count, per the issue
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+
+	attempts := 0
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		attempts++
+		return nil, syscall.ECONNREFUSED
+	}
+
+	_, err := module.dialWithRetries(context.Background(), "127.0.0.1:81", 81, module.config.Timeout)
+	require.Error(t, err)
+	require.Equal(t, 1, attempts, "a refusal must stop the retry loop on the first attempt")
+}
+
+// cyprob-ee#97: EHOSTUNREACH is a device's own back-off signal, field-measured
+// on this estate (30 rapid connects to a management controller produced it).
+// Retrying it, or re-probing it harder in the verification pass, is the
+// opposite of what an adaptive scanner should do.
+func TestTCPPortDiscoveryModule_DialWithRetriesDoesNotRetryHostUnreachable(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = 10 * time.Millisecond
+	module.config.Retries = 3
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+
+	attempts := 0
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		attempts++
+		return nil, syscall.EHOSTUNREACH
+	}
+
+	_, err := module.dialWithRetries(context.Background(), "127.0.0.1:443", 443, module.config.Timeout)
+	require.Error(t, err)
+	require.Equal(t, 1, attempts, "a back-off signal must stop the retry loop on the first attempt")
+}
+
+// cyprob-ee#97: EHOSTUNREACH must not land in the verification pass's
+// reverify set (it would be re-probed at the longer full timeout, hitting a
+// backing-off device harder), while still surfacing as OtherErrorPorts in the
+// final result so the JSON schema is unchanged.
+func TestTCPPortDiscoveryModule_ScanTargetPortsAll_HostUnreachableIsNotReverified(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = time.Second
+	module.config.SweepTimeout = 200 * time.Millisecond
+	module.config.Retries = 0
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+
+	var mu sync.Mutex
+	dialCount := make(map[int]int)
+	dialTimeout = func(_ string, address string, timeout time.Duration) (net.Conn, error) {
+		_, portStr, _ := net.SplitHostPort(address)
+		port, _ := strconv.Atoi(portStr)
+		mu.Lock()
+		dialCount[port]++
+		mu.Unlock()
+		return nil, syscall.EHOSTUNREACH
+	}
+
+	openPortsByTarget := make(map[string][]int)
+	timedOutPortsByTarget := make(map[string][]int)
+	refusedPortsByTarget := make(map[string][]int)
+	otherErrorPortsByTarget := make(map[string][]int)
+	var mapMutex sync.Mutex
+
+	module.scanTargetPortsAll(
+		context.Background(),
+		"127.0.0.1",
+		[]int{443},
+		make(chan struct{}, 8),
+		&mapMutex,
+		openPortsByTarget,
+		timedOutPortsByTarget,
+		refusedPortsByTarget,
+		otherErrorPortsByTarget,
+	)
+
+	require.Equal(t, []int{443}, otherErrorPortsByTarget["127.0.0.1"],
+		"still reported as an other-error port, schema unchanged")
+	require.Empty(t, refusedPortsByTarget["127.0.0.1"],
+		"EHOSTUNREACH is not a refusal and must not be reported as one")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, dialCount[443], "must not be re-probed by the verification pass")
+}
+
+// cyprob-ee#97: EE has plumbed batch_enabled/batch_size/batch_delay through
+// since before this module read any of them; Init must actually parse them.
+func TestTCPPortDiscoveryModule_Init_ParsesBatchPacingOptions(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	require.NoError(t, module.Init("tcp-1", map[string]any{
+		"batch_enabled": true,
+		"batch_size":    50,
+		"batch_delay":   "1500ms",
+	}))
+
+	require.True(t, module.config.BatchEnabled)
+	require.Equal(t, 50, module.config.BatchSize)
+	require.Equal(t, 1500*time.Millisecond, module.config.BatchDelay)
+}
+
+func TestTCPPortDiscoveryModule_Init_BatchPacingDefaultsToDisabled(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	require.NoError(t, module.Init("tcp-1", map[string]any{}))
+
+	require.False(t, module.config.BatchEnabled)
+	require.Zero(t, module.config.BatchSize)
+	require.Zero(t, module.config.BatchDelay)
+}
+
+// cyprob-ee#97: with pacing enabled, a target's ports are probed in
+// BatchSize-sized groups with a BatchDelay pause between groups, instead of
+// all of them landing on the semaphore at once.
+func TestTCPPortDiscoveryModule_ScanPortBatch_PacesWhenBatchEnabled(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = time.Second
+	module.config.BatchEnabled = true
+	module.config.BatchSize = 2
+	module.config.BatchDelay = 60 * time.Millisecond
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	outcomes := newTCPPortScanOutcomes()
+	start := time.Now()
+	module.scanPortBatch(context.Background(), "127.0.0.1", []int{1, 2, 3, 4}, make(chan struct{}, 8), outcomes, module.config.Timeout)
+	elapsed := time.Since(start)
+
+	require.ElementsMatch(t, []int{1, 2, 3, 4}, outcomes.openPorts())
+	require.GreaterOrEqual(t, elapsed, module.config.BatchDelay,
+		"4 ports at batch_size=2 makes two groups, so one BatchDelay pause must elapse between them")
+}
+
+func TestTCPPortDiscoveryModule_ScanPortBatch_UnpacedWhenBatchDisabled(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = time.Second
+	module.config.BatchEnabled = false
+	// If pacing were mistakenly applied anyway, this delay would make the
+	// test time out-ish; asserting a tight upper bound below is the real check.
+	module.config.BatchSize = 2
+	module.config.BatchDelay = 2 * time.Second
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	outcomes := newTCPPortScanOutcomes()
+	start := time.Now()
+	module.scanPortBatch(context.Background(), "127.0.0.1", []int{1, 2, 3, 4}, make(chan struct{}, 8), outcomes, module.config.Timeout)
+	elapsed := time.Since(start)
+
+	require.ElementsMatch(t, []int{1, 2, 3, 4}, outcomes.openPorts())
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"batch_enabled=false must behave exactly like before: one unpaced group")
+}


### PR DESCRIPTION
## Summary

Three surgical fixes to `pkg/modules/discovery/tcp_port_discovery.go`'s load profile against a single host, closing the three priority items from cyprob-ee#97:

1. **Stop retrying refused connections.** `dialWithRetries` broke only on `err == nil`, so a closed port that RSTs instantly was still dialed `Retries+1` times (4x at the forced `top_1000` `retries=3`) - a definitive answer retried for zero new information.
2. **Stop treating EHOSTUNREACH as a transient error.** It was falling into the `otherErrors` bucket and getting re-probed by the verification pass at the *longer* timeout - the opposite of correct behavior, since EHOSTUNREACH is the target's own back-off signal (field-measured on this estate: 30 rapid connects to a management controller produced it on 443/8443). It's still reported under `OtherErrorPorts` in the result (no schema change), just no longer retried or reverified.
3. **Wire up the pacing EE already ships.** `batch_enabled`/`batch_size`/`batch_delay` have been built and plumbed by EE (`adapter.go`) since before this module read any of them - `grep`ping those three names across all of CE's `pkg/` returned zero hits before this PR. When enabled, a target's ports are now probed in `batch_size` groups with `batch_delay` between groups, instead of `Concurrency` alone bounding how many connections a single host receives at once.

Default behavior is unchanged: `batch_enabled` defaults to `false`, so nothing paces unless EE (or a caller) turns it on.

## Evidence

- **Field-reproduced the root cause independently**, against the exact host cyprob-ee#97's comment named (`192.168.0.62`): 8 back-to-back `top_1000`-shaped scans at `concurrency=100`, no batching - port 80 came back closed on 3/8 runs, alternating with no other variable changed. Same shape, same order of magnitude as the issue's own field measurement (3/5 closed). Confirms the concurrency-storm mechanism before fixing it, not just arithmetic from the code.
- Unit tests added for all three fixes (`dialWithRetries` stops at attempt 1 for both `ECONNREFUSED` and `EHOSTUNREACH`; EHOSTUNREACH ports are excluded from `reverifyPorts()` while still landing in `OtherErrorPorts`; `batch_enabled`/`batch_size`/`batch_delay` parse correctly from `Init`; `scanPortBatch` measurably paces when enabled and is unaffected when disabled).
- `go build ./...`, `go vet ./pkg/modules/discovery/...`, `golangci-lint run ./pkg/modules/discovery/...` all clean.
- All pre-existing tests in the package still pass unmodified.

## Test plan

- [x] `go test ./pkg/modules/discovery/...` - all pass, including new coverage
- [x] `golangci-lint run ./pkg/modules/discovery/...` - 0 issues
- [x] Live A/B against the field-confirmed flaky host (192.168.0.62) - baseline reproduced the reported flake

Closes cyprob-ee#97 items 1-3 (item 4, the TLS evidence probe / SMB probe scope, is explicitly lower priority and out of scope here).