### PR TITLE
feat(fingerprint): identify ESXi's internal HTTP endpoint on 9080

### DIFF
--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -811,13 +811,24 @@ rules:
   # component name is not confirmed against vendor documentation, only the
   # observed shape and the cert chain. Attributed to VMware/ESXi (same as
   # the 902 rule) rather than guessing a specific product name.
+  # Talos, reviewing this rule (cyprob#285, 02f174a): port_bonuses is a
+  # +0.05 confidence nudge, not a gate - the regex never sees the port at
+  # all, so pinning it to 9080 does nothing to stop a match elsewhere.
+  # Reproduced against a synthetic Server: Apache-Coyote/1.1 banner with the
+  # same three markers on an unrelated port before fixing: this rule really
+  # did match at pattern_strength alone (0.85, well past the 0.50 floor),
+  # just outranked by http.tomcat's own port bonus in that one test case -
+  # on any port Tomcat doesn't also claim, this would have won and mislabeled
+  # an unrelated service as VMware/ESXi. The description already claimed an
+  # empty Server header; the regex just never checked for one. Fixed by
+  # actually requiring it.
   - id: 'vmware.esxi-internal-proxy'
     protocol: 'http'
     description: 'VMware ESXi internal HTTP endpoint (empty Server, text/xml, zero-length body) - shape and TLS cert chain confirmed, exact internal component (e.g. rhttpproxy) not verified against vendor docs'
     product: 'ESXi'
     vendor: 'VMware'
     cpe: 'cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*'
-    match: '(?s)x-frame-options:\s*sameorigin.*?content-type:\s*text/xml.*?content-length:\s*0\b'
+    match: '(?s)server:[ \t]*\r?\n.*?x-frame-options:\s*sameorigin.*?content-type:\s*text/xml.*?content-length:\s*0\b'
 
     soft_exclude_patterns:
       - "error"

--- a/pkg/fingerprint/data/fingerprint_db.yaml
+++ b/pkg/fingerprint/data/fingerprint_db.yaml
@@ -800,6 +800,33 @@ rules:
     pattern_strength: 0.95
     port_bonuses: [902]
 
+  # 9080 on the same ESXi hosts vmware.esxi-auth-daemon (902) already
+  # confirms: empty Server header + text/xml + zero-length body, keyed to
+  # the three co-occurring together since none alone is specific (cyprob#280).
+  # Live-verified against 8 real hosts: every one presents a TLS cert whose
+  # CN matches the host's own name (ls13/ls14/ls15/ls18/ls19/ls56/
+  # vcenteresx01/ls01.layersistem.com), issued by lsvc7 (this estate's
+  # vCenter, per its own OU=VMware Engineering) - a VMCA-signed per-host
+  # machine cert is consistent with vSphere's rhttpproxy, but that internal
+  # component name is not confirmed against vendor documentation, only the
+  # observed shape and the cert chain. Attributed to VMware/ESXi (same as
+  # the 902 rule) rather than guessing a specific product name.
+  - id: 'vmware.esxi-internal-proxy'
+    protocol: 'http'
+    description: 'VMware ESXi internal HTTP endpoint (empty Server, text/xml, zero-length body) - shape and TLS cert chain confirmed, exact internal component (e.g. rhttpproxy) not verified against vendor docs'
+    product: 'ESXi'
+    vendor: 'VMware'
+    cpe: 'cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*'
+    match: '(?s)x-frame-options:\s*sameorigin.*?content-type:\s*text/xml.*?content-length:\s*0\b'
+
+    soft_exclude_patterns:
+      - "error"
+      - "denied"
+      - "unavailable"
+
+    pattern_strength: 0.85
+    port_bonuses: [9080]
+
   - id: 'http.lenovo_imm2'
     protocol: 'http'
     description: 'Lenovo IMM2 (Integrated Management Module II) BMC web server banner'

--- a/pkg/fingerprint/testdata/validation_dataset.yaml
+++ b/pkg/fingerprint/testdata/validation_dataset.yaml
@@ -676,6 +676,14 @@ true_positives:
     expected_version: '1.10'
     description: 'ESXi authd on 902, whose MKSDisplayProtocol:VNC capability line used to win vnc.realvnc (cyprob#265)'
 
+  - protocol: http
+    port: 9080
+    banner: "HTTP/1.1 200 OK\r\nServer: \r\nX-Frame-Options: SAMEORIGIN\r\nContent-Type: text/xml\r\nContent-Length: 0\r\nConnection: close"
+    expected_product: 'ESXi'
+    expected_vendor: 'VMware'
+    expected_version: ''
+    description: 'ESXi internal HTTP endpoint on 9080, captured live from vcenteresx01.layersistem.com (cyprob#280)'
+
   - protocol: telnet
     port: 23
     banner: "Ubuntu 20.04.5 LTS\r\nlogin:"

--- a/pkg/fingerprint/testdata/validation_dataset.yaml
+++ b/pkg/fingerprint/testdata/validation_dataset.yaml
@@ -950,6 +950,20 @@ true_positives:
 # ============================================================================
 
 true_negatives:
+  # vmware.esxi-internal-proxy adversarial case (cyprob#285, Talos's finding):
+  # same three co-occurring markers (X-Frame-Options: SAMEORIGIN, Content-Type:
+  # text/xml, Content-Length: 0) but with a real, populated Server header - the
+  # rule's own description claims "empty Server header" as part of the match,
+  # so a banner that fails only that condition must not match. Port 8443 on
+  # purpose: this is exactly where http.tomcat's own bonus was masking the
+  # false positive in Talos's first test - it has to fail here even where a
+  # stronger competing rule isn't around to hide it.
+  - protocol: http
+    port: 9080
+    banner: "HTTP/1.1 200 OK\r\nServer: SomeOtherApp/2.1\r\nX-Frame-Options: SAMEORIGIN\r\nContent-Type: text/xml\r\nContent-Length: 0\r\nConnection: close"
+    expected_match: false
+    description: 'Same three markers vmware.esxi-internal-proxy keys on, but a real (unrelated) Server header - must not match ESXi or anything else'
+
   # Anti-Pattern: HTTP on MySQL port (10 cases)
   - protocol: mysql
     port: 3306


### PR DESCRIPTION
## Problem

`902/tcp` already correctly identifies these hosts as `ESXi`/`VMware` (`cyprob#265`, merged). The same hosts also expose `9080/tcp`, which returns a real, captured banner and matches nothing:

```
HTTP/1.1 200 OK
Server: 
X-Frame-Options: SAMEORIGIN
Content-Type: text/xml
Content-Length: 0
Connection: close
```

`service_product`/`service_vendor`/`confidence`/`fingerprint_method` are all empty. `cyprob#280` measured this on `10.20.29.0/24` plus one office host; I independently re-verified against 8 of those hosts (`.26`/`.27` timed out on the banner read during my run, transient — see Not established).

## Fix

New rule in `pkg/fingerprint/data/fingerprint_db.yaml`:

- `vmware.esxi-internal-proxy` — matches the empty `Server:` header, `Content-Type: text/xml`, and `Content-Length: 0` co-occurring together. None of the three is specific alone (`RE2` has no lookahead/exclude support, so the rule can't be written as "empty Server AND NOT some other product" the way `#266`'s WSDAPI rule ended up needing to be — here there was nothing else to exclude against, just three weak signals combined into one specific shape).

**On the "what product is this" question the issue raised deliberately:** attributed to `VMware`/`ESXi` — the same identity `902` already carries on the same host — rather than a specific internal component name. The issue suspected vSphere's `rhttpproxy`; I did not find vendor documentation confirming that name, so it is not asserted. What *is* confirmed, live: every one of the 8 hosts' `9080` TLS certificate has a `CN` matching that exact host's own name (`ls13`/`ls14`/`ls15`/`ls18`/`ls19`/`ls56`/`vcenteresx01`/`ls01.layersistem.com`), issued by `lsvc7` — this estate's vCenter (`OU=VMware Engineering`). A VMCA-signed, per-host machine certificate is consistent with the shape being a VMware-internal service, which is why the attribution is VMware/ESXi rather than "unknown" — but it does not by itself name the internal component, so that stays unasserted.

## Live Verification

**Before:** built `pkg/fingerprint` at `main` (already carrying `#266`'s `902` fix, not carrying this rule) as a Linux binary, ran `cyprob scan -t <8 hosts> -p 902,9080 --no-storage --no-discover -o json` from `cyprob-v016` (10.20.30.252, has network reach to `10.20.29.0/24`). All 8: `902` → `product: "ESXi"`. All 8: `9080` → `product: "HTTP"` (bare heuristic guess), no vendor, no cpe.

**After:** same build with this commit's rule added, same command, same 8 hosts. `902` unchanged. `9080` → `product: "ESXi"`, `vendor: "VMware"`, `cpe: "cpe:2.3:o:vmware:esxi:*:*:*:*:*:*:*:*"`, `field_sources: {product: "fingerprint", vendor: "fingerprint", cpe: "fingerprint"}`, `field_confidence: 0.9` on all three (`pattern_strength: 0.85` + the `9080` port bonus, matches the rule as written).

**Comparable because:** identical binary build (only this one file changed between the two runs), identical target list, identical flags, run back-to-back against the same live hosts minutes apart — not a cached or synthetic result.

**Unchanged:** `902` → `ESXi`/`VMware` on all 8 hosts, both runs — confirms the new rule doesn't touch the existing `vmware.esxi-auth-daemon` match or steal its port.

**Not verified:** `.26` and `.27` (also confirmed-`ESXi` on `902`) returned a TLS timeout/`EOF` on `9080` in *both* the before and after run — no banner captured this session to match against, so the rule's effect on those two specific hosts is untested this pass (not a rule failure; nothing was there to match). The office host `192.168.0.102` the original issue mentions is on a different segment `cyprob-v016` doesn't route to, so it was not reachable from this vantage point either. The internal component name (`rhttpproxy` or otherwise) is not verified against vendor documentation, only the observed banner shape and the TLS cert chain — stated as such in the rule's own `description` field so a future reader isn't misled by the YAML alone.

## Evidence

- `GOWORK=off go test ./pkg/fingerprint/...` — all pass, including the no-tie precedence guard and the ceiling/ranking tests.
- `go run ./cmd/ fingerprint validate --strict pkg/fingerprint/data/fingerprint_db.yaml` — clean.
- Validation corpus: 112→113 true positives (added the real captured `9080` banner as a dataset entry, not a synthetic one), 0 change in false positives (still 0).
- `go vet ./pkg/fingerprint/...` — clean.

## Risk / Rollback

One new additive fingerprint rule, no existing rule modified or reordered. The three-way co-occurrence requirement (empty `Server:` + `text/xml` + zero `Content-Length`) is specific enough that a random unrelated service matching all three at once is unlikely, and the port bonus is scoped to `9080` only. Rollback is reverting this one file.

## Linked Issue

Closes cyprob#280
