### PR TITLE
docs(discovery): describe batching as a worker pool, not a chunk barrier

### DIFF
--- a/pkg/modules/discovery/tcp_port_discovery.go
+++ b/pkg/modules/discovery/tcp_port_discovery.go
@@ -43,8 +43,9 @@ type TCPPortDiscoveryConfig struct {
 	Retries                 int                   `json:"retries"`
 	StopOnFirstOpen         bool                  `json:"stop_on_first_open"`
 	VerificationPassEnabled bool                  `json:"verification_pass_enabled"`
-	// BatchEnabled paces a target's port probes in groups of BatchSize,
-	// waiting BatchDelay between groups, instead of letting Concurrency alone
+	// BatchEnabled caps how many of a target's port probes are in flight at
+	// once at BatchSize, with BatchDelay between a worker finishing one port
+	// and starting its next, instead of letting Concurrency alone
 	// decide how many connections a single host receives at once. EE has
 	// plumbed batch_enabled/batch_size/batch_delay through since before this
 	// module read them (cyprob-ee#97) - a single scan of one host could open
@@ -202,19 +203,19 @@ func newTCPPortDiscoveryModule() *TCPPortDiscoveryModule {
 					Default:     defaultConfig.VerificationPassEnabled,
 				},
 				"batch_enabled": {
-					Description: "Pace a target's port probes in groups of batch_size, waiting batch_delay between groups, instead of sending all of them at once (bounded only by concurrency).",
+					Description: "Pace a target's port probes: at most batch_size of this target's ports are probed at the same time, instead of sending all of them at once (bounded only by concurrency).",
 					Type:        "bool",
 					Required:    false,
 					Default:     defaultConfig.BatchEnabled,
 				},
 				"batch_size": {
-					Description: "Number of ports probed per group when batch_enabled is true.",
+					Description: "Maximum number of this target's ports probed at the same time when batch_enabled is true. A concurrency ceiling for one target, not a chunk size: as each port finishes, the next one starts.",
 					Type:        "int",
 					Required:    false,
 					Default:     0,
 				},
 				"batch_delay": {
-					Description: "Pause between port groups when batch_enabled is true (e.g., '500ms').",
+					Description: "Delay a worker waits between finishing one port and starting its next, when batch_enabled is true (e.g., '500ms'). Not a pause between groups. Zero is a valid paced configuration - pacing is switched on by batch_size, not by this delay.",
 					Type:        "duration",
 					Required:    false,
 					Default:     "0s",

--- a/pkg/modules/discovery/tcp_port_discovery_test.go
+++ b/pkg/modules/discovery/tcp_port_discovery_test.go
@@ -1179,9 +1179,10 @@ func TestTCPPortDiscoveryModule_Init_BatchPacingDefaultsToDisabled(t *testing.T)
 	require.Zero(t, module.config.BatchDelay)
 }
 
-// cyprob-ee#97: with pacing enabled, a target's ports are probed in
-// BatchSize-sized groups with a BatchDelay pause between groups, instead of
-// all of them landing on the semaphore at once.
+// cyprob-ee#97: with pacing enabled, at most BatchSize of a target's ports are
+// in flight at once, each worker waiting BatchDelay between finishing one port
+// and starting its next, instead of all of them landing on the semaphore at
+// once.
 func TestTCPPortDiscoveryModule_ScanPortBatch_PacesWhenBatchEnabled(t *testing.T) {
 	module := newTCPPortDiscoveryModule()
 	module.config.Timeout = time.Second
@@ -1204,7 +1205,7 @@ func TestTCPPortDiscoveryModule_ScanPortBatch_PacesWhenBatchEnabled(t *testing.T
 
 	require.ElementsMatch(t, []int{1, 2, 3, 4}, outcomes.openPorts())
 	require.GreaterOrEqual(t, elapsed, module.config.BatchDelay,
-		"4 ports at batch_size=2 makes two groups, so one BatchDelay pause must elapse between them")
+		"4 ports through batch_size=2 workers means each worker takes a second port, and waits BatchDelay before starting it")
 }
 
 func TestTCPPortDiscoveryModule_ScanPortBatch_UnpacedWhenBatchDisabled(t *testing.T) {


### PR DESCRIPTION
## Problem

`#283` (`58d1773`) replaced batching's chunk barrier with a sliding-window worker pool. Four descriptions of it did not change, three of them user-facing, and `scanPortBatch`'s own doc comment at `:739` already describes what the code actually does. The file contradicted itself, and the accurate version was the one an operator never sees.

A fifth location was found while fixing this, not listed in the issue: the paced-mode test's doc comment and its assertion message both described `BatchSize`-sized groups with a pause between them.

## User / Ops Impact

The ConfigSchema descriptions are what an operator reads when configuring the module, and the stale text led to one specific wrong conclusion:

**"Pause between port groups" implies `batch_delay = 0` means no pacing.** It does not. The gate has no delay term:

```go
func (m *TCPPortDiscoveryModule) pacingEnabled(portCount int) bool {
	return m.config.BatchEnabled && m.config.BatchSize > 0 && m.config.BatchSize < portCount
}
```

so `batch_size=25, batch_delay=0` paces exactly as intended. An operator reading the old text would add a delay they do not need, or conclude pacing is off when it is on.

Not hypothetical: verifying that the gate has no delay condition was a required step during the cyprob-ee#198 measurement, precisely because the documented semantics said otherwise.

## Fix Summary

Five wordings, aligned to what `scanPortBatch:739` already documents. The distinction kept explicit throughout: `batch_size` is a **concurrency ceiling for one target**, not a chunk size, and `batch_delay` is a **per-worker gap between consecutive probes**, not a barrier between groups. `batch_delay = 0` is stated to be a valid paced configuration.

The test's assertion is unchanged and still valid under the worker pool — four ports through two workers means each worker takes a second port and waits `BatchDelay` before starting it, so `elapsed >= BatchDelay` holds for the new reason as well as the old. Only its message changes.

## Behavior Change

None. Four descriptions, one field comment, one test doc comment, one assertion message.

## Evidence

- `go build ./...` — pass.
- `go vet ./pkg/modules/discovery/` — clean.
- `go test ./pkg/modules/discovery/ -count=1` — `ok ... 5.858s`, full package, including the two paced-mode tests whose wording changed.
- Swept both repositories for the chunk-barrier phrasing (`in groups of`, `between groups`, `per group`, `port groups`). EE is clean. The only remaining match in CE is deliberate — `batch_delay`'s new text says "Not a pause between groups", rejecting the old reading explicitly.
- No test asserts on these `Description` strings: the only `*_test.go` touching both `ConfigSchema` and `batch` is `tcp_port_discovery_test.go`, which passes.

## Live Verification

- Before: not applicable and not run. This diff changes no executable path — four schema `Description` strings, one struct field comment, one test doc comment, one `require` message.
- After: not run, for the same reason. The compiled behaviour of `scanPortBatch` and `pacingEnabled` is byte-identical to `origin/main`.
- Comparable because: there is nothing to compare. No call site, no condition and no default value is touched; a live before/after would be running the same scanner against itself.
- Unchanged: `pacingEnabled`'s condition, `scanPortBatch`'s worker-pool implementation, every default in `defaultConfig`, and what the paced-mode test asserts.
- Not verified: whether any operator-facing documentation outside these two repositories repeats the chunk-barrier wording. The sweep covered CE and EE source only.

## Risk / Rollback

None beyond the text. Revert restores the stale descriptions.

## Linked Issue

Closes #284
