### PR TITLE
fix: replace batching's chunk barrier with a sliding-window worker pool

### DIFF
--- a/pkg/modules/discovery/tcp_port_discovery.go
+++ b/pkg/modules/discovery/tcp_port_discovery.go
@@ -736,11 +736,19 @@ func (m *TCPPortDiscoveryModule) scanTargetPortsAll(
 	return openPorts
 }
 
-// scanPortBatch probes ports, optionally paced in groups of m.config.BatchSize
-// with m.config.BatchDelay between groups (cyprob-ee#97): without pacing,
-// Concurrency alone bounds how many connections a single host receives at
-// once, and a single-target scan can open up to Concurrency of them
-// simultaneously against that one IP.
+// scanPortBatch probes ports, optionally paced to at most m.config.BatchSize
+// of them in flight for this target at once, with m.config.BatchDelay between
+// a worker finishing one port and starting its next (cyprob-ee#97/#198):
+// without pacing, Concurrency alone bounds how many connections a single host
+// receives at once, and a single-target scan can open up to Concurrency of
+// them simultaneously against that one IP.
+//
+// Pacing is a fixed-size worker pool (batch_size workers), not a sequence of
+// hard-barrier groups: an earlier design waited for every port in a group to
+// finish - including its slowest straggler - before starting the next group,
+// which let one filtered port (a full timeout) inflate the wall-clock cost
+// of an entire group. Here, a slow port only holds up its own worker; the
+// other batch_size-1 workers keep pulling from the shared queue.
 func (m *TCPPortDiscoveryModule) scanPortBatch(
 	ctx context.Context,
 	ip string,
@@ -749,47 +757,62 @@ func (m *TCPPortDiscoveryModule) scanPortBatch(
 	outcomes *tcpPortScanOutcomes,
 	timeout time.Duration,
 ) {
-	chunks := m.chunkPortsForPacing(ports)
-
-	for i, chunk := range chunks {
-		if ctx.Err() != nil {
-			return
-		}
-
-		m.dialChunk(ctx, ip, chunk, sem, outcomes, timeout)
-
-		if i == len(chunks)-1 || m.config.BatchDelay <= 0 {
-			continue
-		}
-
-		timer := time.NewTimer(m.config.BatchDelay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return
-		case <-timer.C:
-		}
+	if !m.pacingEnabled(len(ports)) {
+		m.dialAllConcurrently(ctx, ip, ports, sem, outcomes, timeout)
+		return
 	}
+
+	portCh := make(chan int)
+	go func() {
+		defer close(portCh)
+		for _, port := range ports {
+			select {
+			case portCh <- port:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var workerWg sync.WaitGroup
+	for w := 0; w < m.config.BatchSize; w++ {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for port := range portCh {
+				if ctx.Err() != nil {
+					return
+				}
+
+				m.dialOnePort(ctx, ip, port, sem, outcomes, timeout)
+
+				if m.config.BatchDelay <= 0 {
+					continue
+				}
+				timer := time.NewTimer(m.config.BatchDelay)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
+			}
+		}()
+	}
+
+	workerWg.Wait()
 }
 
-// chunkPortsForPacing splits ports into BatchSize-sized groups when pacing is
-// enabled; otherwise every port stays in a single group, which is the
+// pacingEnabled reports whether ports should go through the paced worker pool
+// rather than firing all at once. Pacing a batch that already fits in one
+// batch_size-sized group has nothing to pace.
+func (m *TCPPortDiscoveryModule) pacingEnabled(portCount int) bool {
+	return m.config.BatchEnabled && m.config.BatchSize > 0 && m.config.BatchSize < portCount
+}
+
+// dialAllConcurrently probes every port at once, bounded only by sem - the
 // original, unpaced behavior.
-func (m *TCPPortDiscoveryModule) chunkPortsForPacing(ports []int) [][]int {
-	if !m.config.BatchEnabled || m.config.BatchSize <= 0 || m.config.BatchSize >= len(ports) {
-		return [][]int{ports}
-	}
-
-	chunks := make([][]int, 0, (len(ports)+m.config.BatchSize-1)/m.config.BatchSize)
-	for start := 0; start < len(ports); start += m.config.BatchSize {
-		end := min(start+m.config.BatchSize, len(ports))
-		chunks = append(chunks, ports[start:end])
-	}
-	return chunks
-}
-
-// dialChunk probes one group of ports concurrently, bounded by sem.
-func (m *TCPPortDiscoveryModule) dialChunk(
+func (m *TCPPortDiscoveryModule) dialAllConcurrently(
 	ctx context.Context,
 	ip string,
 	ports []int,
@@ -809,33 +832,45 @@ func (m *TCPPortDiscoveryModule) dialChunk(
 		portWg.Add(1)
 		go func(p int) {
 			defer portWg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			address := net.JoinHostPort(ip, strconv.Itoa(p))
-			conn, err := m.dialWithRetries(ctx, address, p, timeout)
-			if err != nil {
-				outcomes.recordNegative(p, err)
-				return
-			}
-			_ = conn.Close()
-
-			outcomes.recordOpen(p)
-
-			if out, ok := ctx.Value(output.OutputKey).(output.Output); ok {
-				out.Diag(output.LevelNormal, fmt.Sprintf("Open port: %s:%d/tcp", ip, p), nil)
-			}
-			engine.PublishEvent(ctx, engine.NewPortOpenEvent(ip, p, "tcp"))
+			m.dialOnePort(ctx, ip, p, sem, outcomes, timeout)
 		}(port)
 	}
 
 	portWg.Wait()
+}
+
+// dialOnePort probes a single port, bounded by sem, and records the outcome.
+func (m *TCPPortDiscoveryModule) dialOnePort(
+	ctx context.Context,
+	ip string,
+	port int,
+	sem chan struct{},
+	outcomes *tcpPortScanOutcomes,
+	timeout time.Duration,
+) {
+	sem <- struct{}{}
+	defer func() { <-sem }()
+
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	address := net.JoinHostPort(ip, strconv.Itoa(port))
+	conn, err := m.dialWithRetries(ctx, address, port, timeout)
+	if err != nil {
+		outcomes.recordNegative(port, err)
+		return
+	}
+	_ = conn.Close()
+
+	outcomes.recordOpen(port)
+
+	if out, ok := ctx.Value(output.OutputKey).(output.Output); ok {
+		out.Diag(output.LevelNormal, fmt.Sprintf("Open port: %s:%d/tcp", ip, port), nil)
+	}
+	engine.PublishEvent(ctx, engine.NewPortOpenEvent(ip, port, "tcp"))
 }
 
 func (m *TCPPortDiscoveryModule) dialWithRetries(ctx context.Context, address string, port int, timeout time.Duration) (net.Conn, error) {
@@ -1023,15 +1058,26 @@ func (o *tcpPortScanOutcomes) reverifyPorts() []int {
 	return ports
 }
 
+// openPorts, and the other accessors below, lock: callers historically only
+// read after wg.Wait() (a happens-before barrier made the lock redundant),
+// but the paced worker pool makes it realistic to want a mid-flight read too
+// (as this package's own tests now do), and an unlocked read racing a
+// concurrent map write is undefined behavior, not just untidy.
 func (o *tcpPortScanOutcomes) openPorts() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
 	return sortedPortsFromSet(o.open)
 }
 
 func (o *tcpPortScanOutcomes) timedOutPorts() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
 	return sortedPortsFromSet(o.timedOut)
 }
 
 func (o *tcpPortScanOutcomes) refusedPorts() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
 	return sortedPortsFromSet(o.refused)
 }
 
@@ -1040,6 +1086,9 @@ func (o *tcpPortScanOutcomes) refusedPorts() []int {
 // are still "some other error", the only change is that backoff ports are
 // excluded from reverifyPorts.
 func (o *tcpPortScanOutcomes) otherErrorPorts() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	if len(o.backoff) == 0 {
 		return sortedPortsFromSet(o.otherErrors)
 	}

--- a/pkg/modules/discovery/tcp_port_discovery_test.go
+++ b/pkg/modules/discovery/tcp_port_discovery_test.go
@@ -1233,3 +1233,52 @@ func TestTCPPortDiscoveryModule_ScanPortBatch_UnpacedWhenBatchDisabled(t *testin
 	require.Less(t, elapsed, 500*time.Millisecond,
 		"batch_enabled=false must behave exactly like before: one unpaced group")
 }
+
+// cyprob-ee#198: an earlier version of pacing waited for an entire group of
+// batch_size ports to finish - including its slowest straggler - before
+// starting the next group, so one filtered port inflated the wall-clock cost
+// of every port sharing its group (and, transitively, every group after it,
+// since groups ran strictly sequentially). This proved out live: an isolated
+// single-host scan went from 16.5s to 32.5s once pacing was enabled, far
+// beyond what batch_size x batch_delay predicts. The worker-pool design fixes
+// this structurally: whichever worker draws the slow port only blocks its own
+// queue, and the other batch_size-1 workers keep making independent progress.
+func TestTCPPortDiscoveryModule_ScanPortBatch_SlowPortDoesNotBlockOtherWorkers(t *testing.T) {
+	module := newTCPPortDiscoveryModule()
+	module.config.Timeout = time.Second
+	module.config.BatchEnabled = true
+	module.config.BatchSize = 2
+	module.config.BatchDelay = 10 * time.Millisecond
+
+	originalDial := dialTimeout
+	t.Cleanup(func() { dialTimeout = originalDial })
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		_, portStr, _ := net.SplitHostPort(address)
+		if portStr == "1" {
+			time.Sleep(500 * time.Millisecond)
+		}
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		return c1, nil
+	}
+
+	outcomes := newTCPPortScanOutcomes()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		module.scanPortBatch(context.Background(), "127.0.0.1", []int{1, 2, 3, 4, 5, 6}, make(chan struct{}, 8), outcomes, module.config.Timeout)
+	}()
+
+	// Port 1 is still 350ms from finishing its dial. Under the old
+	// chunk-barrier design, nothing else could have progressed either - the
+	// whole group (and every group after it) waits for the barrier. Under
+	// the worker pool, the other worker has no reason to be affected: it
+	// should have independently finished the rest of the queue by now.
+	time.Sleep(200 * time.Millisecond)
+	require.NotContains(t, outcomes.openPorts(), 1, "port 1 should still be mid-dial at this checkpoint")
+	require.GreaterOrEqual(t, len(outcomes.openPorts()), 3,
+		"the other worker must have kept processing its own queue while port 1's worker was blocked")
+
+	<-done
+	require.ElementsMatch(t, []int{1, 2, 3, 4, 5, 6}, outcomes.openPorts())
+}


### PR DESCRIPTION
## Summary

Follow-up to cyprob/cyprob#282, addressing what cyprob-ee#198's live testing found: the previous pacing implementation split a target's ports into fixed-size groups and waited for the entire group - including its slowest straggler - to finish before starting the next group. Deployed live (cyprob-ee#199, reverted), this cost far more than `batch_size x batch_delay` predicts: one filtered port (a full per-attempt timeout) inflated the cost of every other port sharing its group, and because groups ran strictly sequentially, that cost compounded across every group after it. Isolated single-host measurement: 16.5s unpaced -> 32.5s paced. A full-subnet scan's total runtime grew enough to collide with an unrelated 10-minute execution timeout, silently dropping a host that hadn't been reached yet.

**Fix:** replaced the chunk barrier with a fixed-size worker pool. `batch_size` workers pull ports from a shared queue; each pauses `batch_delay` after finishing one port before picking up its next. A slow port only blocks the one worker that drew it - the other `batch_size - 1` workers keep draining the queue independently. Each target still gets a real, tight concurrency ceiling of `batch_size` (separate from the global `Concurrency` semaphore, which still bounds the total across every target in a multi-host scan).

**Also fixed:** a latent data race `-race` caught while testing this. `tcpPortScanOutcomes`'s read accessors (`openPorts`/`timedOutPorts`/`refusedPorts`/`otherErrorPorts`) never took the struct's own mutex - safe before only because every call site read after a `wg.Wait()` happens-before barrier. This PR's own new test needed a genuine concurrent read (checking progress mid-scan), which correctly surfaced the gap. All four accessors now lock, matching the writers.

## Evidence

- New regression test (`TestTCPPortDiscoveryModule_ScanPortBatch_SlowPortDoesNotBlockOtherWorkers`) reproduces the exact defect shape - one slow port among several fast ones - and asserts the other worker keeps making independent progress while the slow dial is still in flight. This would fail against the old chunk-barrier code (a slow port anywhere in a group blocks the whole group).
- Full package suite green under `-race`, including the new test run 5x in a loop for flakiness with no failures.
- `golangci-lint run` - 0 issues.
- **Live-verified against the same host cyprob-ee#198/#199 used (`192.168.0.62`):** the new paced path completes and correctly reports port 80 open (the baseline unpaced run in the same session flaked to closed). Reporting this honestly rather than only the favorable framing: pacing is still substantially slower than unpaced on this host once `retries=3` (the forced `top_1000` policy) amplifies genuinely-filtered ports' per-port dial cost - 12s unpaced vs 37s paced with `batch_size=25`/`batch_delay=100ms` on a 150-port range. That cost is inherent to trading concurrency for accuracy and is separate from the chunk-barrier defect this PR removes; it is not re-tuned here.

## Scope

This PR fixes the CE-side mechanism only. It does **not** re-enable `batch_enabled` by default in EE - cyprob-ee#199 was reverted for the reasons above and stays reverted. Whether/when to re-enable a default, and what `batch_size`/`batch_delay`/`retries` values are actually worth the slowdown, is cyprob-ee#198's open question and needs its own live before/after evidence per that issue's guidance, not assumed here.